### PR TITLE
🐛 Fix self-approve: use comment + admin merge

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -764,9 +764,10 @@ jobs:
           *No human review required unless PR is in draft state.*"
 
           if [ "$ACTION" = "merge" ]; then
-            gh pr review ${{ steps.pr.outputs.pr_number }} --approve --body "$REVIEW_BODY"
+            # GITHUB_TOKEN can't approve its own PR, so post as comment + merge with --admin
+            gh pr comment ${{ steps.pr.outputs.pr_number }} --body "$REVIEW_BODY"
           else
-            gh pr review ${{ steps.pr.outputs.pr_number }} --request-changes --body "$REVIEW_BODY"
+            gh pr comment ${{ steps.pr.outputs.pr_number }} --body "$REVIEW_BODY"
           fi
 
       - name: 'Auto-review: Merge PR'


### PR DESCRIPTION
GITHUB_TOKEN can't approve its own PR. Post review as comment, merge with --admin.