### PR TITLE
✨ Align solutions generator with kc-mission-v1 install template

### DIFF
--- a/scripts/__tests__/generate-cncf-missions.test.mjs
+++ b/scripts/__tests__/generate-cncf-missions.test.mjs
@@ -72,34 +72,37 @@ describe('slugify', () => {
 
 describe('generateMission', () => {
   const resolution = {
-    problem: 'Pod is crashing on startup',
-    solution: 'Fix the liveness probe configuration',
-    yamlSnippets: [],
-    steps: ['Check liveness probe', 'Update timeout value'],
+    problem: 'Pod is crashing on startup due to misconfigured liveness probe timeout. The default 1s timeout is too short for the initialization.',
+    solution: 'Fix the liveness probe configuration by increasing the initial delay and timeout. Set initialDelaySeconds to 30 and timeoutSeconds to 10 to allow sufficient startup time.',
+    yamlSnippets: ['apiVersion: v1\nkind: Pod\nmetadata:\n  name: test\nspec:\n  containers:\n  - name: app\n    livenessProbe:\n      initialDelaySeconds: 30'],
+    steps: ['Check liveness probe configuration', 'Update timeout value to 10 seconds'],
   }
 
-  it('produces valid kc-mission-v1 format', () => {
+  it('produces valid kc-mission-v1 format', async () => {
     const issue = mockIssue({ title: 'Pod crash loop' })
-    const mission = generateMission(sampleProject, issue, resolution)
-    expect(mission.format).toBe('kc-mission-v1')
+    const mission = await generateMission(sampleProject, issue, resolution)
+    expect(mission.version).toBe('kc-mission-v1')
+    expect(mission.name).toBeDefined()
+    expect(mission.missionClass).toBe('solution')
     expect(mission.mission).toBeDefined()
     expect(mission.metadata).toBeDefined()
+    expect(mission.prerequisites).toBeDefined()
     expect(mission.security).toBeDefined()
   })
 
-  it('includes correct CNCF project tag', () => {
+  it('includes correct CNCF project tag', async () => {
     const issue = mockIssue({ title: 'Pod crash loop' })
-    const mission = generateMission(sampleProject, issue, resolution)
+    const mission = await generateMission(sampleProject, issue, resolution)
     expect(mission.metadata.tags).toContain('kubernetes')
     expect(mission.metadata.cncfProjects).toEqual(['kubernetes'])
   })
 
-  it('mission type matches issue labels', () => {
+  it('mission type matches issue labels', async () => {
     const issue = mockIssue({
       title: 'Memory leak in controller',
       labels: [{ name: 'memory' }],
     })
-    const mission = generateMission(sampleProject, issue, resolution)
+    const mission = await generateMission(sampleProject, issue, resolution)
     // "memory" triggers 'analyze'
     expect(mission.mission.type).toBe('analyze')
   })

--- a/scripts/generate-cncf-missions.mjs
+++ b/scripts/generate-cncf-missions.mjs
@@ -606,20 +606,26 @@ async function generateMission(project, issue, resolution, linkedPR) {
     console.log(`    [regex fallback] ${missionSteps.length} steps`)
   }
 
+  const slug = slugify(`${project.name}-${issue.number}-${issue.title}`)
+
   const mission = {
-    format: 'kc-mission-v1',
-    exportedAt: new Date().toISOString(),
-    exportedBy: 'cncf-mission-generator',
-    consoleVersion: 'auto-generated',
+    version: 'kc-mission-v1',
+    name: slug,
+    missionClass: 'solution',
+    author: 'KubeStellar Bot',
+    authorGithub: 'kubestellar',
     mission: {
       title: `${project.name}: ${issue.title}`,
       description: missionDesc,
       type: missionType,
       status: 'completed',
-      steps: missionSteps,
+      steps: missionSteps.map(s => ({
+        title: s.title.slice(0, 120),
+        description: (s.description || '').slice(0, 3000),
+      })),
       resolution: {
         summary: missionResolution,
-        steps: missionSteps.map(s => s.title),
+        codeSnippets: extractCodeSnippets(missionSteps, resolution),
       },
     },
     metadata: {
@@ -627,17 +633,27 @@ async function generateMission(project, issue, resolution, linkedPR) {
         project.name,
         project.maturity,
         project.category,
+        missionType,
         ...extractLabels(issue),
       ].filter((v, i, a) => a.indexOf(v) === i),
-      category: CATEGORY_TO_DIR[project.category] || 'troubleshooting',
       cncfProjects: [project.name],
       targetResourceKinds: extractResourceKinds(issue),
       difficulty: missionDifficulty,
-      sourceIssue: issue.html_url,
-      sourceRepo: project.repo,
+      issueTypes: [missionType],
+      maturity: project.maturity,
+      sourceUrls: {
+        issue: issue.html_url,
+        repo: `https://github.com/${project.repo}`,
+        ...(linkedPR ? { pr: linkedPR.html_url } : {}),
+      },
       reactions: issue.reactions?.total_count || 0,
       comments: issue.comments || 0,
       synthesizedBy: llmResult ? 'llm' : 'regex',
+    },
+    prerequisites: {
+      kubernetes: '>=1.24',
+      tools: ['kubectl'],
+      description: `A running Kubernetes cluster with ${project.name} installed or the issue environment reproducible.`,
     },
     security: {
       scannedAt: new Date().toISOString(),
@@ -647,12 +663,25 @@ async function generateMission(project, issue, resolution, linkedPR) {
     },
   }
 
-  // Include code snippets if available
-  if (resolution.yamlSnippets.length > 0) {
-    mission.mission.resolution.codeSnippets = resolution.yamlSnippets.slice(0, 3)
-  }
-
   return mission
+}
+
+function extractCodeSnippets(steps, resolution) {
+  const snippets = []
+  for (const step of steps) {
+    const matches = (step.description || '').matchAll(/```[\w]*\n([\s\S]*?)```/g)
+    for (const m of matches) {
+      if (m[1].trim().length > 10) snippets.push(m[1].trim())
+      if (snippets.length >= 5) return snippets
+    }
+  }
+  if (resolution.yamlSnippets) {
+    for (const s of resolution.yamlSnippets) {
+      if (snippets.length >= 5) break
+      if (s.trim().length > 10) snippets.push(s.trim())
+    }
+  }
+  return snippets
 }
 
 function deduplicateAgainstExisting(slug, projectDir) {
@@ -835,7 +864,7 @@ async function main() {
               report.missions.push({
                 title: mission.mission.title,
                 difficulty: mission.metadata.difficulty,
-                sourceIssue: mission.metadata.sourceIssue,
+                sourceIssue: mission.metadata.sourceUrls?.issue || '',
                 qualityScore: qualityResult.score,
                 synthesizedBy: mission.metadata.synthesizedBy,
               })

--- a/scripts/quality-scorer.mjs
+++ b/scripts/quality-scorer.mjs
@@ -167,7 +167,7 @@ function scoreMetadata(meta) {
   else score += 0.5
 
   // Has source issue link
-  if (meta.sourceIssue) score += 2
+  if (meta.sourceUrls?.issue || meta.sourceUrls?.source || meta.sourceIssue) score += 2
 
   // Has reactions (engagement indicator)
   if (meta.reactions > 20) score += 2

--- a/scripts/sources/base-source.mjs
+++ b/scripts/sources/base-source.mjs
@@ -96,13 +96,17 @@ export async function buildMission({ title, description, problem, solution, step
     // LLM not available, continue with raw extraction
   }
 
+  const slug = slugify(`${project.name}-${sourceType}-${title}`)
+
   if (llmResult) {
+    const missionSteps = (llmResult.steps || []).map(s => ({
+      title: s.title.slice(0, 120),
+      description: (s.description || '').slice(0, 3000),
+    }))
     return {
-      format: 'kc-mission-v1',
-      exportedAt: new Date().toISOString(),
-      exportedBy: 'cncf-mission-generator',
-      consoleVersion: 'auto-generated',
-      missionClass: 'troubleshoot',
+      version: 'kc-mission-v1',
+      name: slug,
+      missionClass: 'solution',
       author: 'KubeStellar Bot',
       authorGithub: 'kubestellar',
       mission: {
@@ -110,23 +114,29 @@ export async function buildMission({ title, description, problem, solution, step
         description: llmResult.description,
         type: llmResult.type || type || 'troubleshoot',
         status: 'completed',
-        steps: llmResult.steps,
+        steps: missionSteps,
         resolution: {
           summary: llmResult.resolution,
-          steps: llmResult.steps.map(s => s.title),
-          codeSnippets: yamlSnippets?.slice(0, 3),
+          codeSnippets: extractSnippetsFromSteps(missionSteps, yamlSnippets),
         },
       },
       metadata: {
-        tags: labels || [],
-        category: project.category,
+        tags: [project.name, project.maturity, ...(labels || [])].filter((v, i, a) => a.indexOf(v) === i),
         cncfProjects: [project.name],
         targetResourceKinds: resourceKinds || [],
         difficulty: llmResult.difficulty || difficulty || 'intermediate',
-        sourceUrl,
-        sourceType,
-        sourceRepo: project.repo,
+        issueTypes: [llmResult.type || type || 'troubleshoot'],
+        maturity: project.maturity,
+        sourceUrls: {
+          [sourceType || 'source']: sourceUrl,
+          repo: `https://github.com/${project.repo}`,
+        },
         synthesizedBy: 'llm',
+      },
+      prerequisites: {
+        kubernetes: '>=1.24',
+        tools: ['kubectl'],
+        description: `A running Kubernetes cluster with ${project.name} installed or the issue environment reproducible.`,
       },
       security: {
         scannedAt: new Date().toISOString(),
@@ -138,12 +148,14 @@ export async function buildMission({ title, description, problem, solution, step
   }
 
   // Fallback: raw extraction
+  const rawSteps = (steps || []).map(s => {
+    const step = typeof s === 'string' ? { title: s, description: s } : s
+    return { title: step.title.slice(0, 120), description: (step.description || '').slice(0, 3000) }
+  })
   return {
-    format: 'kc-mission-v1',
-    exportedAt: new Date().toISOString(),
-    exportedBy: 'cncf-mission-generator',
-    consoleVersion: 'auto-generated',
-    missionClass: 'troubleshoot',
+    version: 'kc-mission-v1',
+    name: slug,
+    missionClass: 'solution',
     author: 'KubeStellar Bot',
     authorGithub: 'kubestellar',
     mission: {
@@ -151,23 +163,29 @@ export async function buildMission({ title, description, problem, solution, step
       description: description || problem || title,
       type: type || 'troubleshoot',
       status: 'completed',
-      steps: (steps || []).map(s => typeof s === 'string' ? { title: s, description: s } : s),
+      steps: rawSteps,
       resolution: {
         summary: solution || description || '',
-        steps: steps || [],
-        codeSnippets: yamlSnippets?.slice(0, 3),
+        codeSnippets: extractSnippetsFromSteps(rawSteps, yamlSnippets),
       },
     },
     metadata: {
-      tags: labels || [],
-      category: project.category,
+      tags: [project.name, project.maturity, ...(labels || [])].filter((v, i, a) => a.indexOf(v) === i),
       cncfProjects: [project.name],
       targetResourceKinds: resourceKinds || [],
       difficulty: difficulty || 'intermediate',
-      sourceUrl,
-      sourceType,
-      sourceRepo: project.repo,
+      issueTypes: [type || 'troubleshoot'],
+      maturity: project.maturity,
+      sourceUrls: {
+        [sourceType || 'source']: sourceUrl,
+        repo: `https://github.com/${project.repo}`,
+      },
       synthesizedBy: 'regex',
+    },
+    prerequisites: {
+      kubernetes: '>=1.24',
+      tools: ['kubectl'],
+      description: `A running Kubernetes cluster with ${project.name} installed or the issue environment reproducible.`,
     },
     security: {
       scannedAt: new Date().toISOString(),
@@ -176,4 +194,22 @@ export async function buildMission({ title, description, problem, solution, step
       findings: [],
     },
   }
+}
+
+function extractSnippetsFromSteps(steps, yamlSnippets) {
+  const snippets = []
+  for (const step of steps) {
+    const matches = (step.description || '').matchAll(/```[\w]*\n([\s\S]*?)```/g)
+    for (const m of matches) {
+      if (m[1].trim().length > 10) snippets.push(m[1].trim())
+      if (snippets.length >= 5) return snippets
+    }
+  }
+  if (yamlSnippets) {
+    for (const s of yamlSnippets) {
+      if (snippets.length >= 5) break
+      if (s.trim().length > 10) snippets.push(s.trim())
+    }
+  }
+  return snippets
 }


### PR DESCRIPTION
## Summary

Updates the solutions generator (generate-cncf-missions.mjs) and base source (base-source.mjs) to output the same kc-mission-v1 template format used by the install generator.

### Changes

- **generate-cncf-missions.mjs**: Output format now matches install template with `version`, `name`, `missionClass: 'solution'`, `author`, `authorGithub`, `prerequisites` fields. Uses `sourceUrls` object instead of flat `sourceIssue`/`sourceRepo`.
- **base-source.mjs**: Updated `buildMission()` with same template structure (used by Reddit, StackOverflow, GitHub Discussions sources)
- **quality-scorer.mjs**: Accepts both new `sourceUrls` and legacy `sourceIssue` fields
- **Tests**: Updated to async `generateMission` calls, new field names, and richer mock data that passes quality gates

### Why

The solutions generator was using an older output format (`format`, `exportedAt`, `exportedBy`) that didn't match the newer install template (`version`, `name`, `missionClass`). This caused:
1. Schema validation failures (scanner expects `version` + `name`)  
2. Missing `missionClass` field making it harder for the console frontend to classify missions
3. Inconsistent metadata structure between install and solution missions