### PR TITLE
🐛 Make all knowledge sources error-resilient

### DIFF
--- a/scripts/generate-cncf-missions.mjs
+++ b/scripts/generate-cncf-missions.mjs
@@ -168,42 +168,50 @@ async function githubApi(url, options = {}) {
   }
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const response = await fetch(url, { ...options, headers: { ...headers, ...options.headers } })
+    try {
+      const response = await fetch(url, { ...options, headers: { ...headers, ...options.headers }, signal: AbortSignal.timeout(30000) })
 
-    // Track rate limits from response headers
-    const remaining = response.headers.get('x-ratelimit-remaining')
-    const reset = response.headers.get('x-ratelimit-reset')
-    if (remaining != null) rateLimitRemaining = parseInt(remaining, 10)
-    if (reset != null) rateLimitReset = parseInt(reset, 10)
+      // Track rate limits from response headers
+      const remaining = response.headers.get('x-ratelimit-remaining')
+      const reset = response.headers.get('x-ratelimit-reset')
+      if (remaining != null) rateLimitRemaining = parseInt(remaining, 10)
+      if (reset != null) rateLimitReset = parseInt(reset, 10)
 
-    if (response.status === 403 && rateLimitRemaining === 0) {
-      const waitMs = Math.max(0, (rateLimitReset * 1000) - Date.now()) + 1000
-      console.warn(`  Rate limited. Waiting ${Math.round(waitMs / 1000)}s before retry...`)
-      await sleep(waitMs)
-      continue
-    }
+      if (response.status === 403 && rateLimitRemaining === 0) {
+        const waitMs = Math.max(0, (rateLimitReset * 1000) - Date.now()) + 1000
+        console.warn(`  Rate limited. Waiting ${Math.round(waitMs / 1000)}s before retry...`)
+        await sleep(waitMs)
+        continue
+      }
 
-    if (response.status === 422) {
-      console.warn(`  GitHub API returned 422 for ${url}, skipping.`)
-      return null
-    }
+      if (response.status === 422) {
+        console.warn(`  GitHub API returned 422 for ${url}, skipping.`)
+        return null
+      }
 
-    if (response.status >= 500) {
+      if (response.status >= 500) {
+        const backoff = BASE_BACKOFF_MS * Math.pow(2, attempt)
+        console.warn(`  Server error ${response.status}, retrying in ${backoff}ms...`)
+        await sleep(backoff)
+        continue
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '')
+        console.warn(`  GitHub API ${response.status}: ${url} - ${body.slice(0, 200)}`)
+        return null
+      }
+
+      return response.json()
+    } catch (err) {
       const backoff = BASE_BACKOFF_MS * Math.pow(2, attempt)
-      console.warn(`  Server error ${response.status}, retrying in ${backoff}ms...`)
-      await sleep(backoff)
-      continue
+      console.warn(`  GitHub API request error (attempt ${attempt + 1}/${MAX_RETRIES}): ${err.message}`)
+      if (attempt < MAX_RETRIES - 1) await sleep(backoff)
     }
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => '')
-      throw new Error(`GitHub API ${response.status}: ${url} - ${body.slice(0, 200)}`)
-    }
-
-    return response.json()
   }
 
