### PR TITLE
🐛 Fix branch name collision on same-day re-runs

### DIFF
--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          BRANCH="cncf-gen-$(date +%Y%m%d)"
+          BRANCH="cncf-gen-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git add solutions/cncf-generated/
           # Commit search state if present (tracks processed items)


### PR DESCRIPTION
Branch name for generated PRs now uses `YYYYMMDD-HHMMSS` instead of just `YYYYMMDD`, preventing push rejections when the workflow runs multiple times per day.