### PR TITLE
🐛 Fix LLM auth for GitHub Models API

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Generate install missions (batch ${{ matrix.batch }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LLM_TOKEN: ${{ secrets.GH_MODELS_PAT || secrets.GITHUB_TOKEN }}
           TARGET_PROJECTS: ${{ inputs.projects || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           FORCE_REGENERATE: ${{ inputs.force_regenerate || 'false' }}
@@ -530,6 +531,7 @@ jobs:
         if: steps.sample.outputs.count != '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LLM_TOKEN: ${{ secrets.GH_MODELS_PAT || secrets.GITHUB_TOKEN }}
           REPORT_PATH: mission-execution-report.json
           MISSION_TIMEOUT_MS: '300000'
           STEP_TIMEOUT_MS: '120000'


### PR DESCRIPTION
The default `GITHUB_TOKEN` in Actions returns 401 from GitHub Models API. Added `GH_MODELS_PAT` secret and pass as `LLM_TOKEN` to generator + executor.