-  throw new Error(`GitHub API failed after ${MAX_RETRIES} retries: ${url}`)
+  console.warn(`  GitHub API failed after ${MAX_RETRIES} retries: ${url}`)
+  return null
 }
 
 async function findHighEngagementIssues(project) {
@@ -690,7 +698,11 @@ async function main() {
 
 // Only run main when executed directly
 if (process.argv[1]?.endsWith('generate-cncf-missions.mjs')) {
-  main().catch(err => { console.error(err); process.exit(1) })
+  main().catch(err => {
+    console.error('Unhandled error in main (workflow will NOT fail):', err.message)
+    // Exit 0 so the workflow job succeeds — source errors should never block the pipeline
+    process.exit(0)
+  })
 }
 
 export { detectMissionType, extractLabels, extractResourceKinds, estimateDifficulty, slugify, generateMission, extractResolutionFromIssue, formatReport }

--- a/scripts/sources/github-discussions.mjs
+++ b/scripts/sources/github-discussions.mjs
@@ -91,6 +91,7 @@ export class GitHubDiscussionsSource extends BaseSource {
             query,
             variables: { owner, repo, cursor },
           }),
+          signal: AbortSignal.timeout(30000),
         })
 
         if (!response.ok) {
@@ -190,6 +191,7 @@ export class GitHubDiscussionsSource extends BaseSource {
           }`,
           variables: { owner, repo },
         }),
+        signal: AbortSignal.timeout(15000),
       })
       if (!response.ok) return false
       const result = await response.json()

--- a/scripts/sources/reddit.mjs
+++ b/scripts/sources/reddit.mjs
@@ -2,11 +2,15 @@
  * Reddit knowledge source — searches Reddit's public JSON API for
  * high-quality posts related to CNCF projects.
  *
- * No API key required. Uses https://www.reddit.com/search.json
- * Rate limit: ~60 req/min for unauthenticated requests.
+ * Uses old.reddit.com JSON endpoints which are more permissive from
+ * cloud/CI environments. Requires a compliant User-Agent per Reddit API rules.
  */
 import { BaseSource, slugify, buildMission } from './base-source.mjs'
 import { computeSinceDate } from './search-state.mjs'
+
+// Reddit requires descriptive User-Agent: platform:appid:version (by contact)
+const REDDIT_USER_AGENT = 'linux:cncf-mission-generator:v1.0.0 (by /u/kubestellar-bot; github.com/kubestellar/console-kb)'
+const REDDIT_BASE = 'https://old.reddit.com'
 
 export class RedditSource extends BaseSource {
   constructor(config) {
@@ -27,13 +31,17 @@ export class RedditSource extends BaseSource {
     for (const subreddit of projectSubs) {
       if (items.length >= this.maxPerProject) break
 
-      const query = encodeURIComponent(`${project.name} site:reddit.com/r/${subreddit}`)
-      const url = `https://www.reddit.com/r/${subreddit}/search.json?q=${encodeURIComponent(project.name)}&sort=top&t=year&restrict_sr=1&limit=25`
+      const url = `${REDDIT_BASE}/r/${subreddit}/search.json?q=${encodeURIComponent(project.name)}&sort=top&t=year&restrict_sr=1&limit=25`
 
       try {
         await this.throttle()
         const response = await fetch(url, {
-          headers: { 'User-Agent': 'cncf-mission-generator/1.0' },
+          headers: {
+            'User-Agent': REDDIT_USER_AGENT,
+            'Accept': 'application/json',
+          },
+          redirect: 'follow',
+          signal: AbortSignal.timeout(15000),
         })
 
         if (!response.ok) {
@@ -115,9 +123,14 @@ export class RedditSource extends BaseSource {
   async fetchTopComments(permalink) {
     try {
       await this.throttle()
-      const url = `https://www.reddit.com${permalink}.json?sort=top&limit=5`
+      const url = `${REDDIT_BASE}${permalink}.json?sort=top&limit=5`
       const response = await fetch(url, {
-        headers: { 'User-Agent': 'cncf-mission-generator/1.0' },
+        headers: {
+          'User-Agent': REDDIT_USER_AGENT,
+          'Accept': 'application/json',
+        },
+        redirect: 'follow',
+        signal: AbortSignal.timeout(15000),
       })
       if (!response.ok) return null
 

--- a/scripts/sources/stackoverflow.mjs
+++ b/scripts/sources/stackoverflow.mjs
@@ -44,7 +44,7 @@ export class StackOverflowSource extends BaseSource {
 
     try {
       await this.throttle()
-      const response = await fetch(url)
+      const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
 
       if (!response.ok) {
         console.warn(`  SO: ${response.status} for ${project.name}, skipping`)
@@ -89,7 +89,7 @@ export class StackOverflowSource extends BaseSource {
           `&filter=withbody` +
           `&pagesize=15`
 
-        const response = await fetch(textUrl)
+        const response = await fetch(textUrl, { signal: AbortSignal.timeout(15000) })
         if (response.ok) {
           const data = await response.json()
           const existingIds = new Set(items.map(i => i.question_id))
@@ -153,7 +153,7 @@ export class StackOverflowSource extends BaseSource {
       await this.throttle()
       const url = `https://api.stackexchange.com/2.3/questions/${questionId}/answers?` +
         `order=desc&sort=votes&site=stackoverflow&filter=withbody`
-      const response = await fetch(url)
+      const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
       if (!response.ok) return null
 
       const data = await response.json()


### PR DESCRIPTION
No source error (rate limit, 403, timeout, etc.) should ever crash the workflow.

**Changes:**
- `githubApi()` returns `null` instead of `throw` on non-OK responses and retries exhausted
- All `fetch()` calls have **15-30s timeouts** via `AbortSignal.timeout()` — no hanging
- Reddit: switched to `old.reddit.com` + compliant User-Agent (`linux:cncf-mission-generator:v1.0.0`)
- `main()` exits code 0 even on unhandled errors — source failures never block the pipeline
- Each fetch wrapped in try/catch with warn logging and graceful skip

**Tested locally:** GitHub 401, Reddit 404 all logged as warnings and skipped. Process exits cleanly.