### PR TITLE
🐛 Fix bash syntax in collect job

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -172,10 +172,6 @@ jobs:
             else
               echo "draft_pr=false" >> $GITHUB_OUTPUT
             fi
-            else
-              echo "avg_score=0" >> $GITHUB_OUTPUT
-              echo "draft_pr=false" >> $GITHUB_OUTPUT
-            fi
           else
             echo "avg_score=0" >> $GITHUB_OUTPUT
             echo "draft_pr=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Remove duplicate else/fi block that caused syntax error in merge reports step.