### PR TITLE
✨ Enrich all 164 install missions with uninstall, upgrade, and troubleshooting

### DIFF
--- a/scripts/enrich-install-missions.mjs
+++ b/scripts/enrich-install-missions.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+/**
+ * Enriches existing install missions with uninstall, upgrade, and troubleshooting sections.
+ * Reads each install-*.json, calls LLM for the 3 missing sections, merges them back.
+ *
+ * Environment variables:
+ *   GITHUB_TOKEN       — GitHub Models auth
+ *   TARGET_PROJECTS    — comma-separated file names to process (empty = all)
+ *   BATCH_INDEX        — batch index for parallelism
+ *   BATCH_SIZE         — files per batch (default 20)
+ *   DRY_RUN            — if 'true', no files written
+ *   CONCURRENCY        — parallel LLM calls (default 3)
+ */
+import { writeFileSync, readFileSync, readdirSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+const DRY_RUN = process.env.DRY_RUN === 'true'
+const BATCH_INDEX = process.env.BATCH_INDEX != null ? parseInt(process.env.BATCH_INDEX, 10) : null
+const BATCH_SIZE = parseInt(process.env.BATCH_SIZE || '20', 10)
+const CONCURRENCY = parseInt(process.env.CONCURRENCY || '3', 10)
+const TARGET_PROJECTS = process.env.TARGET_PROJECTS
+  ? process.env.TARGET_PROJECTS.split(',').map(s => s.trim()).filter(Boolean)
+  : null
+const SOLUTIONS_DIR = join(process.cwd(), 'solutions', 'cncf-install')
+
+const LLM_ENDPOINT = process.env.LLM_ENDPOINT || 'https://models.inference.ai.azure.com/chat/completions'
+const LLM_MODEL = process.env.LLM_MODEL || 'gpt-4o-mini'
+const LLM_TIMEOUT_MS = 60_000
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms))
+
+// ─── Prompt ──────────────────────────────────────────────────────────
+
+const ENRICH_SYSTEM_PROMPT = `You are an expert Kubernetes technical writer. You are given an EXISTING install mission for a CNCF project. The mission already has install steps. Your job is to generate ONLY the missing sections: uninstall, upgrade, and troubleshooting.
+
+Your output MUST be a JSON object with exactly these 3 fields:
+{
+  "uninstall": [
+    {
+      "title": "Short imperative title (e.g. 'Remove the Helm release')",
+      "description": "Detailed step to cleanly remove the project. Include cleanup of CRDs, namespaces, PVCs, etc. Use code blocks for commands."
+    }
+  ],
+  "upgrade": [
+    {
+      "title": "Short imperative title (e.g. 'Update the Helm repository')",
+      "description": "Detailed step to upgrade/update an existing installation. Include backup steps, version checks, and rollback instructions. Use code blocks for commands."
+    }
+  ],
+  "troubleshooting": [
+    {
+      "title": "Short title describing the issue (e.g. 'Pods stuck in CrashLoopBackOff')",
+      "description": "Description of the problem, how to diagnose it, and the fix. Include exact diagnostic commands in code blocks."
+    }
+  ]
+}
+
+Rules:
+- "uninstall" MUST have EXACTLY 3 separate steps as 3 separate objects: (1) remove the release/deployment, (2) clean up CRDs and persistent resources, (3) remove namespace and verify
+- "upgrade" MUST have EXACTLY 3 separate steps as 3 separate objects: (1) backup current state, (2) update repo and run upgrade command, (3) verify the upgrade
+- "troubleshooting" MUST have EXACTLY 4 separate items as 4 separate objects, each a different common issue
+- IMPORTANT: Each step must be its OWN object in the array with its OWN title and description. Do NOT combine multiple steps into one.
+- All commands must be copy-pasteable — never say "see the documentation"
+- Use the SAME namespace, release name, and tool (helm/kubectl/etc.) from the existing install steps
+- Pin versions where possible
+- Do NOT repeat install steps — only generate the 3 new sections`
+
+function buildEnrichPrompt(mission) {
+  const title = mission.mission?.title || 'Unknown'
+  const description = mission.mission?.description || ''
+  const steps = (mission.mission?.steps || [])
+    .map((s, i) => `${i + 1}. **${s.title}**\n${s.description}`)
+    .join('\n\n')
+  const methods = (mission.metadata?.installMethods || []).join(', ')
+  const projects = (mission.metadata?.cncfProjects || []).join(', ')
+
+  return `# Existing Install Mission
+
+**Title:** ${title}
+**Description:** ${description}
+**CNCF Project(s):** ${projects}
+**Install Methods:** ${methods}
+
+## Current Install Steps
+
+${steps}
+
+---
+
+Based on the above install mission, generate the uninstall, upgrade, and troubleshooting sections. Use the same namespace, release name, and tools shown in the install steps. Return JSON only.`
+}
+
+// ─── LLM Call ────────────────────────────────────────────────────────
+
+async function callLLM(mission) {
+  const token = process.env.LLM_TOKEN || GITHUB_TOKEN
+  if (!token) return null
+
+  const prompt = buildEnrichPrompt(mission)
+
+  for (let attempt = 0; attempt <= 2; attempt++) {
+    try {
+      const response = await fetch(LLM_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: LLM_MODEL,
+          messages: [
+            { role: 'system', content: ENRICH_SYSTEM_PROMPT },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0.3,
+          max_tokens: 2500,
+          response_format: { type: 'json_object' },
+        }),
+        signal: AbortSignal.timeout(LLM_TIMEOUT_MS),
+      })
+
+      if (response.status === 429) {
+        const wait = parseInt(response.headers.get('retry-after') || '10', 10)
+        console.warn(`  [LLM] Rate limited, waiting ${wait}s`)
+        await sleep(wait * 1000)
+        continue
+      }
+      if (!response.ok) {
+        console.warn(`  [LLM] API error ${response.status}`)
+        return null
+      }
+
+      const data = await response.json()
+      const content = data.choices?.[0]?.message?.content
+      if (!content) return null
+
+      const parsed = JSON.parse(content)
+      return parsed
+    } catch (err) {
+      console.warn(`  [LLM] ${err.name === 'AbortError' ? 'Timeout' : err.message} (attempt ${attempt + 1})`)
+      if (attempt < 2) await sleep(3000 * (attempt + 1))
+    }
+  }
+  return null
+}
+
+// ─── Validation ──────────────────────────────────────────────────────
+
+function validateSection(steps, name, minCount) {
+  if (!Array.isArray(steps) || steps.length < minCount) return false
+  return steps.every(s => s.title && typeof s.title === 'string' && s.description && typeof s.description === 'string')
+}
+
+function sanitizeSteps(steps, maxTitle = 120, maxDesc = 3000) {
+  return steps.map(s => ({
+    title: s.title.slice(0, maxTitle),
+    description: s.description.slice(0, maxDesc),
+  }))
+}
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+async function enrichFile(filePath, fileName) {
+  const raw = readFileSync(filePath, 'utf-8')
+  const mission = JSON.parse(raw)
+
+  // Skip if already enriched
+  const m = mission.mission || {}
+  if (m.uninstall?.length > 0 && m.upgrade?.length > 0 && m.troubleshooting?.length > 0) {
+    return { status: 'skipped', reason: 'already enriched' }
+  }
+
+  console.log(`  Enriching ${fileName}...`)
+  const result = await callLLM(mission)
+
+  if (!result) {
+    return { status: 'error', reason: 'LLM returned null' }
+  }
+
+  // Validate all 3 sections
+  const hasUninstall = validateSection(result.uninstall, 'uninstall', 1)
+  const hasUpgrade = validateSection(result.upgrade, 'upgrade', 1)
+  const hasTrouble = validateSection(result.troubleshooting, 'troubleshooting', 1)
+
+  if (!hasUninstall && !hasUpgrade && !hasTrouble) {
+    return { status: 'error', reason: 'All sections invalid' }
+  }
+
+  // Merge into mission — only add sections that are valid AND missing
+  let sectionsAdded = 0
+  if (hasUninstall && !(m.uninstall?.length > 0)) {
+    mission.mission.uninstall = sanitizeSteps(result.uninstall)
+    sectionsAdded++
+  }
+  if (hasUpgrade && !(m.upgrade?.length > 0)) {
+    mission.mission.upgrade = sanitizeSteps(result.upgrade)
+    sectionsAdded++
+  }
+  if (hasTrouble && !(m.troubleshooting?.length > 0)) {
+    mission.mission.troubleshooting = sanitizeSteps(result.troubleshooting)
+    sectionsAdded++
+  }
+
+  if (sectionsAdded === 0) {
+    return { status: 'skipped', reason: 'no new sections needed' }
+  }
+
+  if (!DRY_RUN) {
+    writeFileSync(filePath, JSON.stringify(mission, null, 2) + '\n')
+  }
+
+  return {
+    status: 'enriched',
+    sections: sectionsAdded,
+    uninstall: hasUninstall ? (result.uninstall?.length || 0) : 0,
+    upgrade: hasUpgrade ? (result.upgrade?.length || 0) : 0,
+    troubleshooting: hasTrouble ? (result.troubleshooting?.length || 0) : 0,
+  }
+}
+
+async function main() {
+  console.log('=== Enrich Install Missions ===')
+  console.log(`Model: ${LLM_MODEL} | DRY_RUN: ${DRY_RUN} | Concurrency: ${CONCURRENCY}`)
+
+  if (!GITHUB_TOKEN && !process.env.LLM_TOKEN) {
+    console.error('GITHUB_TOKEN or LLM_TOKEN required')
+    process.exit(1)
+  }
+
+  let files = readdirSync(SOLUTIONS_DIR)
+    .filter(f => f.startsWith('install-') && f.endsWith('.json'))
+    .sort()
+
+  if (TARGET_PROJECTS) {
+    files = files.filter(f => TARGET_PROJECTS.some(t => f.includes(t)))
+  }
+
+  // Batch slicing
+  if (BATCH_INDEX != null) {
+    const start = BATCH_INDEX * BATCH_SIZE
+    const end = start + BATCH_SIZE
+    console.log(`Batch ${BATCH_INDEX}: files ${start}–${Math.min(end, files.length) - 1} of ${files.length}`)
+    files = files.slice(start, end)
+  }
+
+  console.log(`Processing ${files.length} files\n`)
+
+  const report = { enriched: 0, skipped: 0, errors: 0, total: files.length }
+
+  // Process with concurrency limit
+  for (let i = 0; i < files.length; i += CONCURRENCY) {
+    const batch = files.slice(i, i + CONCURRENCY)
+    const results = await Promise.all(
+      batch.map(async (fileName) => {
+        const filePath = join(SOLUTIONS_DIR, fileName)
+        try {
+          const result = await enrichFile(filePath, fileName)
+          if (result.status === 'enriched') {
+            console.log(`  ✅ ${fileName}: +${result.sections} sections (u:${result.uninstall} up:${result.upgrade} t:${result.troubleshooting})`)
+            report.enriched++
+          } else if (result.status === 'skipped') {
+            console.log(`  ⏭️  ${fileName}: ${result.reason}`)
+            report.skipped++
+          } else {
+            console.log(`  ❌ ${fileName}: ${result.reason}`)
+            report.errors++
+          }
+          return result
+        } catch (err) {
+          console.error(`  ❌ ${fileName}: ${err.message}`)
+          report.errors++
+          return { status: 'error', reason: err.message }
+        }
+      })
+    )
+    // Brief pause between batches
+    if (i + CONCURRENCY < files.length) await sleep(500)
+  }
+
+  console.log(`\n=== Report ===`)
+  console.log(`Enriched: ${report.enriched} | Skipped: ${report.skipped} | Errors: ${report.errors} | Total: ${report.total}`)
+
+  if (report.errors > report.total * 0.3) {
+    console.error('Too many errors (>30%), exiting with failure')
+    process.exit(1)
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err)
+  process.exit(1)
+})

--- a/solutions/cncf-install/install-aeraki-mesh.json
+++ b/solutions/cncf-install/install-aeraki-mesh.json
@@ -36,7 +36,53 @@
         "kubectl edit deployment aeraki --namespace aeraki",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Aeraki release from the Kubernetes cluster using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall aeraki --namespace aeraki\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that may have been created during the installation. This ensures that all resources are cleaned up.\n```bash\nkubectl delete crd $(kubectl get crd | grep aeraki | awk '{print $1}')\nkubectl delete pvc --all --namespace aeraki\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'aeraki' namespace to clean up any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace aeraki\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Aeraki installation. This can be done by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace aeraki -o yaml > aeraki-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the Aeraki installation to the desired version.\n```bash\nhelm repo update\nhelm upgrade aeraki aeraki/aeraki --namespace aeraki --version 1.5.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the Aeraki pods are running with the new version and that the deployment is successful.\n```bash\nkubectl get pods --namespace aeraki\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Aeraki pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace aeraki\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that the version specified is available in the repository. You can check available versions with:\n```bash\nhelm search repo aeraki/aeraki --versions\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If services managed by Aeraki are not reachable, verify that the service endpoints are correctly configured and that the necessary network policies are in place.\n```bash\nkubectl get svc --namespace aeraki\nkubectl describe svc <service-name> --namespace aeraki\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If Aeraki pods are failing due to insufficient resources, check the resource limits and requests configured in the deployment. Adjust them as necessary.\n```bash\nkubectl get deployment aeraki --namespace aeraki -o yaml\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-akri.json
+++ b/solutions/cncf-install/install-akri.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment akri --namespace akri",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Akri release from the Kubernetes cluster using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall akri --namespace akri\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation of Akri. This ensures that all resources are cleaned up properly.\n```bash\nkubectl delete crd akriresources.akri.dev\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Akri namespace to remove all remaining resources associated with Akri. After deletion, verify that the namespace has been removed.\n```bash\nkubectl delete namespace akri\nkubectl get namespaces | grep akri\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, create a backup of the current state of the Akri deployment. This includes saving the current configuration and any important data.\n```bash\nkubectl get deployment akri --namespace akri -o yaml > akri-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then run the upgrade command to update the Akri installation to the latest version.\n```bash\nhelm repo update\nhelm upgrade akri akri/akri --namespace akri\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Akri pods are running successfully after the upgrade. This ensures that the upgrade was successful and that the application is functioning as expected.\n```bash\nkubectl get pods --namespace akri\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Akri pods are stuck in a CrashLoopBackOff state, check the logs of the pods to diagnose the issue. This can indicate problems with the application or its configuration.\n```bash\nkubectl logs <pod-name> --namespace akri\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission denied errors, verify that the Role and RoleBinding for Akri are correctly configured. Check the current roles and bindings in the namespace.\n```bash\nkubectl get role -n akri\nkubectl get rolebinding -n akri\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to Out Of Memory (OOM) errors, consider adjusting the resource limits set for the Akri deployment. Check the events for the pods to see if OOMKilled is reported.\n```bash\nkubectl describe pod <pod-name> --namespace akri\n```"
+      },
+      {
+        "title": "Akri not recognizing devices",
+        "description": "If Akri is not recognizing devices, ensure that the device plugins are correctly configured and that the devices are available on the nodes. Check the Akri logs for any errors related to device discovery.\n```bash\nkubectl logs <akri-pod-name> --namespace akri\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-alertmanager.json
+++ b/solutions/cncf-install/install-alertmanager.json
@@ -40,7 +40,53 @@
         "kubectl create configmap alertmanager-config --from-file=<your_alertmanager_config.yml> --namespace monitoring\nkubectl patch deployment alertmanager --namespace monitoring --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": [\"--config.file=/etc/alertmanager/alertmanager.yml\"]}]'",
         "kubectl port-forward svc/alertmanager --namespace monitoring 9093:9093"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Alertmanager release from the monitoring namespace using Helm to remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall alertmanager --namespace monitoring\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation. This step ensures that no leftover resources remain.\n```bash\nkubectl delete crd alertmanagers.monitoring.coreos.com\nkubectl delete pvc --all --namespace monitoring\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the monitoring namespace to clean up all remaining resources and verify that it has been removed.\n```bash\nkubectl delete namespace monitoring\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Alertmanager configuration and any persistent data. This ensures you can restore to the previous state if needed.\n```bash\nkubectl get configmap alertmanager-config --namespace monitoring -o yaml > alertmanager-config-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Alertmanager to the desired version. Replace `<new_version>` with the version you wish to upgrade to.\n```bash\nhelm repo update\nhelm upgrade alertmanager prometheus-community/alertmanager --version <new_version> --namespace monitoring\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Alertmanager pod to ensure it is running the new version successfully after the upgrade.\n```bash\nkubectl get pods --namespace monitoring\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This indicates that the Alertmanager pod is failing to start. Check the pod logs for errors.\n```bash\nkubectl logs <pod_name> --namespace monitoring\n```"
+      },
+      {
+        "title": "Configuration errors",
+        "description": "If Alertmanager fails to start due to configuration issues, validate the configuration file. You can check the configmap for any misconfigurations.\n```bash\nkubectl describe configmap alertmanager-config --namespace monitoring\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access Alertmanager, ensure the service is running and the port forwarding is set up correctly. Check the service status.\n```bash\nkubectl get svc --namespace monitoring\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the Alertmanager pod is not starting due to resource constraints, check the resource requests and limits in the deployment. Adjust them if necessary.\n```bash\nkubectl describe deployment alertmanager --namespace monitoring\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-antrea.json
+++ b/solutions/cncf-install/install-antrea.json
@@ -36,7 +36,53 @@
         "kubectl edit deployment antrea-controller -n kube-system",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 200m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Antrea deployment, use the following command to uninstall the Helm release from the kube-system namespace:\n```bash\nhelm uninstall antrea --namespace kube-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the release, you should remove any Custom Resource Definitions (CRDs) and persistent resources that were created. Run the following commands:\n```bash\nkubectl delete crd antreanetworking.io\nkubectl delete crd antreaegressrules.antrea.io\nkubectl delete crd antreanetworkpolicies.antrea.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "If you created a specific namespace for Antrea, you can remove it with the following command. Verify that the namespace has been deleted:\n```bash\nkubectl delete namespace kube-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's good practice to back up the current state of your Antrea installation. You can do this by exporting the current configuration:\n```bash\nkubectl get deployment antrea-controller -n kube-system -o yaml > antrea-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to upgrade Antrea to the latest version:\n```bash\nhelm repo update\nhelm upgrade antrea antrea/antrea --namespace kube-system --version v2.6.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Antrea pods are running the new version:\n```bash\nkubectl get pods -n kube-system -l app=antrea\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that the Antrea pods are in a CrashLoopBackOff state, check the logs for more details:\n```bash\nkubectl logs <pod-name> -n kube-system\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Network policies not enforced",
+        "description": "If network policies are not being enforced as expected, ensure that the Antrea controller is running:\n```bash\nkubectl get pods -n kube-system -l app=antrea-controller\n```\nIf it's not running, check the logs for errors."
+      },
+      {
+        "title": "High resource usage",
+        "description": "If you observe high CPU or memory usage from Antrea components, check the resource limits set in the deployment:\n```bash\nkubectl get deployment antrea-controller -n kube-system -o yaml\n```\nConsider adjusting the resource limits based on your cluster's needs."
+      },
+      {
+        "title": "Antrea not connecting to Open vSwitch",
+        "description": "If Antrea is not connecting to Open vSwitch, check the status of the OVS service:\n```bash\nkubectl exec -it <antrea-agent-pod-name> -n kube-system -- ovs-vsctl show\n```\nEnsure that the OVS service is running and properly configured."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-argo-events.json
+++ b/solutions/cncf-install/install-argo-events.json
@@ -40,7 +40,53 @@
         "kubectl apply -f - <<EOF\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: argo-events-webhook-sa\n  namespace: argo-events\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: argo-events-webhook\nrules:\n- apiGroups: [\"\"]\n  resources: [\"secrets\", \"configmaps\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"delete\", \"patch\"]\n- apiGroups: [\"argoproj.io\"]\n  resources: [\"eventbus\", \"eventsources\", \"sensors\"]\n  verbs: [\"get\", \"list\", \"watch\"]\nEOF",
         "kubectl port-forward svc/events-webhook -n argo-events 8080:443"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Argo Events release from the `argo-events` namespace using Helm to remove all associated resources.\n```bash\nhelm uninstall argo-events --namespace argo-events\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation of Argo Events.\n```bash\nkubectl delete crd eventbuses.argoproj.io eventsources.argoproj.io sensors.argoproj.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `argo-events` namespace to clean up any remaining resources and verify that it has been removed.\n```bash\nkubectl delete namespace argo-events\nkubectl get namespaces | grep argo-events\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of Argo Events by exporting the existing configurations and resources.\n```bash\nkubectl get all -n argo-events -o yaml > argo-events-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Argo Events release to the latest version.\n```bash\nhelm repo update\nhelm upgrade argo-events argo/argo-events --namespace argo-events --version v1.10.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Argo Events components are running successfully after the upgrade by listing the pods in the `argo-events` namespace.\n```bash\nkubectl get pods -n argo-events\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If any pods are in a CrashLoopBackOff state, check the logs for the affected pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> -n argo-events\n```"
+      },
+      {
+        "title": "Webhook service not reachable",
+        "description": "If the Argo Events webhook service is not reachable, ensure that the service is running and check the port-forwarding command.\n```bash\nkubectl get svc -n argo-events\nkubectl port-forward svc/events-webhook -n argo-events 8080:443\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter RBAC permission errors, verify that the ServiceAccount and ClusterRoleBinding are correctly set up.\n```bash\nkubectl get serviceaccount argo-events-webhook-sa -n argo-events\nkubectl get clusterrole argo-events-webhook -o yaml\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you receive errors related to missing CRDs, ensure that the CRDs were properly installed and are available in the cluster.\n```bash\nkubectl get crd\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-argo-rollouts.json
+++ b/solutions/cncf-install/install-argo-rollouts.json
@@ -40,7 +40,53 @@
         "kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/namespace-install.yaml",
         "kubectl port-forward svc/argo-rollouts-dashboard -n argo-rollouts 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Argo Rollouts Helm release to remove the deployment from your cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources associated with Argo Rollouts."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for Argo Rollouts and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Argo Rollouts configuration."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and execute the upgrade command to install the latest version of Argo Rollouts."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Argo Rollouts controller pod is running the new version in the specified namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when the Argo Rollouts controller pod fails to start repeatedly. Check the logs for errors using the command: \n```bash\nkubectl logs <pod-name> -n argo-rollouts\n```\nFix any configuration issues or resource limitations identified in the logs."
+      },
+      {
+        "title": "Argo Rollouts dashboard not accessible",
+        "description": "If you cannot access the Argo Rollouts dashboard, ensure that the port-forward command is running. Verify the service is up with: \n```bash\nkubectl get svc -n argo-rollouts\n```\nRestart the port-forward command if necessary."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission errors, check the RBAC configuration. Review the applied roles and bindings with: \n```bash\nkubectl get roles,rolebindings -n argo-rollouts\n```\nAdjust the RBAC settings as needed."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check the output for specific error messages. You can roll back to the previous version with: \n```bash\nhelm rollback argo-rollouts <previous-version> --namespace argo-rollouts\n```\nInvestigate the error messages for further troubleshooting."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-argo-workflows.json
+++ b/solutions/cncf-install/install-argo-workflows.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/argo-server -n argo 2746:2746",
         "kubectl edit configmap workflow-controller-configmap -n argo\n# Add or modify the following lines:\n# resourceLimits:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Argo Workflows release from the `argo` namespace using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall argo --namespace argo\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove the Custom Resource Definitions (CRDs) that were installed with Argo Workflows. This step will also clean up any persistent volumes if they were created.\n```bash\nkubectl delete crd workflows.argoproj.io\nkubectl delete crd workflowtemplates.argoproj.io\nkubectl delete crd cronworkflows.argoproj.io\nkubectl delete crd clusterworkflowtemplates.argoproj.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `argo` namespace to clean up any remaining resources and verify that it has been removed.\n```bash\nkubectl delete namespace argo\nkubectl get namespaces | grep argo\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your workflows and configurations. You can export the current workflows and configurations using the following command:\n```bash\nkubectl get workflows -n argo -o yaml > argo-workflows-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Argo Workflows installation to the latest version. Replace `v4.0.2` with the desired version if necessary.\n```bash\nhelm repo update\nhelm upgrade argo argo/argo-workflows --namespace argo --version v4.0.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Argo Workflows pods are running with the new version:\n```bash\nkubectl get pods -n argo\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see pods in a `CrashLoopBackOff` state, check the logs for the specific pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> -n argo\n```\nCommon causes include misconfigured workflows or insufficient resources."
+      },
+      {
+        "title": "Argo UI not accessible",
+        "description": "If you cannot access the Argo UI, ensure that the port-forward command is running. Check the service status:\n```bash\nkubectl get svc argo-server -n argo\n```\nIf the service is not running, you may need to troubleshoot the deployment."
+      },
+      {
+        "title": "Workflows not starting",
+        "description": "If workflows are not starting, check the workflow controller logs for errors:\n```bash\nkubectl logs deployment/workflow-controller -n argo\n```\nEnsure that the controller is running and that there are no permission issues."
+      },
+      {
+        "title": "Failed to create persistent volume claims",
+        "description": "If your workflows require persistent volumes and they are failing to bind, check the PVC status:\n```bash\nkubectl get pvc -n argo\n```\nEnsure that there are available persistent volumes that match the requested storage class and size."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-argo.json
+++ b/solutions/cncf-install/install-argo.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/argocd-server -n argocd 8080:443",
         "kubectl edit deployment argocd-server -n argocd"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Argo CD release using Helm to remove the deployment and associated resources. Run the following command:\n```bash\nhelm uninstall argocd --namespace argocd\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation. Execute the following commands:\n```bash\nkubectl delete crd applications.argoproj.io\nkubectl delete crd appprojects.argoproj.io\nkubectl delete crd repositories.argoproj.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'argocd' namespace to clean up all remaining resources. Verify that the namespace has been removed by running:\n```bash\nkubectl delete namespace argocd\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Argo CD installation. You can export the current configuration with:\n```bash\nkubectl get all -n argocd -o yaml > argocd-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Argo CD to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade argocd argo/argo-cd --version v3.4.0 --namespace argocd\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that all Argo CD pods are running with the new version. Execute:\n```bash\nkubectl get pods -n argocd\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see Argo CD pods in a CrashLoopBackOff state, check the logs for the affected pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> -n argocd\n``` \nLook for error messages that indicate configuration issues or missing dependencies."
+      },
+      {
+        "title": "Unable to access Argo CD API Server",
+        "description": "If you cannot access the Argo CD API server, ensure that the port-forward command is running. Check the service status with:\n```bash\nkubectl get svc -n argocd\n``` \nIf the service is not found, verify that the installation was successful."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, check the current version of the release with:\n```bash\nhelm list --namespace argocd\n``` \nEnsure that you are specifying a valid version in the upgrade command."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If Argo CD pods are being killed due to Out Of Memory (OOM) errors, consider increasing the memory limits set in the deployment. Check the pod status with:\n```bash\nkubectl describe pod <pod-name> -n argocd\n``` \nThen edit the deployment to adjust the resource limits accordingly."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-armada.json
+++ b/solutions/cncf-install/install-armada.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment armada --namespace armada",
         "resources:\n  limits:\n    cpu: \"1000m\"\n    memory: \"512Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Armada release from the 'armada' namespace using Helm to remove the deployment and associated resources:\n```bash\nhelm uninstall armada --namespace armada\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Armada:\n```bash\nkubectl delete crd armadajobs.armada.k8s.io\nkubectl delete pvc --all --namespace armada\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'armada' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace armada\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Armada deployment:\n```bash\nkubectl get all --namespace armada -o yaml > armada-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Armada release to the latest version:\n```bash\nhelm repo update\nhelm upgrade armada armada/armada --namespace armada --version v0.20.35\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that all pods are running and the upgrade was successful:\n```bash\nkubectl get pods --namespace armada\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see pods in the 'CrashLoopBackOff' state, check the logs for the failing pod:\n```bash\nkubectl logs <pod-name> --namespace armada\n```\nInvestigate the logs for errors and adjust the configuration or resource limits as necessary."
+      },
+      {
+        "title": "ServiceMonitor not scraping metrics",
+        "description": "If Prometheus is not scraping metrics from Armada, verify the ServiceMonitor configuration:\n```bash\nkubectl get servicemonitor armada-monitor --namespace armada -o yaml\n```\nEnsure that the selector matches the labels of the Armada service."
+      },
+      {
+        "title": "Deployment not available",
+        "description": "If the Armada deployment is not available, check the deployment status:\n```bash\nkubectl get deployment armada --namespace armada\n```\nIf the replicas are not available, describe the deployment for more details:\n```bash\nkubectl describe deployment armada --namespace armada\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being terminated with 'OOMKilled', check the resource usage:\n```bash\nkubectl top pods --namespace armada\n```\nConsider increasing the memory limits in the deployment configuration."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-artifact-hub.json
+++ b/solutions/cncf-install/install-artifact-hub.json
@@ -44,7 +44,53 @@
         "helm upgrade artifact-hub artifact-hub/artifact-hub --namespace artifact-hub --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "kubectl port-forward svc/artifact-hub --namespace artifact-hub 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Artifact Hub release from the cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall artifact-hub --namespace artifact-hub\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Artifact Hub to ensure a clean uninstallation.\n```bash\nkubectl delete crd artifacthubrepositories.artifacthub.io\nkubectl delete crd artifacthubcharts.artifacthub.io\nkubectl delete pvc --all --namespace artifact-hub\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'artifact-hub' namespace and verify that it has been removed from the cluster.\n```bash\nkubectl delete namespace artifact-hub\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Artifact Hub installation. You can do this by exporting the current configuration.\n```bash\nhelm get values artifact-hub --namespace artifact-hub > artifact-hub-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Artifact Hub installation to the latest version. Replace '1.22.2-0' with the desired version.\n```bash\nhelm repo update\nhelm upgrade artifact-hub artifact-hub/artifact-hub --version 1.22.2-0 --namespace artifact-hub\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Artifact Hub pods are running the new version successfully.\n```bash\nkubectl get pods --namespace artifact-hub\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Artifact Hub pods are in a CrashLoopBackOff state, check the logs for errors that may indicate the cause of the failure.\n```bash\nkubectl logs <pod-name> --namespace artifact-hub\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Artifact Hub service, ensure that the service is running and check for any network policies that might be blocking access.\n```bash\nkubectl get svc --namespace artifact-hub\nkubectl describe svc artifact-hub --namespace artifact-hub\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to insufficient resources, check the resource requests and limits set in the deployment and adjust them accordingly.\n```bash\nkubectl describe deployment artifact-hub --namespace artifact-hub\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify that you are using the correct namespace and release name.\n```bash\nhelm list --namespace artifact-hub\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-atlantis.json
+++ b/solutions/cncf-install/install-atlantis.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment atlantis --namespace atlantis",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Atlantis release using Helm to remove the deployment from the cluster. Run the following command:\n```bash\nhelm uninstall atlantis --namespace atlantis\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Atlantis. Use the following commands:\n```bash\nkubectl delete pvc --all --namespace atlantis\nkubectl delete crd atlantis.*\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `atlantis` namespace to clean up all remaining resources. Verify that the namespace has been removed:\n```bash\nkubectl delete namespace atlantis\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and any persistent data. You can export the current Helm release configuration with:\n```bash\nhelm get values atlantis --namespace atlantis > atlantis-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Atlantis release to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade atlantis runatlantis/atlantis --namespace atlantis --version v0.41.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Atlantis pods are running the new version successfully:\n```bash\nkubectl get pods --namespace atlantis\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Atlantis pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command:\n```bash\nkubectl logs <pod-name> --namespace atlantis\n```\nLook for any configuration errors or issues with resource limits."
+      },
+      {
+        "title": "Unable to access Atlantis UI",
+        "description": "If you cannot access the Atlantis UI via port forwarding, ensure that the service is running and the port is correctly forwarded. Check the service status with:\n```bash\nkubectl get svc --namespace atlantis\n```\nIf the service is not running, verify the deployment."
+      },
+      {
+        "title": "Terraform plan fails",
+        "description": "If Terraform plans are failing, check the Atlantis logs for specific error messages. Use:\n```bash\nkubectl logs <atlantis-pod-name> --namespace atlantis\n```\nEnsure that the necessary permissions and configurations are set for the Terraform workspace."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade fails, check for compatibility issues with the new version. Review the output of the upgrade command and check the current configuration with:\n```bash\nhelm get values atlantis --namespace atlantis\n```\nYou may need to rollback using:\n```bash\nhelm rollback atlantis --namespace atlantis\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-backstage.json
+++ b/solutions/cncf-install/install-backstage.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/backstage --namespace backstage --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward service/backstage --namespace backstage 7007:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Backstage release using Helm to remove the deployment and associated resources from the cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'backstage' namespace and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Backstage installation."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of Backstage."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Backstage pods to ensure that the upgrade was successful."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start repeatedly. Check the logs of the pod to diagnose the issue."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access Backstage, ensure that the service is running and that the port-forward command is set up correctly."
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you encounter resource allocation errors, verify that your cluster has enough resources available for Backstage."
+      },
+      {
+        "title": "Failed to pull image",
+        "description": "This error indicates that the container image cannot be pulled. Check your image repository credentials and network connectivity."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-bank-vaults.json
+++ b/solutions/cncf-install/install-bank-vaults.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment bank-vaults --namespace bank-vaults -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"bank-vaults\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"512Mi\"}}}]}}}}}'",
         "kubectl create role bank-vaults-role --verb=get,list,watch --resource=pods --namespace bank-vaults\nkubectl create rolebinding bank-vaults-rolebinding --role=bank-vaults-role --serviceaccount=bank-vaults:default --namespace bank-vaults"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Bank-Vaults Helm release from your Kubernetes cluster. This will remove the deployment and associated resources created by the Helm chart.\n```bash\nhelm uninstall bank-vaults --namespace bank-vaults\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Bank-Vaults to ensure a clean removal of all resources.\n```bash\nkubectl delete crd bankvaults.vault.banzaicloud.com\nkubectl delete pvc --all --namespace bank-vaults\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'bank-vaults' namespace to remove all remaining resources and verify that it has been successfully deleted.\n```bash\nkubectl delete namespace bank-vaults\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of Bank-Vaults. This ensures you can restore to the previous version if needed.\n```bash\nhelm get values bank-vaults --namespace bank-vaults > bank-vaults-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade the Bank-Vaults release to the latest version. Replace 'v1.32.2' with the desired version.\n```bash\nhelm repo update\nhelm upgrade bank-vaults bank-vaults/bank-vaults --namespace bank-vaults --version v1.32.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Bank-Vaults pods to ensure that they are running the upgraded version successfully.\n```bash\nkubectl get pods --namespace bank-vaults\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Bank-Vaults pods are in a CrashLoopBackOff state, check the logs for any errors that may indicate the cause of the failure.\n```bash\nkubectl logs <pod-name> --namespace bank-vaults\n```"
+      },
+      {
+        "title": "Insufficient memory or CPU resources",
+        "description": "If you encounter resource allocation issues, check the resource limits set for the Bank-Vaults deployment and adjust them as necessary.\n```bash\nkubectl describe deployment bank-vaults --namespace bank-vaults\n```"
+      },
+      {
+        "title": "RBAC permission errors",
+        "description": "If you see permission errors in the logs, ensure that the Role and RoleBinding for Bank-Vaults are correctly configured and applied.\n```bash\nkubectl get role bank-vaults-role --namespace bank-vaults\nkubectl get rolebinding bank-vaults-rolebinding --namespace bank-vaults\n```"
+      },
+      {
+        "title": "Vault initialization issues",
+        "description": "If Vault fails to initialize, check the configuration settings and ensure that the required environment variables are set correctly in the deployment.\n```bash\nkubectl get configmap bank-vaults-config --namespace bank-vaults -o yaml\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-bfe.json
+++ b/solutions/cncf-install/install-bfe.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment bfe --namespace bfe\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"\n#   requests:\n#     cpu: \"250m\"\n#     memory: \"256Mi\"",
         "kubectl port-forward svc/bfe --namespace bfe 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Use the Helm command to uninstall the BFE release from the Kubernetes cluster. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall bfe --namespace bfe\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) created by BFE, clean them up using the following commands:\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace bfe\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'bfe' namespace to remove all remaining resources associated with the BFE installation. Verify that the namespace has been deleted successfully.\n```bash\nkubectl delete namespace bfe\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current configuration and state of the BFE deployment. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace bfe -o yaml > bfe-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts and then upgrade the BFE installation to the desired version. Replace `<new-version>` with the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade bfe bfe/bfe --version <new-version> --namespace bfe\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the BFE pods to ensure they are running the new version correctly.\n```bash\nkubectl get pods --namespace bfe\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the BFE pods are in a CrashLoopBackOff state, check the logs for the pods to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace bfe\n```"
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the BFE service, ensure that the port forwarding is set up correctly and that the service is running:\n```bash\nkubectl get svc --namespace bfe\nkubectl port-forward svc/bfe --namespace bfe 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you encounter errors related to insufficient resources, check the resource limits and requests set in the deployment:\n```bash\nkubectl describe deployment bfe --namespace bfe\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, verify that you are using the correct namespace and release name:\n```bash\nhelm list --namespace bfe\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-bootc.json
+++ b/solutions/cncf-install/install-bootc.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment bootc --limits=cpu=500m,memory=512Mi --namespace bootc",
         "kubectl port-forward svc/bootc 8080:80 --namespace bootc"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Bootc release from the 'bootc' namespace using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Bootc."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'bootc' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Create a backup of the current Bootc release configuration and resources."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Bootc release to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Bootc pods are running the new version successfully in the 'bootc' namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when the Bootc pods are unable to start successfully. Check the logs of the pods to diagnose the issue using the following command:\n```bash\nkubectl logs <pod-name> --namespace bootc\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Bootc service is not accessible, ensure that the port forwarding is set up correctly. Verify the service status with:\n```bash\nkubectl get svc --namespace bootc\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the Bootc pods are not starting due to resource limits, check the resource allocation using:\n```bash\nkubectl describe deployment bootc --namespace bootc\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify that the release exists in the specified namespace:\n```bash\nhelm list --namespace bootc\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-bpfman.json
+++ b/solutions/cncf-install/install-bpfman.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment bpfman --namespace bpfman\n# Add the following lines under spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"",
         "kubectl port-forward service/bpfman --namespace bpfman 8080:80\n# Now access the dashboard at http://localhost:8080"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the bpfman release from the 'bpfman' namespace using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall bpfman --namespace bpfman\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources that were created by bpfman. This ensures that all related resources are removed from the cluster.\n```bash\nkubectl delete crd bpfman.bpfman.io\nkubectl delete pvc --all --namespace bpfman\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'bpfman' namespace to clean up any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace bpfman\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to backup the current state of your bpfman installation. You can do this by exporting the current configuration.\n```bash\nhelm get values bpfman --namespace bpfman > bpfman-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade bpfman to the latest version. Make sure to specify the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade bpfman bpfman/bpfman --namespace bpfman --version v0.6.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the bpfman pods are running the new version and are in a healthy state.\n```bash\nkubectl get pods --namespace bpfman\nkubectl describe pod <pod-name> --namespace bpfman\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the bpfman pods are in a CrashLoopBackOff state, check the logs for errors that might indicate the cause of the crash.\n```bash\nkubectl logs <pod-name> --namespace bpfman\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the bpfman dashboard, ensure that the service is running and the port forwarding is set up correctly. Check the service status.\n```bash\nkubectl get svc --namespace bpfman\nkubectl port-forward service/bpfman --namespace bpfman 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to resource limits, check the resource usage of the bpfman pods and adjust the limits if necessary.\n```bash\nkubectl top pods --namespace bpfman\nkubectl edit deployment bpfman --namespace bpfman\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you receive errors related to missing CRDs, ensure that the CRDs were not deleted accidentally. You can recreate them if necessary.\n```bash\nkubectl get crd\nhelm install bpfman bpfman/bpfman --namespace bpfman --create-namespace --version v0.5.6\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cadence-workflow.json
+++ b/solutions/cncf-install/install-cadence-workflow.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment cadence --namespace cadence --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'",
         "kubectl port-forward svc/cadence-web --namespace cadence 8088:8088"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Cadence Helm release to remove the deployment and its associated resources from the cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'cadence' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Cadence deployment to ensure you can restore it if needed."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to apply the latest changes."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that all Cadence pods are running successfully after the upgrade to ensure the process completed without issues."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start repeatedly. Check the pod logs to diagnose the problem using the following command:\n```bash\nkubectl logs <pod-name> --namespace cadence\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Cadence Web UI, ensure that the port forwarding is set up correctly. You can check the service status with:\n```bash\nkubectl get svc --namespace cadence\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the Cadence pods are not starting due to resource constraints, check the resource limits and requests set in the deployment:\n```bash\nkubectl describe deployment cadence --namespace cadence\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check the error message for clues. You can also check the current Helm release status with:\n```bash\nhelm status cadence --namespace cadence\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-capsule.json
+++ b/solutions/cncf-install/install-capsule.json
@@ -40,7 +40,53 @@
         "helm upgrade capsule capsule/capsule --namespace capsule-system --set global.jobs.resources.limits.cpu=500m --set global.jobs.resources.limits.memory=512Mi",
         "kubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: capsule-role\nrules:\n- apiGroups: ['']\n  resources: ['pods', 'pods/log']\n  verbs: ['get', 'list', 'watch']\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Capsule Operator Helm release from the cluster. This will remove the deployment and associated resources created by the Helm chart."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources associated with Capsule to ensure a clean uninstallation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for Capsule and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Capsule installation to prevent data loss."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Capsule Operator to the latest version. Replace '0.12.5' with the desired version if needed."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Capsule Operator pod is running the new version successfully. This command will list all pods in the capsule-system namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Capsule Operator pods are in a CrashLoopBackOff state, check the logs for errors. This may indicate a misconfiguration or resource issue."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that the version specified is compatible with the existing installation. You can check the current version with:"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter RBAC permission errors, verify that the necessary roles and bindings are correctly configured. Check the current RBAC settings with:"
+      },
+      {
+        "title": "Namespace not found",
+        "description": "If you receive an error indicating that the namespace 'capsule-system' does not exist, ensure that the namespace was created successfully during installation. You can check existing namespaces with:"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-carina.json
+++ b/solutions/cncf-install/install-carina.json
@@ -44,7 +44,53 @@
         "helm upgrade carina carina/carina-csi-driver --namespace carina --set controller.resources.limits.cpu=200m --set controller.resources.limits.memory=500Mi",
         "helm upgrade carina carina/carina-csi-driver --namespace carina --set rbac.create=true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Carina Helm release to remove the deployment from your cluster. This will delete all associated resources managed by Helm.\n```bash\nhelm uninstall carina --namespace carina\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources are removed from the cluster.\n```bash\nkubectl delete crd $(kubectl get crd | grep carina | awk '{print $1}')\nkubectl delete pvc --all --namespace carina\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'carina' namespace to clean up any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace carina\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your Carina installation. You can do this by exporting the current configuration.\n```bash\nhelm get values carina --namespace carina > carina-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the Carina installation to the desired version.\n```bash\nhelm repo update\nhelm upgrade carina carina/carina-csi-driver --namespace carina --version v0.12.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Carina pods to ensure they are running the new version without issues.\n```bash\nkubectl get pods --namespace carina\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Carina pods are in a CrashLoopBackOff state, check the logs of the affected pod for errors.\n```bash\nkubectl logs <pod-name> --namespace carina\n```"
+      },
+      {
+        "title": "Persistent Volume Claims not bound",
+        "description": "If PVCs are not bound, ensure that the storage class is correctly configured and available. Check the PVC status with:\n```bash\nkubectl get pvc --namespace carina\n```"
+      },
+      {
+        "title": "Health check endpoint returns error",
+        "description": "If the health check endpoint is returning an error, verify that the Carina controller is running and check its logs for any issues.\n```bash\nkubectl logs deployment/csi-carina-controller --namespace carina\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission errors, ensure that the RBAC roles and bindings are correctly set up. Check the roles with:\n```bash\nkubectl get roles --namespace carina\nkubectl get rolebindings --namespace carina\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cartography.json
+++ b/solutions/cncf-install/install-cartography.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment cartography --namespace cartography --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward service/cartography --namespace cartography 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Cartography Helm release from the cluster using the following command:\n```bash\nhelm uninstall cartography --namespace cartography\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Cartography:\n```bash\nkubectl delete crd cartography --namespace cartography\nkubectl delete pvc --all --namespace cartography\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Cartography namespace and verify that it has been removed:\n```bash\nkubectl delete namespace cartography\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of Cartography by exporting the existing configuration:\n```bash\nkubectl get all --namespace cartography -o yaml > cartography-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Cartography to the latest version:\n```bash\nhelm repo update\nhelm upgrade cartography cartography/cartography --namespace cartography --version 0.140.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Cartography pods are running with the new version:\n```bash\nkubectl get pods --namespace cartography\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Cartography pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace cartography\n```\nInvestigate the logs for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Cartography web interface, ensure the service is running:\n```bash\nkubectl get svc --namespace cartography\n```\nIf the service is not running, check the deployment status:\n```bash\nkubectl get deployments --namespace cartography\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource usage:\n```bash\nkubectl top pods --namespace cartography\n```\nConsider adjusting the resource limits or requests in the deployment."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace cartography\n```\nEnsure that the release name 'cartography' exists in the specified namespace."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-carvel.json
+++ b/solutions/cncf-install/install-carvel.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/ytt --namespace carvel --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward svc/ytt --namespace carvel 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the ytt release from the 'carvel' namespace using Helm. This will remove the deployment and associated resources created by the release.\n```bash\nhelm uninstall ytt --namespace carvel\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volumes created by ytt, clean them up to ensure no leftover resources remain.\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace carvel\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'carvel' namespace to remove all resources associated with it, and verify that it has been removed.\n```bash\nkubectl delete namespace carvel\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and any important data from ytt. You can use the following command to export the current configuration.\n```bash\nkubectl get all --namespace carvel -o yaml > ytt-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Carvel Helm repository and upgrade ytt to the latest version. Replace 'v0.53.2' with the desired version if necessary.\n```bash\nhelm repo update\nhelm upgrade ytt carvel/ytt --namespace carvel --version v0.54.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the ytt pod is running the new version successfully in the 'carvel' namespace after the upgrade.\n```bash\nkubectl get pods --namespace carvel\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the ytt pod is stuck in a CrashLoopBackOff state, check the logs for errors that may indicate the cause of the failure.\n```bash\nkubectl logs <pod-name> --namespace carvel\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the ytt service, ensure that the port forwarding is set up correctly and that the service is running.\n```bash\nkubectl get svc --namespace carvel\nkubectl port-forward svc/ytt --namespace carvel 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If ytt is failing to start due to insufficient resources, check the resource limits and requests set for the deployment and adjust them as necessary.\n```bash\nkubectl describe deployment ytt --namespace carvel\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify that the release name and namespace are correct.\n```bash\nhelm list --namespace carvel\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cdk-for-kubernetes-cdk8s.json
+++ b/solutions/cncf-install/install-cdk-for-kubernetes-cdk8s.json
@@ -44,7 +44,53 @@
         "cdk8s synth",
         "kubectl apply -f dist/my-cdk8s-app.k8s.yaml --namespace my-namespace --create-namespace"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the cdk8s deployment, use the following command to uninstall the release from your Kubernetes cluster. Replace 'my-cdk8s-app' with your actual release name if different.\n\n```bash\nhelm uninstall my-cdk8s-app --namespace my-namespace\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any custom resource definitions (CRDs) and persistent volumes that may have been created during the installation. Use the following commands:\n\n```bash\nkubectl delete crd <your-crd-name>\nkubectl delete pvc --all --namespace my-namespace\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the namespace used for the cdk8s application and verify that it has been removed. Use the following commands:\n\n```bash\nkubectl delete namespace my-namespace\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up your current resources. You can do this by exporting the current state of your Kubernetes resources:\n\n```bash\nkubectl get all --namespace my-namespace -o yaml > backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the cdk8s CLI to the latest version and run the upgrade command. Ensure you are using the correct version:\n\n```bash\nnpm install -g cdk8s-cli@latest\nhelm upgrade my-cdk8s-app --namespace my-namespace\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, check the status of your resources to ensure everything is running smoothly:\n\n```bash\nkubectl get all -n my-namespace\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your pods are stuck in a CrashLoopBackOff state, check the logs to diagnose the issue. Use the following command to view the logs:\n\n```bash\nkubectl logs <pod-name> -n my-namespace\n```"
+      },
+      {
+        "title": "Resource not found error",
+        "description": "If you encounter a 'Resource not found' error when applying manifests, ensure that the resource definitions are correct and that you are targeting the right namespace:\n\n```bash\nkubectl apply -f dist/my-cdk8s-app.k8s.yaml --namespace my-namespace\n```"
+      },
+      {
+        "title": "Permission denied errors",
+        "description": "If you receive permission denied errors, check your Kubernetes RBAC settings and ensure that your service account has the necessary permissions:\n\n```bash\nkubectl get clusterrolebindings\n```"
+      },
+      {
+        "title": "Failed to connect to the server",
+        "description": "If you see a 'Failed to connect to the server' error, verify that your Kubernetes cluster is running and that your kubeconfig is correctly configured:\n\n```bash\nkubectl cluster-info\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cedar.json
+++ b/solutions/cncf-install/install-cedar.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment cedar --namespace cedar\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     memory: \"512Mi\"\n#     cpu: \"500m\"",
         "kubectl create role cedar-role --verb=get,list,watch --resource=pods --namespace cedar\nkubectl create rolebinding cedar-role-binding --role=cedar-role --serviceaccount=default:default --namespace cedar"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Cedar release from your Kubernetes cluster using Helm. This will remove the deployment and associated resources created by the Helm chart."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation. This ensures that all resources are cleaned up."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'cedar' namespace to remove any remaining resources. Verify that the namespace has been deleted successfully."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Cedar installation. You can use the following command to export the current configuration."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Cedar Helm repository and run the upgrade command to upgrade Cedar to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Cedar pods are running the new version successfully in the 'cedar' namespace after the upgrade."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Cedar pods are stuck in CrashLoopBackOff, check the logs for errors. Use the following command to view the logs of a specific pod."
+      },
+      {
+        "title": "Cedar service not responding",
+        "description": "If the Cedar service is not responding, ensure that the service is correctly configured and that the pods are running. Use the following command to check the service status."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission denied errors, verify that the RBAC roles and bindings are correctly set up. Use the following command to list the roles in the 'cedar' namespace."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to out of memory (OOMKilled), consider adjusting the resource limits set for Cedar. Use the following command to edit the deployment."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cert-manager.json
+++ b/solutions/cncf-install/install-cert-manager.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment cert-manager --namespace cert-manager --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'",
         "cat <<EOF | kubectl apply -f -\napiVersion: cert-manager.io/v1\nkind: ClusterIssuer\nmetadata:\n  name: letsencrypt-prod\nspec:\n  acme:\n    # You must replace this email address with your own.\n    email: your-email@example.com\n    server: https://acme-v02.api.letsencrypt.org/directory\n    privateKeySecretRef:\n      name: letsencrypt-prod\n    solvers:\n    - http01:\n        ingress:\n          class: nginx\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the cert-manager release from the 'cert-manager' namespace using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete the Custom Resource Definitions (CRDs) and any persistent resources associated with cert-manager."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'cert-manager' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of cert-manager resources."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Jetstack Helm repository and upgrade cert-manager to the desired version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the cert-manager pods are running the new version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If cert-manager pods are in a CrashLoopBackOff state, check the logs for errors using the following command:\n```bash\nkubectl logs <pod-name> --namespace cert-manager\n```"
+      },
+      {
+        "title": "Certificate issuance fails",
+        "description": "If certificates are not being issued, check the status of the ClusterIssuer:\n```bash\nkubectl describe clusterissuer letsencrypt-prod\n```"
+      },
+      {
+        "title": "Ingress not routing traffic",
+        "description": "If the Ingress is not routing traffic correctly, verify the Ingress resource configuration:\n```bash\nkubectl describe ingress <ingress-name> --namespace cert-manager\n```"
+      },
+      {
+        "title": "CRDs not installed",
+        "description": "If the CRDs are missing, ensure they were installed during the Helm installation. You can check the CRDs with:\n```bash\nkubectl get crds | grep cert-manager.io\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-chaos-mesh.json
+++ b/solutions/cncf-install/install-chaos-mesh.json
@@ -40,7 +40,53 @@
         "kubectl apply -f https://raw.githubusercontent.com/chaos-mesh/chaos-mesh/master/deploy/rbac.yaml --namespace chaos-mesh",
         "kubectl port-forward svc/chaos-dashboard -n chaos-mesh 2333:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Chaos Mesh release from your Kubernetes cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall chaos-mesh --namespace chaos-mesh\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove the Custom Resource Definitions (CRDs) and any persistent resources associated with Chaos Mesh. This ensures that all remnants of the installation are cleaned up.\n```bash\nkubectl delete crd experiments.chaos-mesh.org\nkubectl delete crd schedules.chaos-mesh.org\nkubectl delete crd chaosengines.chaos-mesh.org\nkubectl delete crd chaosresults.chaos-mesh.org\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for Chaos Mesh and verify that it has been removed successfully.\n```bash\nkubectl delete namespace chaos-mesh\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Chaos Mesh installation to avoid data loss.\n```bash\nkubectl get all --namespace chaos-mesh -o yaml > chaos-mesh-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Chaos Mesh installation to the latest version.\n```bash\nhelm repo update\nhelm upgrade chaos-mesh chaos-mesh/chaos-mesh --version v2.9.0 --namespace chaos-mesh\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Chaos Mesh pods are running the new version successfully after the upgrade.\n```bash\nkubectl get pods --namespace chaos-mesh\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Chaos Mesh pods are in a CrashLoopBackOff state, check the logs for the pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace chaos-mesh\n```"
+      },
+      {
+        "title": "Chaos Dashboard not accessible",
+        "description": "If you cannot access the Chaos Dashboard, ensure that the port-forward command is running and check the service status.\n```bash\nkubectl get svc --namespace chaos-mesh\n```"
+      },
+      {
+        "title": "RBAC issues preventing access",
+        "description": "If you encounter permission denied errors, verify that the RBAC configuration is correctly applied and the necessary roles are assigned.\n```bash\nkubectl get clusterrolebindings | grep chaos-mesh\n```"
+      },
+      {
+        "title": "Resource limits causing pod evictions",
+        "description": "If pods are being evicted due to resource limits, check the resource requests and limits set for the Chaos Mesh deployment.\n```bash\nkubectl describe pod <pod-name> --namespace chaos-mesh\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cilium.json
+++ b/solutions/cncf-install/install-cilium.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment cilium --namespace cilium-system\n# Add the following under spec.template.spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"",
         "cat <<EOF | kubectl apply -f -\napiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: deny-all\n  namespace: default\nspec:\n  podSelector: {}\n  policyTypes:\n  - Ingress\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Cilium release from the 'cilium-system' namespace using Helm. This command will remove all resources associated with the release.\n```bash\nhelm uninstall cilium --namespace cilium-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were created during the installation of Cilium. This command will delete the CRDs associated with Cilium.\n```bash\nkubectl delete crd ciliumnetworkpolicies.cilium.io\nkubectl delete crd ciliumnetworkendpoints.cilium.io\nkubectl delete crd ciliumendpoints.cilium.io\nkubectl delete crd ciliumnodes.cilium.io\nkubectl delete crd ciliumclusterwidenetworkpolicies.cilium.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'cilium-system' namespace to clean up any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace cilium-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of the Cilium installation. You can do this by exporting the current configuration and resources.\n```bash\nkubectl get all -n cilium-system -o yaml > cilium-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Cilium release to the latest version. Replace 'v1.19.1' with the desired version if needed.\n```bash\nhelm repo update\nhelm upgrade cilium cilium/cilium --version v1.19.1 --namespace cilium-system\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, check that the Cilium pods are running the new version and are healthy.\n```bash\nkubectl get pods -n cilium-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Cilium pods not starting",
+        "description": "If the Cilium pods are not starting, check the pod logs for errors. This can indicate issues with configuration or resource limits.\n```bash\nkubectl logs -n cilium-system <pod-name>\n```"
+      },
+      {
+        "title": "Network policies not being enforced",
+        "description": "If network policies are not being enforced, verify that the Cilium agent is running and check the network policy configuration.\n```bash\nkubectl get networkpolicy -n default\nkubectl get pods -n cilium-system\n```"
+      },
+      {
+        "title": "Cilium not connecting to Kubernetes API",
+        "description": "If Cilium cannot connect to the Kubernetes API, check the Cilium pod logs for connection errors and ensure that the service account has the necessary permissions.\n```bash\nkubectl logs -n cilium-system <pod-name>\nkubectl describe clusterrole cilium\n```"
+      },
+      {
+        "title": "High CPU usage by Cilium pods",
+        "description": "If you notice high CPU usage by Cilium pods, review the resource limits set in the deployment and adjust them if necessary. You can also check the metrics for more details.\n```bash\nkubectl top pods -n cilium-system\nkubectl edit deployment cilium --namespace cilium-system\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-clusternet.json
+++ b/solutions/cncf-install/install-clusternet.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment clusternet --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi -n clusternet",
         "kubectl port-forward svc/clusternet 8080:80 -n clusternet"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Clusternet release to remove the deployment from your cluster. This will also delete all associated resources managed by Helm.\n```bash\nhelm uninstall clusternet --namespace clusternet\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation. This ensures that no leftover resources remain in your cluster.\n```bash\nkubectl delete crd clusternetclusters.clusternet.io\nkubectl delete crd clusternetendpoints.clusternet.io\nkubectl delete pvc --all -n clusternet\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'clusternet' namespace to completely clean up all resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace clusternet\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your Clusternet installation. You can do this by exporting the current configuration.\n```bash\nkubectl get all -n clusternet -o yaml > clusternet-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to update your Clusternet installation to the latest version.\n```bash\nhelm repo update\nhelm upgrade clusternet clusternet/clusternet --namespace clusternet --version v0.19.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Clusternet pods are running the new version and are healthy.\n```bash\nkubectl get pods -n clusternet\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your Clusternet pods are in a CrashLoopBackOff state, check the logs to diagnose the issue. This often indicates a misconfiguration or resource limits issue.\n```bash\nkubectl logs <pod-name> -n clusternet\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Clusternet API, ensure that the service is running and the port-forwarding is set up correctly. Check the service status and logs.\n```bash\nkubectl get svc -n clusternet\nkubectl port-forward svc/clusternet 8080:80 -n clusternet\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you receive errors related to insufficient resources, check the resource limits and requests set for the deployment. You may need to adjust them based on your cluster capacity.\n```bash\nkubectl describe deployment clusternet -n clusternet\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to missing CRDs, ensure that they were installed correctly. You can check the existing CRDs in your cluster.\n```bash\nkubectl get crd -n clusternet\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-clusterpedia.json
+++ b/solutions/cncf-install/install-clusterpedia.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment clusterpedia -n clusterpedia-system",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Clusterpedia release from the Kubernetes cluster using Helm to remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall clusterpedia --namespace clusterpedia-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete the Custom Resource Definitions (CRDs) created by Clusterpedia and any persistent volume claims (PVCs) if they are no longer needed.\n```bash\nkubectl delete crd clusterpediaresources.clusterpedia.io\nkubectl delete crd clusterpedias.clusterpedia.io\nkubectl delete pvc --all -n clusterpedia-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'clusterpedia-system' namespace and verify that it has been removed along with all its resources.\n```bash\nkubectl delete namespace clusterpedia-system\nkubectl get namespaces | grep clusterpedia-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Clusterpedia installation by exporting the existing resources.\n```bash\nkubectl get all -n clusterpedia-system -o yaml > clusterpedia-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Clusterpedia release to the latest version. Ensure to specify the desired version.\n```bash\nhelm repo update\nhelm upgrade clusterpedia clusterpedia/clusterpedia --version v0.10.0 --namespace clusterpedia-system\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Clusterpedia pods are running the new version successfully after the upgrade.\n```bash\nkubectl get pods -n clusterpedia-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Clusterpedia pods are stuck in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> -n clusterpedia-system\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Clusterpedia API server service is not reachable, ensure that the service is running and check the port forwarding command.\n```bash\nkubectl get svc -n clusterpedia-system\nkubectl port-forward svc/clusterpedia-apiserver -n clusterpedia-system 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If the pods are not starting due to insufficient resources, verify the resource limits and requests set in the deployment.\n```bash\nkubectl describe deployment clusterpedia -n clusterpedia-system\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter errors related to missing CRDs, ensure that the CRDs were not deleted accidentally. You can recreate them if necessary.\n```bash\nkubectl get crd\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-composefs.json
+++ b/solutions/cncf-install/install-composefs.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/composefs --namespace composefs --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward svc/composefs --namespace composefs 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Composefs Helm release from the 'composefs' namespace to remove the deployment and associated resources:\n```bash\nhelm uninstall composefs --namespace composefs\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that may have been created during the installation:\n```bash\nkubectl delete pvc --all --namespace composefs\nkubectl delete crd composefs.*\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'composefs' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace composefs\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and any important data related to Composefs:\n```bash\nkubectl get all --namespace composefs -o yaml > composefs-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Composefs release to the latest version:\n```bash\nhelm repo update\nhelm upgrade composefs composefs/composefs --namespace composefs --version v1.0.9\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Composefs pods are running the new version successfully:\n```bash\nkubectl get pods --namespace composefs\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Composefs pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace composefs\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Composefs service, ensure that the service is running and check the port forwarding command:\n```bash\nkubectl get svc --namespace composefs\nkubectl port-forward svc/composefs --namespace composefs 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to insufficient resources, check the resource limits and requests:\n```bash\nkubectl describe deployment composefs --namespace composefs\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace composefs\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-connect-rpc.json
+++ b/solutions/cncf-install/install-connect-rpc.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment <release-name> --namespace <namespace>",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Connect RPC installation, use the following command to uninstall the release. Replace `<release-name>` and `<namespace>` with your actual release name and namespace:\n```bash\nhelm uninstall <release-name> --namespace <namespace>\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the release, you may need to remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Use the following commands:\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace <namespace>\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, if you no longer need the namespace, you can delete it. Ensure that all resources are cleaned up before doing so:\n```bash\nkubectl delete namespace <namespace>\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up your current configuration and data. You can export the current release configuration with:\n```bash\nhelm get values <release-name> --namespace <namespace> > backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade the Connect RPC release to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade <release-name> connectrpc/connect --namespace <namespace> --version v1.20.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Connect RPC pods are running with the new version. Use the following command:\n```bash\nkubectl get pods --namespace <namespace>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your pods are in a CrashLoopBackOff state, check the logs to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace <namespace>\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, ensure that the service is running and check the endpoints:\n```bash\nkubectl get svc --namespace <namespace>\nkubectl describe svc <service-name> --namespace <namespace>\n```"
+      },
+      {
+        "title": "Deployment not scaling",
+        "description": "If your deployment is not scaling as expected, check the deployment status and events:\n```bash\nkubectl get deployment <release-name> --namespace <namespace>\nkubectl describe deployment <release-name> --namespace <namespace>\n```"
+      },
+      {
+        "title": "Health checks failing",
+        "description": "If the liveness or readiness probes are failing, check the pod logs and probe configuration:\n```bash\nkubectl logs <pod-name> --namespace <namespace>\nkubectl get pods --namespace <namespace> -o jsonpath='{.items[*].status.containerStatuses[*].lastState}'\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-container-network-interface-cni.json
+++ b/solutions/cncf-install/install-container-network-interface-cni.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment cni --namespace <your-namespace>\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     memory: \"512Mi\"\n#     cpu: \"500m\"",
         "kubectl create role cni-role --verb=get,list,watch --resource=pods --namespace <your-namespace>\nkubectl create rolebinding cni-rolebinding --role=cni-role --serviceaccount=<your-namespace>:default --namespace <your-namespace>"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the CNI Helm release from your Kubernetes cluster. Replace `<your-namespace>` with your namespace."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources associated with CNI."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for CNI and verify that it has been removed. Replace `<your-namespace>` with your namespace."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your CNI installation. Replace `<your-namespace>` with your namespace."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the CNI release to the latest version. Replace `<your-namespace>` with your namespace."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the CNI pods are running the new version in your cluster. Replace `<your-namespace>` with your namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when CNI pods repeatedly crash. Check the logs for errors using the following command: \n```bash\nkubectl logs <pod-name> --namespace <your-namespace>\n``` \nFix any configuration issues identified in the logs."
+      },
+      {
+        "title": "CNI not functioning as expected",
+        "description": "If network connectivity issues arise, verify the CNI configuration. Use the following command to check the status of the CNI pods: \n```bash\nkubectl get pods --namespace <your-namespace>\n``` \nEnsure all pods are running and check for any errors."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission denied errors, verify the Role and RoleBinding for CNI. Check the roles with: \n```bash\nkubectl get role --namespace <your-namespace>\nkubectl get rolebinding --namespace <your-namespace>\n``` \nMake sure the correct permissions are granted."
+      },
+      {
+        "title": "Failed to connect to the Kubernetes API",
+        "description": "If CNI fails to connect to the Kubernetes API, check the network policies and firewall settings. Use the following command to check the CNI pod logs for connection errors: \n```bash\nkubectl logs <pod-name> --namespace <your-namespace>\n``` \nEnsure that the CNI has the necessary network access."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-container2wasm.json
+++ b/solutions/cncf-install/install-container2wasm.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment container2wasm --namespace container2wasm\n# In the editor, add the following under spec.containers:\n# resources:\n#   limits:\n#     memory: \"512Mi\"\n#     cpu: \"500m\"",
         "kubectl exec -it <pod-name> --namespace container2wasm -- c2w ubuntu:22.04 out.wasm"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the container2wasm deployment, use the following command to uninstall the Helm release from the 'container2wasm' namespace:\n```bash\nhelm uninstall container2wasm --namespace container2wasm\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) created by the container2wasm installation, you should clean them up. Use the following commands:\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace container2wasm\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the 'container2wasm' namespace to clean up all resources associated with it. Verify that the namespace has been deleted:\n```bash\nkubectl delete namespace container2wasm\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your deployment. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace container2wasm -o yaml > backup-container2wasm.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade the container2wasm release to the latest version:\n```bash\nhelm repo update\nhelm upgrade container2wasm container2wasm/container2wasm --namespace container2wasm --version 0.8.4\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the pods are running the new version and are healthy:\n```bash\nkubectl get pods --namespace container2wasm\nkubectl describe deployment container2wasm --namespace container2wasm\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your pods are in a CrashLoopBackOff state, check the logs to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace container2wasm\n```\nCommon fixes include checking for configuration errors or missing dependencies."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during an upgrade, check the currently installed version and the available versions:\n```bash\nhelm list --namespace container2wasm\nhelm search repo container2wasm --versions\n```\nEnsure you are specifying a valid version in the upgrade command."
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If your pods are being evicted due to resource limits, check the events for the namespace:\n```bash\nkubectl get events --namespace container2wasm\n```\nYou may need to adjust the resource limits in the deployment."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, verify the service configuration and endpoints:\n```bash\nkubectl get svc --namespace container2wasm\nkubectl describe svc <service-name> --namespace container2wasm\nkubectl get endpoints --namespace container2wasm\n```\nCheck for any misconfigurations or issues with the pods backing the service."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-containerd.json
+++ b/solutions/cncf-install/install-containerd.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment containerd -n containerd --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'",
         "kubectl port-forward service/containerd -n containerd 8000:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the containerd Helm release from your Kubernetes cluster using the following command:\n```bash\nhelm uninstall containerd --namespace containerd\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with containerd:\n```bash\nkubectl delete pvc --all --namespace containerd\nkubectl delete crd $(kubectl get crd | grep containerd | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the containerd namespace and verify that it has been removed:\n```bash\nkubectl delete namespace containerd\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the containerd installation:\n```bash\nhelm get values containerd --namespace containerd > containerd-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the containerd release to the latest version:\n```bash\nhelm repo update\nhelm upgrade containerd containerd/containerd --version v2.3.0 --namespace containerd\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the containerd pods are running the new version successfully:\n```bash\nkubectl get pods --namespace containerd\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the containerd pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace containerd\n```\nLook for any error messages that indicate what might be wrong with the configuration or resources."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the containerd service, ensure that the port forwarding is set up correctly:\n```bash\nkubectl port-forward service/containerd -n containerd 8000:80\n```\nAlso, verify that the service is running:\n```bash\nkubectl get svc --namespace containerd\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource limits and requests set for the containerd deployment:\n```bash\nkubectl describe deployment containerd -n containerd\n```\nAdjust the resource limits if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check the error message for details. You can roll back to the previous version using:\n```bash\nhelm rollback containerd <revision-number> --namespace containerd\n```\nList the revisions with:\n```bash\nhelm history containerd --namespace containerd\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-continuous-optimization.json
+++ b/solutions/cncf-install/install-continuous-optimization.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment krkn --namespace <namespace>",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kraken release from your Kubernetes cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall krkn --namespace <namespace>\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation. This ensures a clean removal of Kraken from your cluster.\n```bash\nkubectl delete crd krkns.krkn.io\nkubectl delete pvc --all --namespace <namespace>\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "If you created a new namespace for Kraken, you can delete it along with all its resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace <namespace>\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current configuration and state of Kraken. You can export the current Helm release configuration.\n```bash\nhelm get values krkn --namespace <namespace> > krkn-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade Kraken to the desired version. Replace `<new-version>` with the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade krkn krkn/krkn --namespace <namespace> --version <new-version>\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, check that the Kraken pods are running with the new version. This ensures that the upgrade was successful.\n```bash\nkubectl get pods --namespace <namespace>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kraken pods are in a CrashLoopBackOff state, check the logs for any errors that might indicate the cause of the failure.\n```bash\nkubectl logs <pod-name> --namespace <namespace>\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you receive errors related to insufficient resources, ensure that your cluster has enough CPU and memory available. You can check the resource usage with:\n```bash\nkubectl top pods --namespace <namespace>\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If Kraken is unable to perform actions due to RBAC permissions, verify that the Role and RoleBinding are correctly set up. You can check the current roles with:\n```bash\nkubectl get role --namespace <namespace>\nkubectl get rolebinding --namespace <namespace>\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure that you are using the correct namespace and release name. List all releases in the namespace with:\n```bash\nhelm list --namespace <namespace>\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-contour.json
+++ b/solutions/cncf-install/install-contour.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment contour -n projectcontour",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Contour release from the 'projectcontour' namespace using the following command:\n```bash\nhelm uninstall contour --namespace projectcontour\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were created during the installation. Use the following command:\n```bash\nkubectl delete crd httpproxies.projectcontour.io\nkubectl delete crd services.projectcontour.io\nkubectl delete crd routes.projectcontour.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'projectcontour' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace projectcontour\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to backup the current state of your Contour installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all -n projectcontour -o yaml > contour-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Contour to the latest version:\n```bash\nhelm repo update\nhelm upgrade contour contour/contour --namespace projectcontour --version v1.34.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Contour pods are running the new version successfully:\n```bash\nkubectl get pods -n projectcontour\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Contour pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> -n projectcontour\n```\nLook for any error messages that indicate configuration issues or missing dependencies."
+      },
+      {
+        "title": "Ingress resources not being routed",
+        "description": "If your ingress resources are not being routed correctly, ensure that the Contour service is running and check the configuration:\n```bash\nkubectl get svc -n projectcontour\nkubectl describe ingress <ingress-name> -n <namespace>\n```"
+      },
+      {
+        "title": "RBAC issues preventing access",
+        "description": "If you encounter permission denied errors, verify that the RBAC roles and bindings are correctly applied:\n```bash\nkubectl get roles -n projectcontour\nkubectl get rolebindings -n projectcontour\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, check the service endpoints and ensure that the pods are ready:\n```bash\nkubectl get endpoints -n projectcontour\nkubectl get pods -n projectcontour -o wide\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-copa.json
+++ b/solutions/cncf-install/install-copa.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment copa --namespace copa",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Copa installation, first uninstall the Helm release with the following command:\n```bash\nhelm uninstall copa --namespace copa\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, you should remove any Custom Resource Definitions (CRDs) and persistent resources that were created. Run the following commands:\n```bash\nkubectl delete crd copas.copa.io\nkubectl delete pvc --all --namespace copa\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the namespace used for Copa and verify its removal:\n```bash\nkubectl delete namespace copa\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your installation. You can do this by exporting the current configuration:\n```bash\nhelm get values copa --namespace copa > copa-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Next, update the Helm repository and run the upgrade command to update Copa to the latest version:\n```bash\nhelm repo update\nhelm upgrade copa copa/copa --namespace copa --version v0.14.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Copa pod is running the new version successfully:\n```bash\nkubectl get pods --namespace copa\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Copa pod is stuck in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace copa\n```\nLook for any error messages that indicate what might be going wrong."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, ensure that the version you are trying to upgrade to is compatible. Check the installed version:\n```bash\nhelm list --namespace copa\n```\nThen, specify a compatible version in your upgrade command."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the Copa pod is being terminated due to OOMKilled, consider increasing the memory limit in the deployment:\n```bash\nkubectl edit deployment copa --namespace copa\n```\nUpdate the `resources.limits.memory` value to a higher amount."
+      },
+      {
+        "title": "Unable to connect to the Copa service",
+        "description": "If you cannot connect to the Copa service, check the service status and endpoints:\n```bash\nkubectl get svc --namespace copa\nkubectl describe svc copa --namespace copa\n```\nEnsure that the service is correctly configured and that the endpoints are available."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-coredns.json
+++ b/solutions/cncf-install/install-coredns.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment coredns --namespace coredns",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\"\n  requests:\n    memory: \"256Mi\"\n    cpu: \"250m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the CoreDNS Helm release from the 'coredns' namespace with the following command:\n```bash\nhelm uninstall coredns --namespace coredns\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with CoreDNS. Use the following commands:\n```bash\nkubectl delete pvc --all --namespace coredns\nkubectl delete crd $(kubectl get crd | grep coredns | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'coredns' namespace and verify its removal with the following commands:\n```bash\nkubectl delete namespace coredns\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current CoreDNS configuration and any relevant data. Use the following command to export the current deployment:\n```bash\nkubectl get deployment coredns --namespace coredns -o yaml > coredns-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade CoreDNS to the latest version with the following commands:\n```bash\nhelm repo update\nhelm upgrade coredns coredns/coredns --namespace coredns --version v1.14.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the CoreDNS pods are running the new version successfully:\n```bash\nkubectl get pods --namespace coredns\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If CoreDNS pods are in a 'CrashLoopBackOff' state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace coredns\n```\nLook for configuration issues or resource constraints."
+      },
+      {
+        "title": "CoreDNS service not responding",
+        "description": "If the CoreDNS service is not responding, verify the service configuration:\n```bash\nkubectl get svc --namespace coredns\n```\nEnsure that the service type is correct and that the pods are running."
+      },
+      {
+        "title": "DNS queries failing",
+        "description": "If DNS queries are failing, check the CoreDNS logs for errors:\n```bash\nkubectl logs -l k8s-app=kube-dns --namespace coredns\n```\nInvestigate any errors related to DNS resolution."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to out-of-memory (OOM) issues, check the resource usage:\n```bash\nkubectl top pods --namespace coredns\n```\nConsider increasing the memory limits in the deployment configuration."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cortex.json
+++ b/solutions/cncf-install/install-cortex.json
@@ -40,7 +40,53 @@
         "helm upgrade cortex cortex/cortex --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --namespace cortex",
         "- job_name: 'cortex'\n  static_configs:\n    - targets: ['cortex:9090']"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Cortex release from the Kubernetes cluster using Helm. This command will remove all resources associated with the release in the specified namespace:\n```bash\nhelm uninstall cortex --namespace cortex\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were created during the installation. This command will delete the CRDs associated with Cortex:\n```bash\nkubectl delete crd cortex.*\n```\nAdditionally, clean up any persistent volume claims (PVCs) if they were created:\n```bash\nkubectl delete pvc --all --namespace cortex\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'cortex' namespace to clean up any remaining resources. Verify that the namespace has been removed:\n```bash\nkubectl delete namespace cortex\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of the Cortex deployment. You can do this by exporting the current configuration:\n```bash\nhelm get values cortex --namespace cortex > cortex-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the Cortex release to the desired version:\n```bash\nhelm repo update\nhelm upgrade cortex cortex/cortex --version v1.21.0 --namespace cortex\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the Cortex pods to ensure they are running the new version:\n```bash\nkubectl get pods --namespace cortex\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Cortex pods are in a CrashLoopBackOff state, check the logs for the failing pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace cortex\n```\nCommon causes include misconfiguration or insufficient resources."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Cortex service, verify that the service is correctly configured and running:\n```bash\nkubectl get svc --namespace cortex\n```\nEnsure that the service endpoints are correctly pointing to the pods."
+      },
+      {
+        "title": "High memory usage",
+        "description": "If you notice high memory usage in the Cortex pods, check the resource limits and adjust them if necessary. You can view the resource usage with:\n```bash\nkubectl top pods --namespace cortex\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any error messages and ensure that the chart version is compatible with your current installation. You can view the current release status with:\n```bash\nhelm status cortex --namespace cortex\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-cubefs.json
+++ b/solutions/cncf-install/install-cubefs.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment cubefs --namespace cubefs",
         "resources:\n  limits:\n    memory: \"2Gi\"\n    cpu: \"1\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the CubeFS deployment, use the following command to uninstall the Helm release. This will remove all associated resources created by the release.\n```bash\nhelm uninstall cubefs --namespace cubefs\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the Helm release, you may need to manually delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Use the following commands:\n```bash\nkubectl delete crd cubefsclusters.cubefs.io\nkubectl delete pvc --all --namespace cubefs\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the 'cubefs' namespace to clean up any remaining resources. Verify that the namespace has been deleted by checking the list of namespaces.\n```bash\nkubectl delete namespace cubefs\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your CubeFS deployment. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace cubefs -o yaml > cubefs-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the CubeFS Helm repository and then run the upgrade command to update to the latest version. Replace '3.6.0' with the desired version:\n```bash\nhelm repo update\nhelm upgrade cubefs cubefs/cubefs --version 3.6.0 --namespace cubefs\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the CubeFS pods are running the new version successfully. Use the following command:\n```bash\nkubectl get pods --namespace cubefs\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your CubeFS pods are stuck in a CrashLoopBackOff state, check the logs of the pods to diagnose the issue. Use the following command:\n```bash\nkubectl logs <pod-name> --namespace cubefs\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you are unable to access the CubeFS service, ensure that the port forwarding is set up correctly. Verify the service status with:\n```bash\nkubectl get svc --namespace cubefs\n```\nIf the service is not running, check the deployment status."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource requests and limits set for the CubeFS deployment. Use the following command to view the current configuration:\n```bash\nkubectl get deployment cubefs --namespace cubefs -o yaml\n```\nAdjust the resource limits as necessary."
+      },
+      {
+        "title": "Persistent volume claim pending",
+        "description": "If your PVCs are stuck in a pending state, check if there are available persistent volumes that match the PVC requirements. Use the following command to check the PVC status:\n```bash\nkubectl get pvc --namespace cubefs\n```\nIf no suitable PVs are available, you may need to create them or adjust the PVC specifications."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-dalec.json
+++ b/solutions/cncf-install/install-dalec.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment dalec --namespace dalec",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Dalec release from the 'dalec' namespace using the following command:\n```bash\nhelm uninstall dalec --namespace dalec\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims associated with Dalec:\n```bash\nkubectl delete crd $(kubectl get crd | grep dalec | awk '{print $1}')\nkubectl delete pvc --all --namespace dalec\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'dalec' namespace and verify it has been removed:\n```bash\nkubectl delete namespace dalec\nkubectl get namespaces | grep dalec\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of Dalec:\n```bash\nhelm get values dalec --namespace dalec > dalec-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Dalec to the latest version:\n```bash\nhelm repo update\nhelm upgrade dalec dalec/dalec --namespace dalec --version v0.21.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Dalec pods are running the new version successfully:\n```bash\nkubectl get pods --namespace dalec\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Dalec pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace dalec\n``` \nLook for any error messages that indicate what might be wrong."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Dalec service, ensure the port forwarding is set up correctly:\n```bash\nkubectl port-forward svc/dalec --namespace dalec 8080:80\n``` \nAlso, check the service status:\n```bash\nkubectl get svc --namespace dalec\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to resource issues, check the resource requests and limits:\n```bash\nkubectl describe deployment dalec --namespace dalec\n``` \nAdjust the resource limits if necessary."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace dalec\n``` \nEnsure you are using the correct release name 'dalec'."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-dapr.json
+++ b/solutions/cncf-install/install-dapr.json
@@ -40,7 +40,53 @@
         "global:\n  prometheus:\n    enabled: true\n    port: 9090",
         "helm upgrade dapr dapr/dapr --namespace dapr-system -f dapr-values.yaml"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Dapr release from the Kubernetes cluster with the following command:\n```bash\nhelm uninstall dapr --namespace dapr-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Dapr:\n```bash\nkubectl delete crd --all\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'dapr-system' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace dapr-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Dapr configuration and resources:\n```bash\nkubectl get all -n dapr-system -o yaml > dapr-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Dapr Helm repository and upgrade to the latest version:\n```bash\nhelm repo update\nhelm upgrade dapr dapr/dapr --namespace dapr-system --version 1.18.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Dapr pods are running the new version successfully:\n```bash\nkubectl get pods -n dapr-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Dapr pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> -n dapr-system\n```\nInvestigate the error messages and adjust your configuration as necessary."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Dapr service, verify that the service is running:\n```bash\nkubectl get svc -n dapr-system\n```\nCheck for any misconfigurations in your values file or network policies."
+      },
+      {
+        "title": "Metrics not showing in Prometheus",
+        "description": "If Prometheus is not displaying Dapr metrics, ensure that Prometheus is correctly configured and running:\n```bash\nkubectl get pods -n dapr-system | grep prometheus\n```\nCheck the Prometheus logs for any errors:\n```bash\nkubectl logs <prometheus-pod-name> -n dapr-system\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for version compatibility and existing resources:\n```bash\nhelm history dapr --namespace dapr-system\n```\nIf necessary, rollback to the previous version:\n```bash\nhelm rollback dapr <revision-number> --namespace dapr-system\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-devfile.json
+++ b/solutions/cncf-install/install-devfile.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/devfile --namespace devfile --limits=cpu=500m,memory=512Mi",
         "kubectl create role devfile-role --verb=get,list,watch --resource=devworkspaces --namespace devfile\nkubectl create rolebinding devfile-rolebinding --role=devfile-role --serviceaccount=default:default --namespace devfile"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Devfile release from the Kubernetes cluster using Helm. This will remove the deployment and associated resources created by the Helm chart.\n```bash\nhelm uninstall devfile --namespace devfile\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove the Custom Resource Definitions (CRDs) and any persistent resources that were created during the installation. This ensures that all related resources are cleaned up.\n```bash\nkubectl delete crd devworkspaces.devfile.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for the Devfile installation and verify that it has been removed. This step ensures that all resources are cleaned up from the cluster.\n```bash\nkubectl delete namespace devfile\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of the Devfile resources. You can use the following command to export the current configuration.\n```bash\nkubectl get all --namespace devfile -o yaml > devfile-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of the Devfile chart. Make sure to specify the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade devfile devfile/devfile --namespace devfile --version v2.4.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the Devfile pods are running the new version correctly in the devfile namespace.\n```bash\nkubectl get pods --namespace devfile\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Devfile pods are stuck in a CrashLoopBackOff state, check the logs for the failing pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace devfile\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, check the currently installed version and ensure that the version you are trying to upgrade to is compatible.\n```bash\nhelm list --namespace devfile\n```"
+      },
+      {
+        "title": "RBAC issues preventing access",
+        "description": "If you experience access issues with Devfile resources, verify that the Role and RoleBinding were created correctly and that the service account has the necessary permissions.\n```bash\nkubectl get rolebinding --namespace devfile\nkubectl describe rolebinding devfile-rolebinding --namespace devfile\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to OOMKilled errors, consider adjusting the resource limits set for the Devfile deployment. Check the current resource usage with:\n```bash\nkubectl top pods --namespace devfile\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-devspace.json
+++ b/solutions/cncf-install/install-devspace.json
@@ -40,7 +40,53 @@
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"",
         "dev:\n  watch:\n    enabled: true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the DevSpace release from the Kubernetes cluster using the following command:\n```bash\nhelm uninstall devspace --namespace devspace\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with DevSpace:\n```bash\nkubectl delete crd devspaces.devspace.sh\nkubectl delete pvc --all --namespace devspace\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'devspace' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace devspace\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your DevSpace release:\n```bash\nhelm get values devspace --namespace devspace > devspace-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the DevSpace release to the latest version:\n```bash\nhelm repo update\nhelm upgrade devspace devspace/devspace --version v6.3.21 --namespace devspace\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the DevSpace pods are running the new version after the upgrade:\n```bash\nkubectl get pods --namespace devspace\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your DevSpace pods are in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> --namespace devspace\n``` \nLook for any error messages that might indicate the cause of the crash."
+      },
+      {
+        "title": "Helm upgrade fails with 'release not found'",
+        "description": "If you encounter an error stating 'release not found' during an upgrade, ensure that the release name and namespace are correct:\n```bash\nhelm list --namespace devspace\n``` \nIf the release does not exist, you may need to install it instead."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If your pods are being killed due to Out Of Memory (OOM), consider increasing the memory limits in your `devspace.yaml` file:\n```yaml\nresources:\n  limits:\n    memory: \"1Gi\"\n``` \nAfter updating, redeploy your application."
+      },
+      {
+        "title": "Network issues preventing pod communication",
+        "description": "If your pods are unable to communicate with each other, check the network policies and service configurations:\n```bash\nkubectl get networkpolicies --namespace devspace\nkubectl get services --namespace devspace\n``` \nEnsure that the necessary ports are open and services are correctly defined."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-distribution.json
+++ b/solutions/cncf-install/install-distribution.json
@@ -40,7 +40,53 @@
         "helm upgrade distribution distribution/distribution --namespace distribution --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "kubectl port-forward service/distribution 5000:5000 --namespace distribution"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Distribution Helm release from the cluster to remove the deployment and associated resources:\n```bash\nhelm uninstall distribution --namespace distribution\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd distributions.distribution.io\nkubectl delete pvc --all --namespace distribution\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'distribution' namespace to clean up all remaining resources and verify that it has been removed:\n```bash\nkubectl delete namespace distribution\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Distribution deployment:\n```bash\nhelm get values distribution --namespace distribution > distribution-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Distribution chart to the latest version:\n```bash\nhelm repo update\nhelm upgrade distribution distribution/distribution --version v3.1.0 --namespace distribution\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Distribution pods are running the new version correctly:\n```bash\nkubectl get pods --namespace distribution\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Distribution pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace distribution\n``` \nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Distribution service, ensure that the service is running and check the port-forwarding command:\n```bash\nkubectl get svc --namespace distribution\n``` \nIf the service is not running, check the pod status and logs."
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If the pods are not starting due to resource constraints, verify the resource limits set during installation:\n```bash\nkubectl describe deployment distribution --namespace distribution\n``` \nAdjust the resource limits if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any errors in the output and ensure that the chart version is compatible:\n```bash\nhelm history distribution --namespace distribution\n``` \nYou can roll back to the previous version if needed:\n```bash\nhelm rollback distribution <revision-number> --namespace distribution\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-dragonfly.json
+++ b/solutions/cncf-install/install-dragonfly.json
@@ -40,7 +40,53 @@
         "kubectl get pods --namespace dragonfly",
         "kubectl edit deployment dragonfly --namespace dragonfly"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Dragonfly Helm release from the cluster using the following command:\n```bash\nhelm uninstall dragonfly --namespace dragonfly\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volumes associated with Dragonfly. Run the following commands:\n```bash\nkubectl delete crd $(kubectl get crd | grep dragonfly | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'dragonfly' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace dragonfly\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of Dragonfly. You can export the current configuration using:\n```bash\nkubectl get all --namespace dragonfly -o yaml > dragonfly-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Dragonfly to the latest version:\n```bash\nhelm repo update\nhelm upgrade dragonfly dragonfly/dragonfly --version v2.4.2 --namespace dragonfly\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Dragonfly pods are running the new version successfully:\n```bash\nkubectl get pods --namespace dragonfly\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Dragonfly pods are in a CrashLoopBackOff state, check the logs to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace dragonfly\n``` \nLook for any error messages that might indicate the cause of the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Dragonfly service is not reachable, ensure that the service is running and check the endpoints:\n```bash\nkubectl get svc --namespace dragonfly\nkubectl describe svc dragonfly --namespace dragonfly\n``` \nLook for any misconfigurations or issues with the endpoints."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource usage and limits:\n```bash\nkubectl top pods --namespace dragonfly\n``` \nYou may need to adjust the resource limits in the deployment."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, verify that the release exists in the specified namespace:\n```bash\nhelm list --namespace dragonfly\n``` \nIf the release is missing, ensure that you are using the correct namespace and release name."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-drasi.json
+++ b/solutions/cncf-install/install-drasi.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment drasi --namespace drasi",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Drasi release from the cluster using the following command to remove the deployment and all associated resources:\n```bash\nhelm uninstall drasi --namespace drasi\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd $(kubectl get crd | grep drasi | awk '{print $1}')\nkubectl delete pvc --all --namespace drasi\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'drasi' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace drasi\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, create a backup of the current state of the Drasi release:\n```bash\nhelm get all drasi --namespace drasi > drasi-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Drasi release to the latest version:\n```bash\nhelm repo update\nhelm upgrade drasi drasi/drasi --namespace drasi --version 1.1.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Drasi pods to ensure they are running the upgraded version:\n```bash\nkubectl get pods --namespace drasi\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Drasi pods are stuck in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> --namespace drasi\n``` \nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Drasi service, ensure that the service is running and the port forwarding is set up correctly:\n```bash\nkubectl get svc --namespace drasi\nkubectl port-forward svc/drasi --namespace drasi 8080:80\n``` \nCheck for any firewall rules or network policies that might be blocking access."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you see errors related to insufficient resources, check the resource limits and the available resources in your cluster:\n```bash\nkubectl describe pod <pod-name> --namespace drasi\nkubectl top nodes\n``` \nConsider adjusting the resource limits or scaling your cluster."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for version compatibility and existing resources:\n```bash\nhelm history drasi --namespace drasi\nhelm get all drasi --namespace drasi\n``` \nYou may need to rollback to a previous version if the upgrade cannot be completed."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-easegress.json
+++ b/solutions/cncf-install/install-easegress.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/easegress --namespace easegress 8080:80",
         "kubectl edit deployment easegress --namespace easegress"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Easegress deployment, execute the following command to uninstall the Helm release:\n```bash\nhelm uninstall easegress --namespace easegress\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Easegress:\n```bash\nkubectl delete crd easegresses.megaease.com\nkubectl delete pvc --all --namespace easegress\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Easegress namespace and verify that it has been removed:\n```bash\nkubectl delete namespace easegress\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Easegress deployment:\n```bash\nkubectl get all --namespace easegress -o yaml > easegress-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Easegress release to the latest version:\n```bash\nhelm repo update\nhelm upgrade easegress megaease/easegress --namespace easegress --version v2.11.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Easegress pods are running the new version successfully:\n```bash\nkubectl get pods --namespace easegress\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Easegress pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace easegress\n```\nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Easegress service, ensure that the service is running and check the port-forwarding command:\n```bash\nkubectl get svc --namespace easegress\nkubectl port-forward svc/easegress --namespace easegress 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are failing due to insufficient resources, check the resource requests and limits:\n```bash\nkubectl describe deployment easegress --namespace easegress\n```\nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any existing Helm release issues:\n```bash\nhelm list --namespace easegress\n```\nIf necessary, rollback to the previous version:\n```bash\nhelm rollback easegress <revision-number> --namespace easegress\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-emissary-ingress.json
+++ b/solutions/cncf-install/install-emissary-ingress.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment emissary-ingress --namespace emissary",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Emissary-ingress release, execute the following command to uninstall it from the 'emissary' namespace:\n```bash\nhelm uninstall emissary-ingress --namespace emissary\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Emissary-ingress by running:\n```bash\nkubectl delete crd -l app=emissary-ingress\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'emissary' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace emissary\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of the Emissary-ingress release. You can do this by exporting the current configuration:\n```bash\nhelm get values emissary-ingress --namespace emissary > emissary-ingress-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Emissary-ingress release to the latest version:\n```bash\nhelm repo update\nhelm upgrade emissary-ingress emissary-ingress/emissary --namespace emissary --version 3.11.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Emissary-ingress pods are running the new version:\n```bash\nkubectl get pods --namespace emissary\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that the Emissary-ingress pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace emissary\n```\nCommon issues may include misconfigurations in the deployment or insufficient resources."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Emissary-ingress service is not reachable, ensure that the service is running and check the port forwarding:\n```bash\nkubectl get services --namespace emissary\nkubectl port-forward service/emissary-ingress --namespace emissary 8080:80\n```"
+      },
+      {
+        "title": "Ingress rules not working",
+        "description": "If your ingress rules are not functioning as expected, verify the configuration of your ingress resources:\n```bash\nkubectl get ingress --namespace emissary\nkubectl describe ingress <ingress-name> --namespace emissary\n```"
+      },
+      {
+        "title": "High memory usage",
+        "description": "If you observe high memory usage from the Emissary-ingress pods, consider adjusting the resource limits. Check the current resource usage with:\n```bash\nkubectl top pods --namespace emissary\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-envoy.json
+++ b/solutions/cncf-install/install-envoy.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment envoy --namespace envoy-system",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Envoy release from the Kubernetes cluster using Helm with the following command:\n```bash\nhelm uninstall envoy --namespace envoy-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. Use the following commands:\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace envoy-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'envoy-system' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace envoy-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Envoy installation by exporting the configuration:\n```bash\nkubectl get all --namespace envoy-system -o yaml > envoy-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Envoy installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade envoy envoy/envoy --namespace envoy-system --version v1.38.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Envoy pods are running the new version successfully:\n```bash\nkubectl get pods --namespace envoy-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Envoy pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace envoy-system\n``` \nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Envoy service is not reachable, verify that the port forwarding is set up correctly:\n```bash\nkubectl get svc --namespace envoy-system\n``` \nEnsure that the correct service name and port are being used for port forwarding."
+      },
+      {
+        "title": "High resource usage",
+        "description": "If Envoy is consuming too many resources, check the resource limits and requests set in the deployment:\n```bash\nkubectl describe deployment envoy --namespace envoy-system\n``` \nAdjust the resource limits if necessary."
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If changes made to the Envoy configuration are not reflected, ensure that the deployment has been updated:\n```bash\nkubectl rollout status deployment/envoy --namespace envoy-system\n``` \nIf necessary, redeploy the configuration."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-falco.json
+++ b/solutions/cncf-install/install-falco.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment falco -n falco-system",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\"\n  requests:\n    memory: \"256Mi\"\n    cpu: \"250m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Falco release from the 'falco-system' namespace using the following command:\n```bash\nhelm uninstall falco --namespace falco-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Falco. Use the following commands:\n```bash\nkubectl delete crd falcosecurity.org\nkubectl delete pvc --all -n falco-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'falco-system' namespace and verify its removal with the following commands:\n```bash\nkubectl delete namespace falco-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of Falco. You can do this by exporting the current deployment:\n```bash\nkubectl get deployment falco -n falco-system -o yaml > falco-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Falco to the latest version using the following commands:\n```bash\nhelm repo update\nhelm upgrade falco falco/falco --namespace falco-system --version 0.44.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Falco pod is running the new version successfully:\n```bash\nkubectl get pods -n falco-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Falco pod is not starting",
+        "description": "If the Falco pod is in a 'CrashLoopBackOff' state, check the logs for errors:\n```bash\nkubectl logs -n falco-system deployment/falco\n``` \nLook for any configuration issues or missing permissions."
+      },
+      {
+        "title": "Falco alerts not triggering",
+        "description": "If Falco is not generating alerts, ensure that the rules are correctly configured. Check the rules file:\n```bash\nkubectl exec -n falco-system -it $(kubectl get pods -n falco-system -l app=falco -o jsonpath='{.items[0].metadata.name}') -- cat /etc/falco/falco_rules.yaml\n``` \nMake sure the rules are enabled and correctly defined."
+      },
+      {
+        "title": "Port forwarding not working",
+        "description": "If you cannot access Falco's output via port forwarding, ensure that the service is running:\n```bash\nkubectl get svc -n falco-system\n``` \nIf the service is not available, check the deployment status and logs."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the Falco pod is being killed due to out-of-memory (OOM) issues, consider increasing the memory limits in the deployment:\n```bash\nkubectl edit deployment falco -n falco-system\n``` \nAdjust the 'resources.limits.memory' value accordingly."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-falcosidekick.json
+++ b/solutions/cncf-install/install-falcosidekick.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment falcosidekick --namespace falcosidekick",
         "resources:\n  limits:\n    memory: \"256Mi\"\n    cpu: \"500m\"\n  requests:\n    memory: \"128Mi\"\n    cpu: \"250m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Falcosidekick Helm release from your Kubernetes cluster with the following command. This will remove the deployment and associated resources:\n```bash\nhelm uninstall falcosidekick --namespace falcosidekick\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation. Use the following commands:\n```bash\nkubectl delete crd falcosidekick.falcosecurity.io\nkubectl delete pvc --all --namespace falcosidekick\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'falcosidekick' namespace to clean up any remaining resources. Verify that the namespace has been removed:\n```bash\nkubectl delete namespace falcosidekick\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current configuration and state of Falcosidekick. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace falcosidekick -o yaml > falcosidekick-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Falcosidekick release to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade falcosidekick falcosidekick/falcosidekick --namespace falcosidekick --version 2.33.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Falcosidekick pod is running the new version after the upgrade. Use the following command to verify:\n```bash\nkubectl get pods --namespace falcosidekick\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Falcosidekick pod is in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace falcosidekick\n```\nCommon issues include misconfigured environment variables or resource limits."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Falcosidekick service, ensure that the port forwarding is set up correctly. Check the service configuration:\n```bash\nkubectl get svc --namespace falcosidekick\n```\nIf the service is not running, restart it with:\n```bash\nkubectl delete svc falcosidekick --namespace falcosidekick\nhelm install falcosidekick falcosidekick/falcosidekick --namespace falcosidekick\n```"
+      },
+      {
+        "title": "High memory usage",
+        "description": "If you notice high memory usage, check the resource limits set for the Falcosidekick deployment. You can edit the deployment with:\n```bash\nkubectl edit deployment falcosidekick --namespace falcosidekick\n```\nAdjust the resource limits as necessary."
+      },
+      {
+        "title": "Failed to connect to Falco",
+        "description": "If Falcosidekick fails to connect to Falco, verify that the Falco service is running and reachable. Check the Falco pod status:\n```bash\nkubectl get pods --namespace falco\n```\nIf it's not running, troubleshoot the Falco installation."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-flagger.json
+++ b/solutions/cncf-install/install-flagger.json
@@ -40,7 +40,53 @@
         "helm upgrade flagger flagger/flagger --namespace flagger-system --set serviceMonitor.enabled=true",
         "helm upgrade flagger flagger/flagger --namespace flagger-system --set resources.limits.cpu=500m --set resources.limits.memory=512Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Flagger release from the `flagger-system` namespace using the following command. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall flagger --namespace flagger-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were installed with Flagger. This command will delete the CRDs from the cluster.\n```bash\nkubectl delete crd canaries.flagger.app\nkubectl delete crd automations.flagger.app\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `flagger-system` namespace to clean up all remaining resources. Verify that the namespace has been removed.\n```bash\nkubectl delete namespace flagger-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current configuration and state of the Flagger release. You can export the current values with the following command:\n```bash\nhelm get values flagger --namespace flagger-system > flagger-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to fetch the latest charts and upgrade the Flagger release to the latest version. Replace `1.43.0` with the desired version if necessary.\n```bash\nhelm repo update\nhelm upgrade flagger flagger/flagger --namespace flagger-system --version 1.43.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Flagger pods are running successfully after the upgrade in the `flagger-system` namespace to ensure the upgrade was successful.\n```bash\nkubectl get pods -n flagger-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Flagger pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue. Replace `<pod-name>` with the actual pod name.\n```bash\nkubectl logs <pod-name> -n flagger-system\n```"
+      },
+      {
+        "title": "ServiceMonitor not scraping metrics",
+        "description": "If the ServiceMonitor is not scraping metrics, verify that it is correctly configured and that Prometheus is set up to discover it. Check the ServiceMonitor status:\n```bash\nkubectl get servicemonitor -n flagger-system\n```"
+      },
+      {
+        "title": "Upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the upgrade, check the currently installed version and ensure that the new version is compatible. You can check the installed version with:\n```bash\nhelm list --namespace flagger-system\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the Flagger pods are being OOMKilled, you may need to adjust the resource limits. Check the events for the pods to confirm this:\n```bash\nkubectl describe pod <pod-name> -n flagger-system\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-fluent-bit.json
+++ b/solutions/cncf-install/install-fluent-bit.json
@@ -40,7 +40,53 @@
         "helm upgrade fluent-bit fluent/fluent-bit --namespace fluent-bit --set resources.limits.cpu=100m --set resources.limits.memory=128Mi",
         "helm upgrade fluent-bit fluent/fluent-bit --namespace fluent-bit --set service.type=NodePort"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Fluent Bit deployment, use the following command to uninstall the Helm release from the 'fluent-bit' namespace.\n```bash\nhelm uninstall fluent-bit --namespace fluent-bit\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) created by Fluent Bit, remove them using the following commands:\n```bash\nkubectl delete crd fluentbit.fluentbit.io\nkubectl delete pvc --all --namespace fluent-bit\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'fluent-bit' namespace to clean up any remaining resources. Verify that the namespace has been removed:\n```bash\nkubectl delete namespace fluent-bit\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current configuration and state of Fluent Bit. You can do this by exporting the current values:\n```bash\nhelm get values fluent-bit --namespace fluent-bit > fluent-bit-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade Fluent Bit to the desired version (e.g., v4.3.0):\n```bash\nhelm repo update\nhelm upgrade fluent-bit fluent/fluent-bit --namespace fluent-bit --version v4.3.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the Fluent Bit pods to ensure they are running the new version:\n```bash\nkubectl get pods --namespace fluent-bit\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Fluent Bit pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace fluent-bit\n```\nCommon issues may include misconfigurations in the input or output settings."
+      },
+      {
+        "title": "High CPU or memory usage",
+        "description": "If you notice high resource usage, check the resource limits set for Fluent Bit. You can view the current resource usage with:\n```bash\nkubectl top pods --namespace fluent-bit\n```\nConsider adjusting the resource limits in your Helm upgrade command."
+      },
+      {
+        "title": "No logs being collected",
+        "description": "If Fluent Bit is not collecting logs, verify the input configuration. Check the configuration with:\n```bash\nkubectl describe configmap fluent-bit-config --namespace fluent-bit\n```\nEnsure the input source is correctly defined and accessible."
+      },
+      {
+        "title": "Metrics not exposed",
+        "description": "If you cannot access the metrics, ensure that the service type is set to NodePort. Check the service configuration with:\n```bash\nkubectl get svc --namespace fluent-bit\n```\nIf necessary, reapply the service configuration with the correct settings."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-fluentd.json
+++ b/solutions/cncf-install/install-fluentd.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment fluentd -n fluentd --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'",
         "kubectl port-forward svc/fluentd -n fluentd 24224:24224"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Fluentd release from the cluster using Helm. This will remove the deployment and associated resources, but not the CRDs or persistent volumes.\n```bash\nhelm uninstall fluentd --namespace fluentd\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Fluentd to ensure complete cleanup.\n```bash\nkubectl delete pvc --all --namespace fluentd\nkubectl delete crd fluentd.*\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'fluentd' namespace to remove all remaining resources and verify that it has been deleted.\n```bash\nkubectl delete namespace fluentd\nkubectl get namespaces | grep fluentd\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Fluentd configuration and any relevant data. You can use the following command to export the current configuration.\n```bash\nkubectl get configmap -n fluentd -o yaml > fluentd-backup-configmap.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Fluentd to the desired version. Replace '1.19.3' with the new version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade fluentd fluent/fluentd --version 1.19.3 --namespace fluentd\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Fluentd pods are running the new version successfully in the 'fluentd' namespace.\n```bash\nkubectl get pods --namespace fluentd\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Fluentd pods are in a CrashLoopBackOff state, check the logs for errors. This can indicate misconfiguration or resource issues.\n```bash\nkubectl logs <pod-name> --namespace fluentd\n```"
+      },
+      {
+        "title": "Fluentd service not reachable",
+        "description": "If you cannot access the Fluentd service, ensure that the service is running and check the port-forwarding command. Verify the service status with:\n```bash\nkubectl get svc --namespace fluentd\n```"
+      },
+      {
+        "title": "High memory usage",
+        "description": "If Fluentd is consuming too much memory, consider adjusting the resource limits. Check the current resource usage with:\n```bash\nkubectl top pods --namespace fluentd\n```"
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If changes to the Fluentd configuration are not reflected, ensure that the correct ConfigMap is being used and restart the pods to apply changes:\n```bash\nkubectl rollout restart deployment/fluentd --namespace fluentd\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-fluid.json
+++ b/solutions/cncf-install/install-fluid.json
@@ -40,7 +40,53 @@
         "helm upgrade fluid fluid/fluid --namespace fluid-system --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "helm upgrade fluid fluid/fluid --namespace fluid-system --set properties.alluxio.user.metrics.collection.enabled=true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Fluid installation, use the following command to uninstall the Helm release from the specified namespace:\n```bash\nhelm uninstall fluid --namespace fluid-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the Helm release, you should clean up any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Use the following commands:\n```bash\nkubectl delete crd datasets.fluid.io\nkubectl delete crd datamaps.fluid.io\nkubectl delete pvc --all --namespace fluid-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the namespace used for Fluid and verify that it has been deleted:\n```bash\nkubectl delete namespace fluid-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Fluid installation. You can export the current configuration with:\n```bash\nhelm get values fluid --namespace fluid-system > fluid-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then run the upgrade command to update Fluid to the desired version:\n```bash\nhelm repo update\nhelm upgrade fluid fluid/fluid --namespace fluid-system --version v1.0.9\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the Fluid pods are running the new version successfully:\n```bash\nkubectl get pods --namespace fluid-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Fluid pods are in a CrashLoopBackOff state, you can diagnose the issue by checking the logs:\n```bash\nkubectl logs <pod-name> --namespace fluid-system\n``` \nLook for any error messages that may indicate what is causing the crash."
+      },
+      {
+        "title": "Failed to pull image",
+        "description": "If the pods are failing due to image pull errors, verify that the image name is correct and that your cluster has access to the image repository. Check the events for the pod:\n```bash\nkubectl describe pod <pod-name> --namespace fluid-system\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to insufficient resources, check the resource requests and limits set for the pods. You can view the pod specifications with:\n```bash\nkubectl get pod <pod-name> -o yaml --namespace fluid-system\n``` \nAdjust the resource limits as necessary."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Fluid services, ensure that the services are running and check their endpoints:\n```bash\nkubectl get svc --namespace fluid-system\nkubectl describe svc <service-name> --namespace fluid-system\n``` \nMake sure that the service type is set correctly (e.g., ClusterIP, NodePort) for your use case."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-grpc.json
+++ b/solutions/cncf-install/install-grpc.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment grpc --namespace grpc -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"grpc\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"512Mi\"}}}]}}}}'",
         "kubectl port-forward svc/grpc --namespace grpc 50051:50051"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the gRPC release from your Kubernetes cluster using Helm to remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall grpc --namespace grpc\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation.\n```bash\nkubectl delete crd grpc.*\nkubectl delete pvc --all --namespace grpc\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the gRPC namespace and verify that all resources have been cleaned up.\n```bash\nkubectl delete namespace grpc\nkubectl get all --namespace grpc\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the gRPC deployment to ensure you can restore it if needed.\n```bash\nhelm get values grpc --namespace grpc > grpc-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the gRPC release to the latest version. Replace '1.79.0' with the desired version.\n```bash\nhelm repo update\nhelm upgrade grpc grpc/grpc --version 1.79.0 --namespace grpc\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the gRPC pods are running the new version successfully after the upgrade.\n```bash\nkubectl get pods --namespace grpc\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the gRPC pods are stuck in a CrashLoopBackOff state, check the logs for errors that might indicate what is wrong.\n```bash\nkubectl logs <pod-name> --namespace grpc\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the gRPC service, ensure that the port forwarding is set up correctly and that the service is running.\n```bash\nkubectl get svc --namespace grpc\nkubectl port-forward svc/grpc --namespace grpc 50051:50051\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the deployment fails due to insufficient resources, check the resource limits and the available resources in your cluster.\n```bash\nkubectl describe deployment grpc --namespace grpc\nkubectl get nodes -o=jsonpath='{.items[*].status.allocatable}'\n```"
+      },
+      {
+        "title": "Failed to connect to the gRPC server",
+        "description": "If clients are unable to connect to the gRPC server, verify the network policies and firewall rules that may be blocking traffic.\n```bash\nkubectl get networkpolicy --namespace grpc\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-hami.json
+++ b/solutions/cncf-install/install-hami.json
@@ -40,7 +40,53 @@
         "helm upgrade hami hami/hami --namespace hami --set resources.limits.cpu=1000m,resources.limits.memory=512Mi",
         "kubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: hami\n  name: hami-role\nrules:\n- apiGroups: [\"\"] # core API group\n  resources: [\"pods\", \"pods/log\"]\n  verbs: [\"get\", \"list\", \"watch\"]\nEOF\n\nkubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: hami-role-binding\n  namespace: hami\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: hami-role\nsubjects:\n- kind: ServiceAccount\n  name: default\n  namespace: hami\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the HAMi release from the Kubernetes cluster using the following command:\n```bash\nhelm uninstall hami --namespace hami\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with HAMi:\n```bash\nkubectl delete crd hami.*\nkubectl delete pvc --all --namespace hami\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'hami' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace hami\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources:\n```bash\nhelm get values hami --namespace hami > hami-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the HAMi release to the latest version:\n```bash\nhelm repo update\nhelm upgrade hami hami/hami --namespace hami --version 2.9.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the HAMi pods are running the new version successfully:\n```bash\nkubectl get pods --namespace hami\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the HAMi pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace hami\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you receive errors about insufficient resources, verify the resource limits set in the values.yaml file:\n```bash\nkubectl describe pod <pod-name> --namespace hami\n```"
+      },
+      {
+        "title": "RBAC permissions issue",
+        "description": "If you encounter permission denied errors, ensure that the Role and RoleBinding are correctly set up:\n```bash\nkubectl get role -n hami\nkubectl get rolebinding -n hami\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, verify that the release name and namespace are correct:\n```bash\nhelm list --namespace hami\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-harbor.json
+++ b/solutions/cncf-install/install-harbor.json
@@ -40,7 +40,53 @@
         "# harbor-values.yaml\nresources:\n  requests:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  limits:\n    cpu: \"1\"\n    memory: \"1Gi\"",
         "helm upgrade harbor harbor/harbor --version v2.14.2 --namespace harbor -f harbor-values.yaml"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Harbor release using Helm to remove all associated resources from the cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. Run the following commands:\n```bash\nkubectl delete pvc --all --namespace harbor\nkubectl delete crd $(kubectl get crd | grep harbor | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Harbor namespace and verify that all resources have been removed:\n```bash\nkubectl delete namespace harbor\nkubectl get all --namespace harbor\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current configuration and data. You can export the current Helm release configuration with:\n```bash\nhelm get values harbor --namespace harbor > harbor-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Harbor release to the latest version:\n```bash\nhelm repo update\nhelm upgrade harbor harbor/harbor --version v2.14.3 --namespace harbor -f harbor-backup-values.yaml\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if all the Harbor pods are running successfully after the upgrade:\n```bash\nkubectl get pods --namespace harbor\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue may occur due to misconfigurations or resource limits. To diagnose, check the logs of the affected pod:\n```bash\nkubectl logs <pod-name> --namespace harbor\n```Fix any configuration issues and redeploy the pod."
+      },
+      {
+        "title": "Unable to access Harbor UI",
+        "description": "If you cannot access the Harbor UI, ensure that the port-forward command is running. Check the service status with:\n```bash\nkubectl get svc --namespace harbor\n```If the service is not running, restart the Harbor deployment."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during an upgrade, ensure that the version you are trying to upgrade to is compatible with the current version. You can check the current version with:\n```bash\nhelm list --namespace harbor\n```Rollback to the previous version if necessary:\n```bash\nhelm rollback harbor <revision-number> --namespace harbor\n```"
+      },
+      {
+        "title": "Persistent volume claims not released",
+        "description": "If PVCs are not being released after uninstalling, check the reclaim policy of the storage class. To view the PVCs, run:\n```bash\nkubectl get pvc --namespace harbor\n```If needed, manually delete the PVCs with:\n```bash\nkubectl delete pvc <pvc-name> --namespace harbor\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-helm.json
+++ b/solutions/cncf-install/install-helm.json
@@ -44,7 +44,53 @@
         "helm repo update",
         "helm install my-nginx stable/nginx --namespace default --create-namespace"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Helm release to remove the deployed application from your cluster. Use the following command to delete the Nginx release:\n```bash\nhelm uninstall my-nginx --namespace default\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) associated with the release, clean them up. Use the following commands to delete the CRDs and PVCs:\n```bash\nkubectl delete pvc --all --namespace default\nkubectl delete crd nginxes.example.com\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "If the namespace was created specifically for this release and is no longer needed, delete the namespace. Verify that it has been removed:\n```bash\nkubectl delete namespace default\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it is important to back up the current state of the release. You can do this by exporting the current configuration:\n```bash\nhelm get values my-nginx --namespace default > my-nginx-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then run the upgrade command to upgrade the release to the latest version:\n```bash\nhelm repo update\nhelm upgrade my-nginx stable/nginx --namespace default\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the release has been upgraded successfully and the pods are running:\n```bash\nkubectl get pods --namespace default\nhelm list --namespace default\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your Nginx pods are in a CrashLoopBackOff state, check the logs to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace default\n``` \nCommon causes include misconfigurations or missing environment variables."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure you are using the correct namespace:\n```bash\nhelm list --namespace default\n``` \nIf the release does not appear, it may have been uninstalled or created in a different namespace."
+      },
+      {
+        "title": "Insufficient permissions",
+        "description": "If you receive permission errors when trying to install or upgrade, ensure that your Kubernetes context has the necessary permissions. Check your current context:\n```bash\nkubectl config current-context\n``` \nYou may need to switch contexts or update your RBAC settings."
+      },
+      {
+        "title": "Chart version compatibility issues",
+        "description": "If you encounter issues related to chart versions, verify that the version of the chart you are trying to install is compatible with your Kubernetes version:\n```bash\nhelm search repo stable/nginx --versions\n``` \nConsider specifying a compatible version in your install or upgrade command."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-holmesgpt.json
+++ b/solutions/cncf-install/install-holmesgpt.json
@@ -40,7 +40,53 @@
         "helm upgrade holmes holmes/holmes --namespace holmes --set resources.requests.cpu=100m --set resources.requests.memory=2048Mi --set resources.limits.memory=2048Mi",
         "helm upgrade holmes holmes/holmes --namespace holmes --set toolsets.prometheus/metrics.enabled=true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the HolmesGPT release from your Kubernetes cluster using the following command:\n```bash\nhelm uninstall holmes --namespace holmes\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd $(kubectl get crd | grep holmes | awk '{print $1}')\nkubectl delete pvc --all --namespace holmes\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for the installation and verify that it has been removed:\n```bash\nkubectl delete namespace holmes\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources:\n```bash\nhelm get values holmes --namespace holmes > holmes-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the HolmesGPT installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade holmes holmes/holmes --version 0.21.0 --namespace holmes\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the HolmesGPT pods are running the new version successfully:\n```bash\nkubectl get pods --namespace holmes\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see pods in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace holmes\n``` \nLook for any specific error messages that indicate what might be wrong."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, verify the service status and endpoints:\n```bash\nkubectl get svc --namespace holmes\nkubectl describe svc <service-name> --namespace holmes\n``` \nEnsure that the service is correctly configured and that the pods are healthy."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If pods are not starting due to resource constraints, check the resource requests and limits:\n```bash\nkubectl describe pod <pod-name> --namespace holmes\n``` \nAdjust the resource limits in your Helm configuration if necessary."
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If changes to the configuration are not reflected, ensure you are using the correct upgrade command:\n```bash\nhelm upgrade holmes holmes/holmes --namespace holmes --set <your-configuration>\n``` \nDouble-check the values you are setting to ensure they are correct."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-hwameistor.json
+++ b/solutions/cncf-install/install-hwameistor.json
@@ -40,7 +40,53 @@
         "helm upgrade hwameistor hwameistor/hwameistor --namespace hwameistor --set scheduler.resources.limits.cpu=500m --set scheduler.resources.limits.memory=512Mi",
         "kubectl apply -f servicemonitor-example.yaml --namespace hwameistor"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Hwameistor Helm release to remove the deployment from the cluster. Use the following command to delete the release:\n```bash\nhelm uninstall hwameistor --namespace hwameistor\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Hwameistor. Execute the following commands:\n```bash\nkubectl delete crd hwameistorinstances.hwameistor.io\nkubectl delete crd hwameistorvolumes.hwameistor.io\nkubectl delete pvc --all --namespace hwameistor\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'hwameistor' namespace to clean up all resources. Verify that the namespace has been removed by checking the list of namespaces:\n```bash\nkubectl delete namespace hwameistor\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Hwameistor installation. You can use the following command to export the current Helm release configuration:\n```bash\nhelm get values hwameistor --namespace hwameistor > hwameistor-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Hwameistor release to the latest version. Use the following commands:\n```bash\nhelm repo update\nhelm upgrade hwameistor hwameistor/hwameistor --namespace hwameistor --version 0.16.6\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Hwameistor pods are running with the new version. Check the status of the pods using:\n```bash\nkubectl get pods --namespace hwameistor\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Hwameistor pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace hwameistor\n```"
+      },
+      {
+        "title": "Persistent volume claims not binding",
+        "description": "If PVCs are not binding, ensure that the storage class is correctly configured and available. Check the PVC status with:\n```bash\nkubectl get pvc --namespace hwameistor\n```"
+      },
+      {
+        "title": "ServiceMonitor not working",
+        "description": "If the ServiceMonitor is not functioning, verify that the ServiceMonitor resource is correctly applied and check the logs of the monitoring tool:\n```bash\nkubectl get servicemonitor --namespace hwameistor\nkubectl logs <monitoring-tool-pod-name> --namespace <monitoring-namespace>\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that the version specified is available in the Helm repository. You can list available versions with:\n```bash\nhelm search repo hwameistor/hwameistor --versions\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-hyperlight.json
+++ b/solutions/cncf-install/install-hyperlight.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment hyperlight --namespace hyperlight --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward service/hyperlight --namespace hyperlight 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Hyperlight release from the Kubernetes cluster using Helm. This will remove the deployment and associated resources created by the installation.\n```bash\nhelm uninstall hyperlight --namespace hyperlight\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Hyperlight to ensure a clean removal.\n```bash\nkubectl delete crd $(kubectl get crd | grep hyperlight | awk '{print $1}')\nkubectl delete pvc --all --namespace hyperlight\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'hyperlight' namespace to remove all remaining resources and verify that it has been removed successfully.\n```bash\nkubectl delete namespace hyperlight\nkubectl get namespaces | grep hyperlight\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, create a backup of the current Hyperlight configuration and resources.\n```bash\nkubectl get all --namespace hyperlight -o yaml > hyperlight-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Hyperlight release to the latest version. Ensure you specify the correct version.\n```bash\nhelm repo update\nhelm upgrade hyperlight hyperlight/hyperlight --namespace hyperlight --version v0.12.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Hyperlight pods are running the new version successfully after the upgrade.\n```bash\nkubectl get pods --namespace hyperlight\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Hyperlight pods are in a CrashLoopBackOff state, check the logs to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace hyperlight\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Hyperlight service, ensure that the port forwarding is set up correctly and check the service status.\n```bash\nkubectl get svc --namespace hyperlight\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If pods are failing due to insufficient resources, check the resource requests and limits set for the deployment and adjust them accordingly.\n```bash\nkubectl describe deployment hyperlight --namespace hyperlight\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify that you are using the correct namespace and release name.\n```bash\nhelm list --namespace hyperlight\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-inclavare-containers.json
+++ b/solutions/cncf-install/install-inclavare-containers.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment inclavare-containers --namespace inclavare -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"inclavare-containers\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"512Mi\"}}}]}}}}'",
         "kubectl create role inclavare-role --verb=get,list,watch --resource=pods --namespace inclavare\nkubectl create rolebinding inclavare-rolebinding --role=inclavare-role --serviceaccount=default:default --namespace inclavare"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Inclavare Containers release from your Kubernetes cluster using Helm to cleanly remove the deployment and its associated resources."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for Inclavare Containers and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Inclavare Containers deployment to ensure you can restore it if needed."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to fetch the latest charts and run the upgrade command to update your installation to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Inclavare Containers pods are running the new version successfully in the specified namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start properly and keeps restarting. Check the logs of the pod to diagnose the issue using the following command:\n```bash\nkubectl logs <pod-name> --namespace inclavare\n```"
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you encounter an insufficient resources error, it may be due to the resource limits set for the deployment. You can check the resource usage with:\n```bash\nkubectl top pods --namespace inclavare\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If Inclavare Containers cannot access necessary resources, verify that the RBAC roles and bindings are correctly set up. Check the role bindings with:\n```bash\nkubectl get rolebinding --namespace inclavare\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error indicating that the Helm release cannot be found, ensure that you are using the correct namespace and release name. List all releases in the namespace with:\n```bash\nhelm list --namespace inclavare\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-inspektor-gadget.json
+++ b/solutions/cncf-install/install-inspektor-gadget.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment inspektor-gadget --namespace inspektor-gadget",
         "kubectl port-forward svc/inspektor-gadget --namespace inspektor-gadget 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Inspektor Gadget release from the cluster using Helm. This will remove the deployment and associated resources created by the installation.\n```bash\nhelm uninstall inspektor-gadget --namespace inspektor-gadget\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources related to Inspektor Gadget are cleaned up.\n```bash\nkubectl delete crd gadgets.inspektor-gadget.io\nkubectl delete pvc --all --namespace inspektor-gadget\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `inspektor-gadget` namespace to remove any remaining resources. Verify that the namespace has been deleted successfully.\n```bash\nkubectl delete namespace inspektor-gadget\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Inspektor Gadget installation. You can do this by exporting the current configuration.\n```bash\nkubectl get all --namespace inspektor-gadget -o yaml > inspektor-gadget-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Inspektor Gadget release to the latest version. Make sure to specify the desired version if needed.\n```bash\nhelm repo update\nhelm upgrade inspektor-gadget inspektor-gadget/gadget --namespace inspektor-gadget --version v0.49.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Inspektor Gadget pods are running the new version successfully after the upgrade.\n```bash\nkubectl get pods --namespace inspektor-gadget\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Inspektor Gadget pods are in a CrashLoopBackOff state, check the logs for the pods to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace inspektor-gadget\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Inspektor Gadget dashboard, ensure that the service is running and check the port forwarding command. Verify the service status.\n```bash\nkubectl get svc --namespace inspektor-gadget\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to insufficient resources, check the resource requests and limits defined in the deployment. You may need to adjust them or allocate more resources to your cluster.\n```bash\nkubectl describe deployment inspektor-gadget --namespace inspektor-gadget\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to CRDs, ensure that the CRDs were installed correctly. You can list the CRDs to verify their presence.\n```bash\nkubectl get crd | grep gadgets\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-interlink.json
+++ b/solutions/cncf-install/install-interlink.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment interlink --namespace interlink",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the InterLink Helm release from the 'interlink' namespace using the following command:\n```bash\nhelm uninstall interlink --namespace interlink\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with InterLink. Use the following commands:\n```bash\nkubectl delete crd interlinks.interlink.io\nkubectl delete pvc --all --namespace interlink\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'interlink' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace interlink\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your InterLink installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace interlink -o yaml > interlink-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the InterLink installation to the latest version (e.g., 0.7.0):\n```bash\nhelm repo update\nhelm upgrade interlink interlink/interlink --namespace interlink --version 0.7.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the InterLink pods are running successfully after the upgrade:\n```bash\nkubectl get pods --namespace interlink\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your InterLink pods are stuck in a CrashLoopBackOff state, check the logs for the pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace interlink\n```"
+      },
+      {
+        "title": "TLS handshake errors",
+        "description": "If you encounter TLS handshake errors, verify that the TLS secret is correctly created and the certificate and key are valid:\n```bash\nkubectl get secret interlink-tls --namespace interlink -o yaml\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you see errors related to insufficient resources, check the resource limits set in the deployment and the available resources in your cluster:\n```bash\nkubectl describe deployment interlink --namespace interlink\nkubectl describe nodes\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error indicating that the Helm release is not found, ensure that you are using the correct namespace and release name:\n```bash\nhelm list --namespace interlink\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-istio.json
+++ b/solutions/cncf-install/install-istio.json
@@ -40,7 +40,53 @@
         "kubectl get pods -n istio-system",
         "helm upgrade istiod istio/istiod -n istio-system --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --version 1.29.0"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release for Istiod",
+        "description": "Uninstall the Istiod control plane from the istio-system namespace using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove the Istio Custom Resource Definitions (CRDs) and any persistent resources associated with the installation."
+      },
+      {
+        "title": "Remove the istio-system namespace and verify",
+        "description": "Delete the istio-system namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state of Istio",
+        "description": "Before upgrading, back up the current configuration and custom resources of Istio."
+      },
+      {
+        "title": "Update the Helm repository and run the upgrade command",
+        "description": "Update the Istio Helm repository and upgrade the Istiod release to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Istio pods are running the new version in the istio-system namespace to confirm a successful upgrade."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start repeatedly. Check the pod logs for errors using the command: `kubectl logs <pod-name> -n istio-system`."
+      },
+      {
+        "title": "Istio components not starting",
+        "description": "If Istio components are not starting, check for resource constraints or misconfigurations. Use `kubectl describe pod <pod-name> -n istio-system` to diagnose the issue."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If services are not reachable, ensure that the Istio ingress gateway is configured correctly. Verify with `kubectl get svc -n istio-system`."
+      },
+      {
+        "title": "Configuration changes not taking effect",
+        "description": "If configuration changes are not being applied, check if the Istio configuration resources are correctly defined and applied. Use `kubectl get virtualservices -n istio-system` to review the current configuration."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-jaeger.json
+++ b/solutions/cncf-install/install-jaeger.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/jaeger-query --namespace jaeger 16686:16686",
         "kubectl patch deployment jaeger-collector --namespace jaeger -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"jaeger-collector\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"512Mi\"}}}]}}}}'"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Jaeger release from the Kubernetes cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall jaeger --namespace jaeger\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that no leftover resources remain in the cluster.\n```bash\nkubectl delete crd jaegers.jaegertracing.io\nkubectl delete pvc --all --namespace jaeger\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Jaeger namespace to clean up all remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace jaeger\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your Jaeger installation. You can export the current configuration and any important data.\n```bash\nkubectl get all --namespace jaeger -o yaml > jaeger-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of Jaeger. Replace '2.15.1' with the desired version.\n```bash\nhelm repo update\nhelm upgrade jaeger jaegertracing/jaeger --namespace jaeger --version 2.15.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Jaeger pods are running the new version and are healthy.\n```bash\nkubectl get pods --namespace jaeger\nkubectl describe deployment jaeger-collector --namespace jaeger\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that the Jaeger pods are in a CrashLoopBackOff state, check the logs for errors that may indicate the cause. You can view the logs using the following command:\n```bash\nkubectl logs <pod-name> --namespace jaeger\n```"
+      },
+      {
+        "title": "Jaeger UI not accessible",
+        "description": "If you cannot access the Jaeger UI, ensure that the port forwarding is correctly set up. Check if the service is running:\n```bash\nkubectl get svc --namespace jaeger\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If Jaeger is not performing well, it may be due to insufficient resources. Check the resource limits and requests set for the Jaeger deployment:\n```bash\nkubectl describe deployment jaeger-collector --namespace jaeger\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to CRDs, ensure that they are properly installed. You can check the existing CRDs with:\n```bash\nkubectl get crd\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-k8gb.json
+++ b/solutions/cncf-install/install-k8gb.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment k8gb -n k8gb\n# Add the following under spec.template.spec.containers.resources:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"\n#   requests:\n#     cpu: \"250m\"\n#     memory: \"256Mi\"",
         "kubectl apply -f - <<EOF\napiVersion: k8gb.absa.oss/v1beta1\nkind: Gslb\nmetadata:\n  name: hello-world-gslb\n  namespace: default\n  annotations:\n    k8gb.io/hostname: \"hello.lb.mycompany.com\"\nspec:\n  resourceRef:\n    apiVersion: v1\n    kind: Service\n    matchLabels:\n      app: hello-world\n  strategy:\n    type: failover\n    primaryGeoTag: \"eu\"\n    dnsTtlSeconds: 30\n  splitBrainThresholdSeconds: 300\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the K8GB release from the 'k8gb' namespace to remove all associated resources managed by Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'k8gb' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your K8GB installation by exporting the existing GSLB resources."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the K8GB release to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the K8GB pods to ensure they are running the new version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue indicates that the K8GB pods are failing to start. Check the logs for more information using the following command:\n```bash\nkubectl logs <pod-name> -n k8gb\n```"
+      },
+      {
+        "title": "GSLB resource not resolving",
+        "description": "If the GSLB resource is not resolving, ensure that the annotations are correctly set and the service it references is running:\n```bash\nkubectl get gslb -n default\nkubectl get svc -n default\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the upgrade, check the current version of K8GB installed:\n```bash\nhelm list -n k8gb\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If K8GB is not performing as expected, verify that the resource limits are appropriately set. Check the deployment configuration:\n```bash\nkubectl get deployment k8gb -n k8gb -o yaml\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-k8sgpt.json
+++ b/solutions/cncf-install/install-k8sgpt.json
@@ -40,7 +40,53 @@
         "kubectl create secret generic k8sgpt-secret --from-literal=secretKey=<your-openai-token> --namespace k8sgpt",
         "kubectl port-forward service/k8sgpt --namespace k8sgpt 8080:8080"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the K8sGPT release from the cluster using Helm. This will remove the deployment and associated resources, but not the CRDs or persistent volumes yet.\n```bash\nhelm uninstall k8sgpt --namespace k8sgpt\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation. This ensures that all resources related to K8sGPT are removed from the cluster.\n```bash\nkubectl delete crd k8sgpt.ai\nkubectl delete pvc --all --namespace k8sgpt\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the K8sGPT namespace to clean up any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace k8sgpt\nkubectl get namespaces | grep k8sgpt\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it is a good practice to back up the current state of your K8sGPT installation. You can do this by exporting the current configuration.\n```bash\nhelm get values k8sgpt --namespace k8sgpt > k8sgpt-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to get the latest charts and then upgrade your K8sGPT installation to the desired version. Replace `<new-version>` with the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade k8sgpt k8sgpt/k8sgpt --namespace k8sgpt --set deployment.image.tag=<new-version>\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the K8sGPT pod to ensure it is running the new version without issues.\n```bash\nkubectl get pods -n k8sgpt\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the K8sGPT pods are in a CrashLoopBackOff state, check the logs to diagnose the issue. This can happen due to misconfiguration or missing secrets.\n```bash\nkubectl logs <pod-name> -n k8sgpt\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the K8sGPT service, ensure that the port-forwarding command is running and check if the service is up.\n```bash\nkubectl get svc -n k8sgpt\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource limits and requests set for the K8sGPT deployment. You may need to adjust these values based on your cluster's capacity.\n```bash\nkubectl describe deployment k8sgpt -n k8sgpt\n```"
+      },
+      {
+        "title": "OpenAI secret not found",
+        "description": "If K8sGPT cannot access the OpenAI API, verify that the secret containing your OpenAI token exists and is correctly configured.\n```bash\nkubectl get secret k8sgpt-secret -n k8sgpt\nkubectl describe secret k8sgpt-secret -n k8sgpt\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-k8up.json
+++ b/solutions/cncf-install/install-k8up.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/k8up --namespace k8up-system 8080:8080",
         "kubectl edit deployment k8up --namespace k8up-system\n# Add the following under spec.template.spec.containers:\n# resources:\n#   requests:\n#     memory: \"512Mi\"\n#     cpu: \"250m\"\n#   limits:\n#     memory: \"1Gi\"\n#     cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the K8up release, use the following command to uninstall it from the specified namespace:\n```bash\nhelm uninstall k8up --namespace k8up-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the Helm release, you should remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Use the following commands:\n```bash\nkubectl delete crd backups.k8up.io\nkubectl delete crd schedules.k8up.io\nkubectl delete pvc --all --namespace k8up-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the K8up namespace and verify that it has been deleted:\n```bash\nkubectl delete namespace k8up-system\nkubectl get namespaces | grep k8up-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up your current K8up configuration and resources. You can do this by exporting the current Helm release:\n```bash\nhelm get values k8up --namespace k8up-system > k8up-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Next, update the Helm repository and upgrade the K8up release to the latest version:\n```bash\nhelm repo update\nhelm upgrade k8up k8up/k8up --namespace k8up-system --version k8up-4.9.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the K8up pods are running the new version:\n```bash\nkubectl get pods --namespace k8up-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that the K8up pods are stuck in a CrashLoopBackOff state, check the logs for the pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace k8up-system\n``` \nLook for any error messages that might indicate configuration issues or resource constraints."
+      },
+      {
+        "title": "Backup jobs not running",
+        "description": "If your backup jobs are not running as scheduled, check the status of the backup custom resources:\n```bash\nkubectl get backups --namespace k8up-system\n``` \nEnsure that the schedules are correctly configured and that the K8up controller is running."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the K8up service, verify that the service is running and check the port-forwarding command:\n```bash\nkubectl get svc --namespace k8up-system\n``` \nEnsure that the service is exposed correctly and that the port-forwarding command is still active."
+      },
+      {
+        "title": "Persistent Volume Claims not bound",
+        "description": "If the PVCs created by K8up are not bound, check the status of the PVCs:\n```bash\nkubectl get pvc --namespace k8up-system\n``` \nEnsure that the storage class is available and that there are sufficient resources in your cluster."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kagent.json
+++ b/solutions/cncf-install/install-kagent.json
@@ -40,7 +40,53 @@
         "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: kagent\n  namespace: kagent\nspec:\n  template:\n    spec:\n      containers:\n      - name: kagent\n        resources:\n          limits:\n            memory: \"512Mi\"\n            cpu: \"500m\"",
         "kubectl apply -f kagent-resources.yaml"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the kagent release from the cluster using Helm. This command will remove all associated resources created by the release.\n```bash\nhelm uninstall kagent --namespace kagent\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources are cleaned up.\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace kagent\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kagent namespace to remove any remaining resources and verify that it has been successfully deleted.\n```bash\nkubectl delete namespace kagent\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the kagent deployment. You can use the following command to export the current configuration:\n```bash\nkubectl get deployment kagent --namespace kagent -o yaml > kagent-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the kagent release to the latest version. Use the following commands:\n```bash\nhelm repo update\nhelm upgrade kagent kagent/kagent --namespace kagent --version v0.8.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the kagent pods are running the new version successfully after the upgrade:\n```bash\nkubectl get pods --namespace kagent\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue may occur if there is a misconfiguration in the deployment. To diagnose, check the logs of the pod:\n```bash\nkubectl logs <pod-name> --namespace kagent\n``` \nIf the logs indicate a configuration issue, review your deployment settings and correct any errors."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the kagent service is not reachable, ensure that the service is running and check the port forwarding setup:\n```bash\nkubectl get svc --namespace kagent\nkubectl port-forward svc/kagent --namespace kagent 8080:80\n``` \nMake sure the correct ports are being forwarded."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter errors related to insufficient resources, check the resource limits set in your deployment:\n```bash\nkubectl describe deployment kagent --namespace kagent\n``` \nConsider increasing the resource limits in your `kagent-resources.yaml` file and redeploy."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error indicating that the Helm release cannot be found, verify that the release exists in the specified namespace:\n```bash\nhelm list --namespace kagent\n``` \nIf the release does not appear, ensure that you are using the correct namespace and release name."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kairos.json
+++ b/solutions/cncf-install/install-kairos.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kairos --namespace kairos",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Kairos installation, first uninstall the Helm release using the following command:\n```bash\nhelm uninstall kairos --namespace kairos\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation:\n```bash\nkubectl delete crd $(kubectl get crd | grep kairos | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the namespace and verify that all resources have been cleaned up:\n```bash\nkubectl delete namespace kairos\nkubectl get all --namespace kairos\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of the Kairos installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace kairos -o yaml > kairos-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kairos installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade kairos kairos/kairos --namespace kairos --version v4.1.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Kairos pods are running the new version:\n```bash\nkubectl get pods --namespace kairos\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Kairos pods are stuck in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> --namespace kairos\n``` \nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, ensure that the port forwarding is set up correctly. Check the service status:\n```bash\nkubectl get svc --namespace kairos\n``` \nIf the service is not running, you may need to restart the deployment."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource usage and limits:\n```bash\nkubectl describe deployment kairos --namespace kairos\n``` \nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, verify that you are in the correct namespace and that the release name is correct:\n```bash\nhelm list --namespace kairos\n``` \nIf the release is not listed, it may have been uninstalled or not installed correctly."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kcl.json
+++ b/solutions/cncf-install/install-kcl.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kcl --namespace kcl\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     memory: \"512Mi\"\n#     cpu: \"500m\"",
         "kubectl port-forward service/kcl --namespace kcl 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KCL release from your Kubernetes cluster using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall kcl --namespace kcl\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) created by KCL, clean them up to free up resources.\n```bash\nkubectl delete crd <crd-name>\n# Replace <crd-name> with the actual CRD name\nkubectl delete pvc --all --namespace kcl\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the KCL namespace and verify that all resources have been removed. This step is optional but recommended to clean up the environment.\n```bash\nkubectl delete namespace kcl\nkubectl get all --namespace kcl\n# Ensure no resources are listed\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's crucial to backup the current state of your KCL installation. You can do this by exporting the current configuration.\n```bash\nkubectl get all --namespace kcl -o yaml > kcl-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of KCL. Ensure you specify the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade kcl kcl-lang/kcl --namespace kcl --version 0.12.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the KCL pods are running the new version successfully in the kcl namespace.\n```bash\nkubectl get pods --namespace kcl\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If KCL pods are stuck in a CrashLoopBackOff state, check the pod logs for errors that might indicate the cause.\n```bash\nkubectl logs <pod-name> --namespace kcl\n# Replace <pod-name> with the actual pod name\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the KCL service, ensure that the port forwarding is set up correctly and that the service is running.\n```bash\nkubectl get svc --namespace kcl\n# Check if the service is listed and running\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the KCL pods are failing to start due to insufficient resources, check the resource requests and limits set in the deployment.\n```bash\nkubectl describe deployment kcl --namespace kcl\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify that you are using the correct namespace and release name.\n```bash\nhelm list --namespace kcl\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kcp.json
+++ b/solutions/cncf-install/install-kcp.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kcp --namespace kcp-system\n# Add the following under spec.containers:\n# resources:\n#   requests:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"\n#   limits:\n#     cpu: \"1\"\n#     memory: \"1Gi\"",
         "kubectl create clusterrole kcp-admin --verb=* --resource=* \n\nkubectl create clusterrolebinding kcp-admin-binding --clusterrole=kcp-admin --serviceaccount=kcp-system:kcp"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the kcp release from the kcp-system namespace using Helm to remove the deployment and associated resources.\n```bash\nhelm uninstall kcp --namespace kcp-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation.\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace kcp-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kcp-system namespace and verify that it has been removed successfully.\n```bash\nkubectl delete namespace kcp-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources in the kcp-system namespace.\n```bash\nkubectl get all --namespace kcp-system -o yaml > kcp-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the kcp release to the latest version.\n```bash\nhelm repo update\nhelm upgrade kcp kcp/kcp --namespace kcp-system --version v0.31.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the kcp pods are running the new version after the upgrade.\n```bash\nkubectl get pods --namespace kcp-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If kcp pods are in a CrashLoopBackOff state, check the logs for errors that might indicate the cause.\n```bash\nkubectl logs <pod-name> --namespace kcp-system\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during upgrade, ensure that the specified version is available in the Helm repository.\n```bash\nhelm search repo kcp/kcp --versions\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you face permission issues, verify that the ClusterRole and ClusterRoleBinding are correctly set up for the kcp service account.\n```bash\nkubectl get clusterrolebindings | grep kcp-admin-binding\n```"
+      },
+      {
+        "title": "Namespace not found error",
+        "description": "If you receive a namespace not found error, ensure that the kcp-system namespace exists and is correctly referenced in your commands.\n```bash\nkubectl get namespaces\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-keda.json
+++ b/solutions/cncf-install/install-keda.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment keda-operator --namespace keda",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KEDA Helm release from your Kubernetes cluster using the following command. This will remove the deployment and associated resources from the 'keda' namespace:\n```bash\nhelm uninstall keda --namespace keda\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were installed with KEDA. Use the following command to delete the CRDs:\n```bash\nkubectl delete crd scaledobjects.keda.sh\nkubectl delete crd triggerauthentications.keda.sh\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'keda' namespace to clean up any remaining resources. Verify that the namespace has been removed:\n```bash\nkubectl delete namespace keda\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of KEDA by exporting the existing configuration. Use the following command to get the current deployment:\n```bash\nkubectl get deployment keda-operator --namespace keda -o yaml > keda-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the KEDA Helm repository and run the upgrade command to upgrade KEDA to the latest version:\n```bash\nhelm repo update\nhelm upgrade keda kedacore/keda --namespace keda --version 2.20.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the KEDA upgrade was successful by listing the pods in the 'keda' namespace and ensuring they are running:\n```bash\nkubectl get pods --namespace keda\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If KEDA pods are in a CrashLoopBackOff state, check the logs for the pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace keda\n```\nLook for any error messages that may indicate configuration issues or resource constraints."
+      },
+      {
+        "title": "KEDA not scaling as expected",
+        "description": "If KEDA is not scaling your workloads as expected, verify that the ScaledObject configurations are correct. Check the status of your ScaledObjects:\n```bash\nkubectl get scaledobjects --namespace keda\n```\nEnsure that the metrics and triggers are properly defined."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter RBAC permission errors, ensure that the RBAC configuration has been applied correctly. Check the roles and bindings:\n```bash\nkubectl get roles,rolebindings --namespace keda\n```\nIf necessary, reapply the RBAC configuration."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, verify that you are using the correct namespace and release name. List all Helm releases in the namespace:\n```bash\nhelm list --namespace keda\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kepler.json
+++ b/solutions/cncf-install/install-kepler.json
@@ -40,7 +40,53 @@
         "kubectl port-forward service/kepler 8080:80 --namespace kepler",
         "kubectl edit deployment kepler --namespace kepler"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To uninstall Kepler, first remove the Helm release using the following command:\n```bash\nhelm uninstall kepler --namespace kepler\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, clean up any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation:\n```bash\nkubectl delete crd keplers.kepler.sustainable-computing.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'kepler' namespace to remove all associated resources and verify that it has been removed:\n```bash\nkubectl delete namespace kepler\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Kepler installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace kepler -o yaml > kepler-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version:\n```bash\nhelm repo update\nhelm upgrade kepler kepler/kepler --namespace kepler --version v0.12.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Kepler pods are running the new version:\n```bash\nkubectl get pods --namespace kepler\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kepler pods are stuck in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace kepler\n``` \nLook for any configuration issues or resource constraints."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Kepler service, ensure that the port-forwarding command is running and check the service status:\n```bash\nkubectl get svc --namespace kepler\n``` \nMake sure the service is correctly configured and the pods are running."
+      },
+      {
+        "title": "High resource usage",
+        "description": "If you notice high CPU or memory usage, check the resource limits set for the deployment:\n```bash\nkubectl describe deployment kepler --namespace kepler\n``` \nConsider adjusting the resource limits if necessary."
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to missing CRDs, verify that the CRDs were installed correctly:\n```bash\nkubectl get crd --namespace kepler\n``` \nIf they are missing, reinstall the Helm chart to ensure all resources are created."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-keycloak.json
+++ b/solutions/cncf-install/install-keycloak.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/keycloak 8080:80 --namespace keycloak",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"1Gi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Keycloak release using Helm to remove all associated resources except for CRDs and persistent volumes:\n```bash\nhelm uninstall keycloak --namespace keycloak\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete the Custom Resource Definitions (CRDs) and any persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd keycloaks.keycloak.org\nkubectl delete pvc --all --namespace keycloak\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Keycloak namespace and verify that it has been removed:\n```bash\nkubectl delete namespace keycloak\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Keycloak configuration and any necessary data:\n```bash\nkubectl get all --namespace keycloak -o yaml > keycloak-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Keycloak to the latest version:\n```bash\nhelm repo update\nhelm upgrade keycloak keycloak/keycloak --version 26.5.5 --namespace keycloak\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Keycloak pods are running the new version successfully:\n```bash\nkubectl get pods --namespace keycloak\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue may occur if there are misconfigurations or resource limits are too low. Check the logs for the pod:\n```bash\nkubectl logs <pod-name> --namespace keycloak\n``` \nFix any configuration issues and consider increasing resource limits."
+      },
+      {
+        "title": "Keycloak service not reachable",
+        "description": "If the Keycloak service is not reachable, ensure that the service is running and check the port forwarding:\n```bash\nkubectl get svc --namespace keycloak\nkubectl port-forward svc/keycloak 8080:80 --namespace keycloak\n``` \nVerify that the correct ports are being forwarded."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the upgrade, ensure that you are using a compatible version. Check the current version:\n```bash\nhelm list --namespace keycloak\n``` \nThen specify a compatible version in your upgrade command."
+      },
+      {
+        "title": "Persistent volume claims not deleted",
+        "description": "If PVCs are not deleted after uninstalling, manually delete them:\n```bash\nkubectl get pvc --namespace keycloak\nkubectl delete pvc <pvc-name> --namespace keycloak\n``` \nEnsure that the PVCs are not in use by any other resources."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-keylime.json
+++ b/solutions/cncf-install/install-keylime.json
@@ -40,7 +40,53 @@
         "helm upgrade keylime keylime/keylime --namespace keylime --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "kubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: keylime\n  name: keylime-role\nrules:\n- apiGroups: [\"\"]\n  resources: [\"pods\", \"pods/log\"]\n  verbs: [\"get\", \"list\", \"watch\"]\nEOF\n\nkubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: keylime-role-binding\n  namespace: keylime\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: keylime-role\nsubjects:\n- kind: ServiceAccount\n  name: default\n  namespace: keylime\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Keylime Helm release to remove the deployment from your cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Keylime."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Keylime namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Keylime installation."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of Keylime."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Keylime components are running correctly after the upgrade."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue may occur if there is a misconfiguration or missing dependencies. Use the following command to check the logs of the pod: \n```bash\nkubectl logs <pod-name> --namespace keylime\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during upgrade, check the installed version and the available versions with: \n```bash\nhelm list --namespace keylime\nhelm search repo keylime --versions\n```"
+      },
+      {
+        "title": "RBAC permissions errors",
+        "description": "If Keylime is unable to access resources, verify the Role and RoleBinding configurations. Check the current roles with: \n```bash\nkubectl get roles --namespace keylime\nkubectl get rolebindings --namespace keylime\n```"
+      },
+      {
+        "title": "Service unavailable errors",
+        "description": "If you see service unavailable errors, ensure that all Keylime components are running. Check the status of the pods with: \n```bash\nkubectl get pods --namespace keylime\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kgateway.json
+++ b/solutions/cncf-install/install-kgateway.json
@@ -40,7 +40,53 @@
         "kubectl get pods --namespace kgateway",
         "apiVersion: gateway.kgateway.dev/v1alpha1\nkind: BackendConfigPolicy\nmetadata:\n  name: httpbin-cb\n  namespace: default\nspec:\n  targetRefs:\n  - group: \"\"\n    kind: Service\n    name: httpbin\n  circuitBreakers:\n    maxConnections: 1000\n    maxPendingRequests: 500\n    maxRequests: 2000\n    maxRetries: 10"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the kgateway release from the kgateway namespace using Helm. This command will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall kgateway --namespace kgateway\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove the Custom Resource Definitions (CRDs) and any persistent volumes associated with the kgateway installation. This ensures that no leftover resources remain in the cluster.\n```bash\nhelm uninstall kgateway-crds --namespace kgateway\nkubectl delete pvc --all --namespace kgateway\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kgateway namespace to clean up any remaining resources and verify that it has been removed successfully.\n```bash\nkubectl delete namespace kgateway\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the kgateway installation. You can export the current resources to YAML files for safekeeping.\n```bash\nkubectl get all --namespace kgateway -o yaml > kgateway-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the kgateway installation to the latest version. Ensure you specify the desired version if not upgrading to the latest.\n```bash\nhelm repo update\nhelm upgrade kgateway kgateway/kgateway --namespace kgateway --version v2.3.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the kgateway pods are running the new version and that there are no issues.\n```bash\nkubectl get pods --namespace kgateway\nkubectl describe pod <pod-name> --namespace kgateway\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If kgateway pods are in a CrashLoopBackOff state, check the logs for errors that may indicate the cause of the crash.\n```bash\nkubectl logs <pod-name> --namespace kgateway\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If services are not reachable through the kgateway, verify that the BackendConfigPolicy is correctly configured and applied. Check the status of the policy.\n```bash\nkubectl get backendconfigpolicy --namespace default\nkubectl describe backendconfigpolicy httpbin-cb --namespace default\n```"
+      },
+      {
+        "title": "Ingress rules not applied",
+        "description": "If ingress rules are not being applied, ensure that the kgateway is correctly configured to handle ingress traffic. Check the kgateway configuration.\n```bash\nkubectl get gateways --namespace kgateway\nkubectl describe gateway <gateway-name> --namespace kgateway\n```"
+      },
+      {
+        "title": "High latency in API responses",
+        "description": "If you are experiencing high latency in API responses, check the resource limits and requests for the kgateway pods. Adjust them if necessary.\n```bash\nkubectl get pods --namespace kgateway -o=jsonpath='{.items[*].spec.containers[*].resources}'\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kitops.json
+++ b/solutions/cncf-install/install-kitops.json
@@ -40,7 +40,53 @@
         "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: kitops\n  namespace: kitops\nspec:\n  template:\n    spec:\n      containers:\n        - name: kitops\n          resources:\n            limits:\n              cpu: \"500m\"\n              memory: \"512Mi\"",
         "kubectl apply -f kitops-resources.yaml"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KitOps release from the Kubernetes cluster using Helm. This will remove the deployment and associated resources but not the CRDs or persistent volumes.\n```bash\nhelm uninstall kitops --namespace kitops\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with KitOps to ensure a clean removal.\n```bash\nkubectl delete crd kitops.kitops.org\nkubectl delete pvc --all --namespace kitops\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the KitOps namespace and verify that it has been removed successfully. This will clean up any remaining resources in the namespace.\n```bash\nkubectl delete namespace kitops\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the KitOps release. You can use the following command to export the current configuration.\n```bash\nhelm get values kitops --namespace kitops > kitops-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts and then upgrade KitOps to the desired version. Replace `v1.12.0` with the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade kitops kitops/kitops --namespace kitops --version v1.12.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the KitOps pods to ensure they are running the new version successfully after the upgrade.\n```bash\nkubectl get pods --namespace kitops\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the KitOps pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace kitops\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the KitOps service, ensure that the port forwarding is set up correctly and the service is running.\n```bash\nkubectl get svc --namespace kitops\nkubectl port-forward svc/kitops --namespace kitops 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the KitOps deployment fails due to insufficient resources, check the resource requests and limits set in the deployment configuration. Adjust them as necessary.\n```bash\nkubectl describe deployment kitops --namespace kitops\n```"
+      },
+      {
+        "title": "Failed to apply resource limits",
+        "description": "If the resource limits configuration fails to apply, check the YAML syntax and ensure the deployment is correctly defined. Validate the YAML file with:\n```bash\nkubectl apply -f kitops-resources.yaml --dry-run=client\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kmesh.json
+++ b/solutions/cncf-install/install-kmesh.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment kmesh --namespace <namespace> -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"kmesh\",\"resources\":{\"limits\":{\"cpu\":\"1\",\"memory\":\"800Mi\"}}}]}}}}'",
         "kubectl edit configmap kmesh-config --namespace <namespace>\n# Add or modify the monitoring settings in the config map as needed."
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kmesh release from your Kubernetes cluster using Helm. Replace `<namespace>` with your desired namespace:\n```bash\nhelm uninstall kmesh --namespace <namespace>\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Kmesh:\n```bash\nkubectl delete crd $(kubectl get crd | grep kmesh | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for Kmesh and verify that it has been removed:\n```bash\nkubectl delete namespace <namespace>\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Kmesh configuration and resources:\n```bash\nkubectl get all --namespace <namespace> -o yaml > kmesh-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kmesh installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade kmesh kmesh/kmesh-helm --namespace <namespace> --version 0.1.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Kmesh pods are running the new version successfully:\n```bash\nkubectl get pods --namespace <namespace>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Kmesh pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace <namespace>\n```\nLook for any error messages that indicate configuration issues or resource constraints."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If services are not reachable, verify that the Kmesh configuration is correct:\n```bash\nkubectl get configmap kmesh-config --namespace <namespace> -o yaml\n```\nEnsure that the service endpoints are properly defined."
+      },
+      {
+        "title": "High resource usage",
+        "description": "If you notice high CPU or memory usage, check the resource limits set for Kmesh:\n```bash\nkubectl describe deployment kmesh --namespace <namespace>\n```\nConsider adjusting the resource limits in the deployment."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade fails, check the Helm release status:\n```bash\nhelm status kmesh --namespace <namespace>\n```\nIf necessary, roll back to the previous version:\n```bash\nhelm rollback kmesh --namespace <namespace> <revision-number>\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-knative-eventing.json
+++ b/solutions/cncf-install/install-knative-eventing.json
@@ -40,7 +40,53 @@
         "kubectl apply -f - <<EOF\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: config-br-default-channel\n  namespace: knative-eventing\ndata:\n  channel-template-spec: |\n    apiVersion: messaging.knative.dev/v1\n    kind: InMemoryChannel\nEOF",
         "kubectl apply -f - <<EOF\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: config-br-defaults\n  namespace: knative-eventing\ndata:\n  default-br-config: |\n    clusterDefault:\n      brokerClass: MTChannelBasedBroker\nEOF"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Knative Eventing release from the `knative-eventing` namespace using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Knative Eventing."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `knative-eventing` namespace and verify that it has been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Knative Eventing installation."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to upgrade Knative Eventing to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that all pods in the `knative-eventing` namespace are running successfully after the upgrade."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If pods are in a CrashLoopBackOff state, check the logs for the failing pod to diagnose the issue. Use the following command to view logs:\n```bash\nkubectl logs <pod-name> --namespace knative-eventing\n```"
+      },
+      {
+        "title": "Broker not receiving events",
+        "description": "If the broker is not receiving events, ensure that the event source is correctly configured and that the broker is running. Check the broker status with:\n```bash\nkubectl get brokers --namespace knative-eventing\n```"
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If configuration changes are not taking effect, verify that the ConfigMaps have been applied correctly. Check the ConfigMaps with:\n```bash\nkubectl get configmaps --namespace knative-eventing\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If a service is not reachable, ensure that the service is running and check the ingress configuration. Use the following command to check the service status:\n```bash\nkubectl get services --namespace knative-eventing\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-konveyor.json
+++ b/solutions/cncf-install/install-konveyor.json
@@ -40,7 +40,53 @@
         "helm upgrade konveyor konveyor/konveyor --namespace konveyor --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "apiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: konveyor-ingress\n  namespace: konveyor\nspec:\n  rules:\n  - host: <your-domain>\n    http:\n      paths:\n      - path: /\n        pathType: Prefix\n        backend:\n          service:\n            name: konveyor-ui\n            port:\n              number: 80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Konveyor Operator release from your Kubernetes cluster using Helm. This will remove the deployment and associated resources from the `konveyor` namespace.\n```bash\nhelm uninstall konveyor --namespace konveyor\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources are cleaned up.\n```bash\nkubectl delete crd $(kubectl get crd | grep konveyor | awk '{print $1}')\nkubectl delete pvc --all --namespace konveyor\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `konveyor` namespace to remove any remaining resources and verify that it has been successfully deleted.\n```bash\nkubectl delete namespace konveyor\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Konveyor installation. This can be done by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace konveyor -o yaml > konveyor-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Konveyor Operator to the latest version. Ensure you specify the correct version.\n```bash\nhelm repo update\nhelm upgrade konveyor konveyor/konveyor --namespace konveyor --version v99.1.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Konveyor Operator pod is running successfully after the upgrade. Ensure that the version is updated.\n```bash\nkubectl get pods --namespace konveyor\nkubectl describe deployment konveyor --namespace konveyor | grep Image\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Konveyor Operator pods are in a CrashLoopBackOff state, check the logs for errors. This may indicate a misconfiguration or resource issue.\n```bash\nkubectl logs <pod-name> --namespace konveyor\n```"
+      },
+      {
+        "title": "Ingress not reachable",
+        "description": "If the Ingress resource is not reachable, verify the Ingress configuration and check the service endpoints. Ensure that the Ingress controller is running.\n```bash\nkubectl describe ingress konveyor-ingress --namespace konveyor\nkubectl get svc --namespace konveyor\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to out-of-memory (OOM) errors, check the resource limits set for the Konveyor Operator and adjust them accordingly.\n```bash\nkubectl describe pod <pod-name> --namespace konveyor | grep -i oom\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that the specified version is available in the Helm repository and that there are no pending changes.\n```bash\nhelm search repo konveyor/konveyor --versions\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kpt.json
+++ b/solutions/cncf-install/install-kpt.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment kpt --namespace kpt-system --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward svc/kpt --namespace kpt-system 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the kpt release from the kpt-system namespace using Helm to remove the deployment and associated resources:\n```bash\nhelm uninstall kpt --namespace kpt-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd --all\nkubectl delete pvc --all --namespace kpt-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kpt-system namespace and verify that it has been removed:\n```bash\nkubectl delete namespace kpt-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources in the kpt-system namespace:\n```bash\nkubectl get all --namespace kpt-system -o yaml > kpt-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the kpt release to the latest version:\n```bash\nhelm repo update\nhelm upgrade kpt kpt/kpt --namespace kpt-system --version v1.0.0-beta.62\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the kpt pod is running with the upgraded version:\n```bash\nkubectl get pods --namespace kpt-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the kpt pod is in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace kpt-system\n``` \nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during upgrade, ensure that the version specified is available in the repository:\n```bash\nhelm search repo kpt/kpt --versions\n``` \nIf the desired version is not listed, update the repo or choose a different version."
+      },
+      {
+        "title": "Service not reachable after port-forwarding",
+        "description": "If you cannot access the kpt CLI after port-forwarding, check if the service is running:\n```bash\nkubectl get svc --namespace kpt-system\n``` \nEnsure that the service is correctly configured and that the port-forward command is still active."
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If the kpt pod is being evicted due to resource limits, check the events for the pod:\n```bash\nkubectl describe pod <pod-name> --namespace kpt-system\n``` \nAdjust the resource limits if necessary to ensure the pod has enough resources to run."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kserve.json
+++ b/solutions/cncf-install/install-kserve.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kserve --namespace kserve-system",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the KServe installation, execute the following command to uninstall the Helm release from the 'kserve-system' namespace:\n```bash\nhelm uninstall kserve --namespace kserve-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the Helm release, remove the Custom Resource Definitions (CRDs) and any persistent resources that were created. Run the following commands:\n```bash\nkubectl delete crd inferenceservices.kserve.io\nkubectl delete crd predictors.kserve.io\nkubectl delete crd transformers.kserve.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'kserve-system' namespace to clean up any remaining resources. Verify that the namespace has been removed:\n```bash\nkubectl delete namespace kserve-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading KServe, it's important to back up the current state of your deployment. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace kserve-system -o yaml > kserve-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade KServe to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade kserve kserve/kserve-crd-minimal --namespace kserve-system --version v0.17.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the KServe components are running with the updated version:\n```bash\nkubectl get pods --namespace kserve-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If KServe pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace kserve-system\n``` \nLook for error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the KServe service is not reachable, verify that the service is running and check the endpoints:\n```bash\nkubectl get svc --namespace kserve-system\nkubectl describe svc kserve --namespace kserve-system\n``` \nEnsure that the service has valid endpoints."
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If KServe is failing to start due to insufficient resources, check the resource requests and limits set in the deployment:\n```bash\nkubectl get deployment kserve --namespace kserve-system -o yaml\n``` \nAdjust the resource limits as necessary in the deployment configuration."
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to missing CRDs, ensure that the CRDs were installed correctly. You can check the status of the CRDs with:\n```bash\nkubectl get crd\n``` \nIf they are missing, reinstall the CRDs using the Helm chart."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kuadrant.json
+++ b/solutions/cncf-install/install-kuadrant.json
@@ -36,7 +36,53 @@
         "kubectl edit deployment kuadrant-operator --namespace kuadrant",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kuadrant Operator release using Helm with the following command:\n```bash\nhelm uninstall kuadrant-operator --namespace kuadrant\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) created by the Kuadrant Operator with the following command:\n```bash\nkubectl delete crd kuadrant*.kuadrant.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'kuadrant' namespace and verify its removal with the following commands:\n```bash\nkubectl delete namespace kuadrant\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Kuadrant Operator with the following command:\n```bash\nkubectl get all --namespace kuadrant -o yaml > kuadrant-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kuadrant Operator to the latest version with the following commands:\n```bash\nhelm repo update\nhelm upgrade kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant --version v1.5.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Kuadrant Operator pod is running the new version with the following command:\n```bash\nkubectl get pods --namespace kuadrant\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kuadrant Operator pod is in a CrashLoopBackOff state, check the logs for errors with the following command:\n```bash\nkubectl logs <pod-name> --namespace kuadrant\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, check the installed version with:\n```bash\nhelm list --namespace kuadrant\n```\nThen ensure the version you are upgrading to is compatible."
+      },
+      {
+        "title": "CRDs not found after upgrade",
+        "description": "If the CRDs are not found after an upgrade, ensure they are still installed with:\n```bash\nkubectl get crd --namespace kuadrant\n```"
+      },
+      {
+        "title": "Resource limits not applied",
+        "description": "If the resource limits are not applied as expected, check the deployment configuration with:\n```bash\nkubectl get deployment kuadrant-operator --namespace kuadrant -o yaml\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kuasar.json
+++ b/solutions/cncf-install/install-kuasar.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kuasar --namespace kuasar",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kuasar Helm release from the cluster using the following command:\n```bash\nhelm uninstall kuasar --namespace kuasar\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Kuasar. Use the following commands:\n```bash\nkubectl delete crd $(kubectl get crd | grep kuasar | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Kuasar namespace and verify that it has been removed:\n```bash\nkubectl delete namespace kuasar\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Kuasar release. You can do this by exporting the current configuration:\n```bash\nhelm get values kuasar --namespace kuasar > kuasar-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kuasar release to the latest version:\n```bash\nhelm repo update\nhelm upgrade kuasar kuasar/kuasar --namespace kuasar --version v1.0.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Kuasar pods to ensure they are running the upgraded version:\n```bash\nkubectl get pods --namespace kuasar\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kuasar pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace kuasar\n```Fix any configuration issues or resource limits that may be causing the crashes."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Kuasar service is not reachable, ensure that the service is running and check for any network policies:\n```bash\nkubectl get svc --namespace kuasar\nkubectl describe svc kuasar --namespace kuasar\n```Verify that the port-forwarding command is set correctly."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, check the installed version and the available versions:\n```bash\nhelm list --namespace kuasar\nhelm search repo kuasar/kuasar --versions\n```Ensure you are upgrading to a compatible version."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If pods are not starting due to insufficient resources, check the resource requests and limits:\n```bash\nkubectl describe deployment kuasar --namespace kuasar\n```Adjust the resource limits in the deployment if necessary."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kube-ovn.json
+++ b/solutions/cncf-install/install-kube-ovn.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kube-ovn -n kube-system",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kube-OVN release from the kube-system namespace using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall kube-ovn --namespace kube-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Kube-OVN to ensure a clean uninstallation.\n```bash\nkubectl delete crd -l app=kube-ovn\nkubectl delete pvc -l app=kube-ovn -n kube-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kube-system namespace if it is no longer needed, and verify that all resources have been removed.\n```bash\nkubectl delete namespace kube-system\nkubectl get all -n kube-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Kube-OVN installation to prevent data loss. You can export the current configuration.\n```bash\nkubectl get all -n kube-system -o yaml > kube-ovn-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kube-OVN release to the latest version. Replace `1.16.1` with the desired version.\n```bash\nhelm repo update\nhelm upgrade kube-ovn kube-ovn/kube-ovn-v2 --namespace kube-system --version 1.16.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the Kube-OVN pods to ensure they are running the new version.\n```bash\nkubectl get pods -n kube-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Kube-OVN pods are in a CrashLoopBackOff state, check the logs for errors that might indicate the cause of the failure.\n```bash\nkubectl logs <pod-name> -n kube-system\n```"
+      },
+      {
+        "title": "Network connectivity issues",
+        "description": "If you experience network connectivity issues, verify that the Kube-OVN components are running and check the network policies.\n```bash\nkubectl get pods -n kube-system\nkubectl get networkpolicy -n kube-system\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to out-of-memory (OOM) errors, review the resource limits set for Kube-OVN and adjust them as necessary.\n```bash\nkubectl describe pod <pod-name> -n kube-system | grep -i 'oom'\n```"
+      },
+      {
+        "title": "Prometheus metrics not scraping",
+        "description": "If Prometheus is not scraping metrics from Kube-OVN, check the annotations and ensure that Prometheus is configured to scrape the correct endpoints.\n```bash\nkubectl get deployment kube-ovn -n kube-system -o yaml | grep annotations -A 5\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kube-vip.json
+++ b/solutions/cncf-install/install-kube-vip.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kube-vip -n kube-vip",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kube-Vip Helm release from the cluster using the following command. This will remove the deployment and associated resources from the specified namespace.\n```bash\nhelm uninstall kube-vip --namespace kube-vip\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) that were created during the installation. This ensures that all resources are cleaned up properly.\n```bash\nkubectl delete crd kubevips.kube-vip.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `kube-vip` namespace to remove any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace kube-vip\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it is important to back up the current state of the Kube-Vip deployment. You can do this by exporting the current configuration.\n```bash\nkubectl get deployment kube-vip -n kube-vip -o yaml > kube-vip-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the Kube-Vip installation to the desired version (e.g., v1.1.0).\n```bash\nhelm repo update\nhelm upgrade kube-vip kube-vip/kube-vip --namespace kube-vip --version v1.1.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the Kube-Vip pods to ensure they are running the new version and functioning correctly.\n```bash\nkubectl get pods -n kube-vip\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kube-Vip pods are in a CrashLoopBackOff state, check the logs for any errors that may indicate the cause of the issue.\n```bash\nkubectl logs <pod-name> -n kube-vip\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Kube-Vip service is not reachable, verify that the service is correctly configured and that the pods are running. Check the service details and pod status.\n```bash\nkubectl get svc -n kube-vip\nkubectl get pods -n kube-vip\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If Kube-Vip is failing to start due to insufficient resources, check the resource limits and requests set in the deployment. Adjust them if necessary.\n```bash\nkubectl describe deployment kube-vip -n kube-vip\n```"
+      },
+      {
+        "title": "Configuration errors",
+        "description": "If there are issues with the configuration, review the deployment configuration and logs to identify any misconfigurations.\n```bash\nkubectl get deployment kube-vip -n kube-vip -o yaml\nkubectl logs <pod-name> -n kube-vip\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubean.json
+++ b/solutions/cncf-install/install-kubean.json
@@ -40,7 +40,53 @@
         "helm upgrade kubean kubean/kubean --namespace kubean --set kubeanOperator.resources.limits.cpu=500m --set kubeanOperator.resources.limits.memory=512Mi",
         "kubectl create serviceaccount kubean-sa -n kubean\nkubectl create clusterrolebinding kubean-sa --clusterrole=cluster-admin --serviceaccount=kubean:kubean-sa"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kubean Helm release to remove the deployment from your cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Kubean."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Kubean namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Kubean installation."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the new version of Kubean."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Kubean pods to ensure they are running the new version."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start properly and keeps crashing. To diagnose, check the logs of the pod using the following command:\n```bash\nkubectl logs <pod-name> -n kubean\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during an upgrade, it may be due to incompatible changes. Check the current version with:\n```bash\nhelm list -n kubean\n```\nThen, specify the exact version to upgrade to using the `--version` flag."
+      },
+      {
+        "title": "RBAC permission errors",
+        "description": "If you see permission denied errors, ensure that the service account has the correct permissions. Verify the service account and role binding with:\n```bash\nkubectl get serviceaccount kubean-sa -n kubean\nkubectl get clusterrolebinding kubean-sa\n```\nIf necessary, recreate the role binding."
+      },
+      {
+        "title": "Kubean operator not responding",
+        "description": "If the Kubean operator is unresponsive, check its logs for errors:\n```bash\nkubectl logs -l app=kubean-operator -n kubean\n```\nInvestigate any errors and ensure that the operator pod is running."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubearmor.json
+++ b/solutions/cncf-install/install-kubearmor.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kubearmor --namespace kubearmor",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KubeArmor release from the cluster using Helm. This will remove all associated resources created by the Helm chart.\n```bash\nhelm uninstall kubearmor --namespace kubearmor\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) that were installed with KubeArmor. This step is important to ensure that no leftover resources remain in the cluster.\n```bash\nkubectl delete crd kubearmorpolicies.kubearmor.io\nkubectl delete crd kubearmorhosts.kubearmor.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the KubeArmor namespace to clean up all remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace kubearmor\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current configuration and state of KubeArmor. You can export the current deployment and any relevant configurations.\n```bash\nkubectl get deployment kubearmor --namespace kubearmor -o yaml > kubearmor-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade KubeArmor to the desired version (e.g., v1.7.0).\n```bash\nhelm repo update\nhelm upgrade kubearmor kubearmor/kubearmor --namespace kubearmor --version v1.7.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the KubeArmor pods to ensure they are running the new version correctly.\n```bash\nkubectl get pods --namespace kubearmor\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If KubeArmor pods are in a CrashLoopBackOff state, check the logs for errors that may indicate the cause of the crash.\n```bash\nkubectl logs <pod-name> --namespace kubearmor\n```"
+      },
+      {
+        "title": "KubeArmor not enforcing policies",
+        "description": "If KubeArmor is not enforcing the expected policies, verify that the policies are correctly defined and applied. Check the status of the KubeArmor policies.\n```bash\nkubectl get kubearmorpolicies --namespace kubearmor\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If KubeArmor cannot access certain resources, ensure that the RBAC roles and bindings are correctly configured. Check the role and binding.\n```bash\nkubectl get clusterrole kubearmor-role\nkubectl get clusterrolebinding kubearmor-role-binding\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the KubeArmor pods are being terminated due to OOMKilled status, consider adjusting the resource limits in the deployment. Check the current resource usage.\n```bash\nkubectl describe pod <pod-name> --namespace kubearmor\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubeclipper.json
+++ b/solutions/cncf-install/install-kubeclipper.json
@@ -40,7 +40,53 @@
         "kubectl port-forward service/kc-server --namespace kubeclipper 8080:80",
         "kubectl edit deployment kc-server --namespace kubeclipper"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To remove the KubeClipper release, execute the following command to uninstall it from the specified namespace:\n```bash\nhelm uninstall kubeclipper --namespace kubeclipper\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the release, clean up any Custom Resource Definitions (CRDs) and persistent volumes that were created. Run the following commands:\n```bash\nkubectl delete crd kubeclippers.kubeclipper.io\nkubectl delete pvc --all --namespace kubeclipper\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the namespace used for KubeClipper and verify that it has been removed:\n```bash\nkubectl delete namespace kubeclipper\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your KubeClipper installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace kubeclipper -o yaml > kubeclipper-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the new version of KubeClipper:\n```bash\nhelm repo update\nhelm upgrade kubeclipper kubeclipper/kubeclipper --version v1.5.0 --namespace kubeclipper\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the KubeClipper pods are running the new version:\n```bash\nkubectl get pods --namespace kubeclipper\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the KubeClipper pods are stuck in a CrashLoopBackOff state, check the logs for the pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace kubeclipper\n``` \nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the KubeClipper service, ensure that the service is running and check the port-forwarding command:\n```bash\nkubectl get svc --namespace kubeclipper\n``` \nIf the service is not running, you may need to restart the pods or check the deployment configuration."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If KubeClipper fails to start due to insufficient resources, check the resource requests and limits set in the deployment:\n```bash\nkubectl describe deployment kc-server --namespace kubeclipper\n``` \nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any conflicting resources or version compatibility issues. You can view the error message in the terminal. To rollback to the previous version, use:\n```bash\nhelm rollback kubeclipper --namespace kubeclipper\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubeelasti.json
+++ b/solutions/cncf-install/install-kubeelasti.json
@@ -40,7 +40,53 @@
         "helm upgrade elasti kubeelasti/elasti --namespace kubeelasti --set global.resources.limits.cpu=500m --set global.resources.limits.memory=512Mi",
         "helm upgrade elasti kubeelasti/elasti --namespace kubeelasti --set global.enableMonitoring=true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KubeElasti release from the `kubeelasti` namespace using the following command:\n```bash\nhelm uninstall elasti --namespace kubeelasti\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. Use the following commands:\n```bash\nkubectl delete crd $(kubectl get crd | grep kubeelasti | awk '{print $1}')\nkubectl delete pvc --all --namespace kubeelasti\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `kubeelasti` namespace and verify its removal with the following commands:\n```bash\nkubectl delete namespace kubeelasti\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Helm release configuration with the following command:\n```bash\nhelm get values elasti --namespace kubeelasti > elasti-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade KubeElasti to the latest version using the following commands:\n```bash\nhelm repo update\nhelm upgrade elasti kubeelasti/elasti --namespace kubeelasti --version 0.1.22\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the KubeElasti pods are running after the upgrade by executing:\n```bash\nkubectl get pods --namespace kubeelasti\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the KubeElasti pods are in a CrashLoopBackOff state, check the logs of the pods to diagnose the issue:\n```bash\nkubectl logs <pod-name> --namespace kubeelasti\n``` \nLook for any errors in the logs that may indicate misconfiguration or resource limits."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, ensure that you are using the correct version of the chart. Check the available versions with:\n```bash\nhelm search repo kubeelasti/elasti --versions\n``` \nThen specify the correct version in your upgrade command."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the KubeElasti service is not reachable, check the service status and endpoints:\n```bash\nkubectl get svc --namespace kubeelasti\nkubectl describe svc elasti --namespace kubeelasti\n``` \nEnsure that the service is correctly configured and that the pods are running."
+      },
+      {
+        "title": "Persistent volume claims are not bound",
+        "description": "If the PVCs are not bound, check the status of the PVCs and the underlying storage class:\n```bash\nkubectl get pvc --namespace kubeelasti\nkubectl describe pvc <pvc-name> --namespace kubeelasti\n``` \nEnsure that the storage class is available and that there are sufficient resources."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubefleet.json
+++ b/solutions/cncf-install/install-kubefleet.json
@@ -40,7 +40,53 @@
         "helm upgrade hub-agent kubefleet/hub-agent --namespace fleet-system --set resources.limits.cpu=500m --set resources.limits.memory=1Gi",
         "kubectl create clusterrole hub-agent-role --verb=get,list,watch,create,update,patch,delete --resource=pods,services,deployments\nkubectl create clusterrolebinding hub-agent-role-binding --clusterrole=hub-agent-role --serviceaccount=fleet-system:default"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KubeFleet hub agent Helm release to remove the deployment from your cluster. Run the following command:\n```bash\nhelm uninstall hub-agent --namespace fleet-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources that were created by KubeFleet. Use the following commands to remove them:\n```bash\nkubectl delete crd <crd-name>\n# Replace <crd-name> with the actual CRD names associated with KubeFleet\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for KubeFleet and verify that it has been removed. Execute the following commands:\n```bash\nkubectl delete namespace fleet-system\nkubectl get namespaces\n# Ensure 'fleet-system' is no longer listed\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the KubeFleet hub agent. You can do this by exporting the current configuration:\n```bash\nhelm get values hub-agent --namespace fleet-system > hub-agent-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the KubeFleet hub agent to the latest version. Execute the following commands:\n```bash\nhelm repo update\nhelm upgrade hub-agent kubefleet/hub-agent --namespace fleet-system --version 0.2.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the hub agent pod is running with the new version. Use the following command:\n```bash\nkubectl get pods --namespace fleet-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the hub agent pods are stuck in a CrashLoopBackOff state, check the logs for errors. Use the following command to view logs:\n```bash\nkubectl logs <pod-name> --namespace fleet-system\n# Replace <pod-name> with the name of the hub agent pod\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that the specified version is available in the repository. Check available versions with:\n```bash\nhelm search repo kubefleet/hub-agent --versions\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter RBAC permission issues, verify that the ClusterRole and ClusterRoleBinding are correctly set up. Check the bindings with:\n```bash\nkubectl get clusterrolebinding hub-agent-role-binding\n```"
+      },
+      {
+        "title": "Namespace not found error",
+        "description": "If you receive a 'namespace not found' error, ensure that the 'fleet-system' namespace exists. You can check existing namespaces with:\n```bash\nkubectl get namespaces\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubeflow.json
+++ b/solutions/cncf-install/install-kubeflow.json
@@ -40,7 +40,53 @@
         "helm upgrade kubeflow kubeflow/kubeflow --namespace kubeflow --set resources.limits.cpu=500m --set resources.limits.memory=1Gi",
         "kubectl port-forward svc/istio-ingressgateway -n kubeflow 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Kubeflow installation, first uninstall the Helm release using the following command. This will remove all the resources associated with the release, but not the CRDs or persistent volumes.\n```bash\nhelm uninstall kubeflow --namespace kubeflow\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, you need to remove the Custom Resource Definitions (CRDs) that were installed with Kubeflow. This command will delete all CRDs related to Kubeflow. Additionally, if you have any persistent volumes (PVCs) that you want to clean up, you can delete them as well.\n```bash\nkubectl delete crd $(kubectl get crd | grep kubeflow.org | awk '{print $1}')\nkubectl delete pvc --all --namespace kubeflow\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'kubeflow' namespace to clean up any remaining resources. After deletion, verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace kubeflow\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Kubeflow installation. You can do this by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace kubeflow -o yaml > kubeflow-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, and then run the upgrade command to update your Kubeflow installation to the desired version. Replace 'v1.10.1' with the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade kubeflow kubeflow/kubeflow --version v1.10.1 --namespace kubeflow\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that all the pods are running in the 'kubeflow' namespace to ensure a successful upgrade.\n```bash\nkubectl get pods --namespace kubeflow\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that some pods are stuck in a CrashLoopBackOff state, you can check the logs of the affected pod to diagnose the issue. Replace 'pod-name' with the actual name of the pod.\n```bash\nkubectl logs pod-name --namespace kubeflow\n```"
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Kubeflow dashboard, ensure that the port forwarding is set up correctly. You can check the service status with the following command:\n```bash\nkubectl get svc --namespace kubeflow\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource usage of the pods and nodes. You can use the following commands to diagnose:\n```bash\nkubectl top pods --namespace kubeflow\nkubectl top nodes\n```"
+      },
+      {
+        "title": "Helm release failed to install",
+        "description": "If the Helm release fails to install, check the events in the namespace for any errors. This can provide insight into what went wrong during the installation process.\n```bash\nkubectl get events --namespace kubeflow\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kuberhealthy.json
+++ b/solutions/cncf-install/install-kuberhealthy.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/kuberhealthy --namespace kuberhealthy 8080:80",
         "kubectl edit deployment kuberhealthy --namespace kuberhealthy"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kuberhealthy Helm release from the cluster using the following command:\n```bash\nhelm uninstall kuberhealthy --namespace kuberhealthy\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Kuberhealthy:\n```bash\nkubectl delete crd kuberhealthies.kuberhealthy.com\nkubectl delete pvc --all --namespace kuberhealthy\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kuberhealthy namespace and verify its removal:\n```bash\nkubectl delete namespace kuberhealthy\nkubectl get namespaces | grep kuberhealthy\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Kuberhealthy configuration:\n```bash\nhelm get values kuberhealthy --namespace kuberhealthy > kuberhealthy-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Kuberhealthy to the latest version:\n```bash\nhelm repo update\nhelm upgrade kuberhealthy kuberhealthy/kuberhealthy --namespace kuberhealthy --version v2.8.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Kuberhealthy pods are running the new version successfully:\n```bash\nkubectl get pods --namespace kuberhealthy\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Kuberhealthy pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace kuberhealthy\n```\nInvestigate the error messages and adjust configurations as needed."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Kuberhealthy status page, ensure the service is running:\n```bash\nkubectl get svc --namespace kuberhealthy\n```\nIf the service is not running, check the deployment status and logs."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If Kuberhealthy fails to start due to resource constraints, check the resource usage:\n```bash\nkubectl describe pod <pod-name> --namespace kuberhealthy\n```\nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace kuberhealthy\n```\nEnsure you are using the correct release name 'kuberhealthy'."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubescape.json
+++ b/solutions/cncf-install/install-kubescape.json
@@ -40,7 +40,53 @@
         "kubectl port-forward service/kubescape -n kubescape 8080:80",
         "kubectl patch deployment kubescape -n kubescape --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kubescape Helm release from the 'kubescape' namespace to remove the deployment and associated resources.\n```bash\nhelm uninstall kubescape --namespace kubescape\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation.\n```bash\nkubectl delete crd kubescape --ignore-not-found\nkubectl delete pvc --all -n kubescape\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'kubescape' namespace and verify that it has been removed successfully.\n```bash\nkubectl delete namespace kubescape\nkubectl get namespaces | grep kubescape\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Kubescape deployment and any associated resources.\n```bash\nkubectl get all -n kubescape -o yaml > kubescape-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kubescape release to the latest version.\n```bash\nhelm repo update\nhelm upgrade kubescape kubescape/kubescape --namespace kubescape --version v4.1.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Kubescape pods are running the new version successfully after the upgrade.\n```bash\nkubectl get pods -n kubescape\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kubescape pods are in a CrashLoopBackOff state, check the logs for errors.\n```bash\nkubectl logs <pod-name> -n kubescape\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Kubescape service, ensure that the port-forwarding command is running and check the service status.\n```bash\nkubectl get svc -n kubescape\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter resource allocation issues, verify the resource limits and requests set for the deployment.\n```bash\nkubectl describe deployment kubescape -n kubescape\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If Helm reports that the release is not found, ensure you are using the correct namespace and release name.\n```bash\nhelm list --namespace kubescape\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubevela.json
+++ b/solutions/cncf-install/install-kubevela.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment vela-core --namespace kubevela --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'",
         "kubectl create role kubevela-admin --verb=* --resource=* --namespace kubevela\nkubectl create rolebinding kubevela-admin-binding --role=kubevela-admin --user=system:serviceaccount:kubevela:default --namespace kubevela"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KubeVela release from the cluster using Helm. This will remove the deployment and associated resources created by the installation.\n```bash\nhelm uninstall vela-core --namespace kubevela\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources related to KubeVela are cleaned up.\n```bash\nkubectl delete crd $(kubectl get crd | grep 'kubevela.io' | awk '{print $1}')\nkubectl delete pvc --all --namespace kubevela\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'kubevela' namespace to remove all remaining resources and verify that it has been deleted successfully.\n```bash\nkubectl delete namespace kubevela\nkubectl get namespaces | grep kubevela\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of KubeVela. You can do this by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace kubevela -o yaml > kubevela-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to upgrade KubeVela to the latest version. Make sure to specify the new version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade vela-core kubevela/vela-core --version v1.10.8 --namespace kubevela\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the KubeVela pods are running the new version successfully. Check the status of the pods to ensure everything is functioning correctly.\n```bash\nkubectl get pods --namespace kubevela\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the KubeVela pods are stuck in a CrashLoopBackOff state, check the logs for the failing pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace kubevela\n```"
+      },
+      {
+        "title": "Helm upgrade fails with 'release not found'",
+        "description": "If you encounter an error stating 'release not found' during an upgrade, ensure that the release name is correct and that it exists in the specified namespace.\n```bash\nhelm list --namespace kubevela\n```"
+      },
+      {
+        "title": "RBAC issues preventing access",
+        "description": "If you face permission issues, verify that the Role and RoleBinding are correctly set up. Check the bindings for the service account used by KubeVela.\n```bash\nkubectl get rolebinding --namespace kubevela\nkubectl describe rolebinding kubevela-admin-binding --namespace kubevela\n```"
+      },
+      {
+        "title": "Resource limits causing pod evictions",
+        "description": "If pods are being evicted due to resource limits, review the resource requests and limits set for the KubeVela deployment and adjust them as necessary.\n```bash\nkubectl get deployment vela-core --namespace kubevela -o yaml | grep resources -A 5\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubevirt.json
+++ b/solutions/cncf-install/install-kubevirt.json
@@ -40,7 +40,53 @@
         "apiVersion: kubevirt.io/v1\nkind: KubeVirt\nmetadata:\n  name: kubevirt\nspec:\n  configuration:\n    developerMode: false\n    resourceLimits:\n      cpu: \"2\"\n      memory: \"4Gi\"",
         "kubectl apply -f kubevirt-resources.yaml -n kubevirt"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove KubeVirt, first uninstall the Helm release with the following command:\n```bash\nhelm uninstall kubevirt --namespace kubevirt\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After removing the release, clean up any Custom Resource Definitions (CRDs) and persistent resources that were created. Execute the following commands:\n```bash\nkubectl delete crd virtualmachines.kubevirt.io\nkubectl delete crd virtualmachineinstances.kubevirt.io\nkubectl delete crd virtualmachineinstancesets.kubevirt.io\nkubectl delete crd virtualmachinepresets.kubevirt.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'kubevirt' namespace and verify its removal:\n```bash\nkubectl delete namespace kubevirt\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading KubeVirt, back up the current state of your resources. You can do this by exporting the current configuration:\n```bash\nkubectl get kubevirt -n kubevirt -o yaml > kubevirt-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of KubeVirt:\n```bash\nhelm repo update\nhelm upgrade kubevirt kubevirt/kubevirt --namespace kubevirt --version v1.8.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that all KubeVirt components are running correctly:\n```bash\nkubectl get pods -n kubevirt\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If KubeVirt pods are stuck in a CrashLoopBackOff state, check the logs of the affected pod to diagnose the issue:\n```bash\nkubectl logs <pod-name> -n kubevirt\n``` \nLook for error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "KubeVirt components not starting",
+        "description": "If KubeVirt components are not starting, check the events in the namespace for any errors:\n```bash\nkubectl get events -n kubevirt\n``` \nThis will help identify any resource constraints or configuration issues."
+      },
+      {
+        "title": "Resource limits causing issues",
+        "description": "If you suspect that resource limits are causing issues, check the resource usage of the KubeVirt pods:\n```bash\nkubectl top pods -n kubevirt\n``` \nAdjust the resource limits in `kubevirt-resources.yaml` if necessary and reapply the configuration."
+      },
+      {
+        "title": "Monitoring not working",
+        "description": "If monitoring is not functioning as expected, verify that the Prometheus and Grafana pods are running:\n```bash\nkubectl get pods -n kubevirt\n``` \nCheck the logs of the Prometheus pod for any errors:\n```bash\nkubectl logs <prometheus-pod-name> -n kubevirt\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kubewarden.json
+++ b/solutions/cncf-install/install-kubewarden.json
@@ -40,7 +40,53 @@
         "helm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --version v1.32.1",
         "# Example command to create a policy (customize as needed)\nkubectl apply -f your-admission-policy.yaml --namespace kubewarden"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kubewarden Controller release using Helm to remove the deployment from your cluster. Run the following command:\n```bash\nhelm uninstall kubewarden-controller --namespace kubewarden\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Kubewarden. Execute the following commands:\n```bash\nkubectl delete crd policies.kubewarden.io\nkubectl delete pvc --all --namespace kubewarden\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Kubewarden namespace and verify that it has been removed. Use the following commands:\n```bash\nkubectl delete namespace kubewarden\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Kubewarden Controller. You can export the current Helm release values with:\n```bash\nhelm get values kubewarden-controller --namespace kubewarden > backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kubewarden Controller to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --version v1.33.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, check that the Kubewarden Controller pod is running with the new version. Use this command:\n```bash\nkubectl get pods --namespace kubewarden\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Kubewarden Controller pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command to view logs:\n```bash\nkubectl logs <pod-name> --namespace kubewarden\n```"
+      },
+      {
+        "title": "Admission policies not being enforced",
+        "description": "If admission policies are not being enforced, ensure that the policies are correctly defined and applied. Verify with:\n```bash\nkubectl get policies --namespace kubewarden\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, confirm that you are using the correct namespace and release name. List all releases with:\n```bash\nhelm list --namespace kubewarden\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If the Kubewarden Controller is failing due to insufficient resources, check the resource limits and requests. Adjust them if necessary using:\n```bash\nhelm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --version v1.32.1\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kuma.json
+++ b/solutions/cncf-install/install-kuma.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kuma-control-plane --namespace kuma",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Kuma release using Helm to remove the deployment from the cluster:\n```bash\nhelm uninstall kuma --namespace kuma\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Kuma:\n```bash\nkubectl delete crd $(kubectl get crd | grep kuma.io | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Kuma namespace and verify that it has been removed:\n```bash\nkubectl delete namespace kuma\nkubectl get namespaces | grep kuma\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Kuma resources:\n```bash\nkubectl get all --namespace kuma -o yaml > kuma-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Kuma installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade kuma kuma/kuma --version v2.13.3 --namespace kuma\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Kuma pods are running the new version:\n```bash\nkubectl get pods --namespace kuma\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Kuma pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace kuma\n```"
+      },
+      {
+        "title": "Kuma control plane not reachable",
+        "description": "If you cannot access the Kuma control plane, ensure the service is running:\n```bash\nkubectl get svc --namespace kuma\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If you encounter resource allocation issues, check the resource limits set in the deployment:\n```bash\nkubectl describe deployment kuma-control-plane --namespace kuma\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to version conflicts, check the installed version and the available versions:\n```bash\nhelm list --namespace kuma\nhelm search repo kuma/kuma --versions\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kured.json
+++ b/solutions/cncf-install/install-kured.json
@@ -40,7 +40,53 @@
         "helm upgrade kured kured/kured --namespace <namespace> --set resources.limits.cpu=100m --set resources.limits.memory=128Mi",
         "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: kured\nrules:\n- apiGroups: [\"\"]\n  resources: [\"nodes\"]\n  verbs: [\"get\", \"list\", \"watch\", \"patch\"]\n- apiGroups: [\"\"]\n  resources: [\"pods\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n- apiGroups: [\"kubelet.k8s.io\"]\n  resources: [\"pods\"]\n  verbs: [\"create\", \"delete\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: kured\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: kured\nsubjects:\n- kind: ServiceAccount\n  name: default\n  namespace: <namespace>"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To uninstall Kured, first remove the Helm release using the following command. Replace `<namespace>` with your specified namespace:\n```bash\nhelm uninstall kured --namespace <namespace>\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, delete any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation:\n```bash\nkubectl delete crd kureds.kured.dev\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, if you no longer need the namespace, delete it and verify that all resources have been removed:\n```bash\nkubectl delete namespace <namespace>\nkubectl get all -n <namespace>\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current Helm release configuration. You can do this by exporting the current values:\n```bash\nhelm get values kured --namespace <namespace> > kured-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade Kured to the latest version. Replace `<namespace>` with your specified namespace:\n```bash\nhelm repo update\nhelm upgrade kured kured/kured --namespace <namespace> --version 1.22.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the pods to ensure that Kured is running the new version correctly:\n```bash\nkubectl get pods -n <namespace>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that Kured pods are in a CrashLoopBackOff state, you can diagnose the issue by checking the logs:\n```bash\nkubectl logs <pod-name> -n <namespace>\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Kured not draining nodes",
+        "description": "If Kured is not draining nodes as expected, check the Kured logs for any errors related to node cordoning:\n```bash\nkubectl logs <kured-pod-name> -n <namespace>\n```\nEnsure that the RBAC permissions are correctly set and that Kured has access to manage nodes."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, check the currently installed version and the version you are trying to upgrade to:\n```bash\nhelm list --namespace <namespace>\n```\nMake sure you are using a compatible version and try upgrading again."
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If Kured pods are being evicted due to resource limits, check the events in the namespace:\n```bash\nkubectl get events -n <namespace>\n```\nConsider adjusting the resource limits set during installation to provide more resources to the Kured pods."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kusionstack.json
+++ b/solutions/cncf-install/install-kusionstack.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kusion --namespace kusion\n# Add the following under spec.template.spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"",
         "kubectl port-forward svc/kusion --namespace kusion 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KusionStack release from the 'kusion' namespace using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims associated with KusionStack."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'kusion' namespace and verify that it has been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Create a backup of the current KusionStack release configuration."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the KusionStack release to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the KusionStack pods are running successfully after the upgrade."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue may occur if there are configuration errors or resource constraints. To diagnose, check the pod logs using the following command:\n```bash\nkubectl logs <pod-name> --namespace kusion\n```\nFix the underlying issue based on the logs."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the KusionStack service is not reachable, ensure that the service is running and the port forwarding is set up correctly. Check the service status with:\n```bash\nkubectl get svc --namespace kusion\n```\nIf the service is down, restart the deployment."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the upgrade, check the current version of the release with:\n```bash\nhelm list --namespace kusion\n```\nEnsure that you are upgrading to a compatible version."
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you receive an insufficient resources error, check the resource limits set in the deployment. You can view the current resource requests and limits with:\n```bash\nkubectl describe deployment kusion --namespace kusion\n```\nAdjust the resource limits if necessary."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-kyverno.json
+++ b/solutions/cncf-install/install-kyverno.json
@@ -40,7 +40,53 @@
         "helm upgrade kyverno kyverno/kyverno --namespace kyverno --set podSecurityStandard=baseline",
         "apiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: require-non-root\nspec:\n  validationFailureAction: enforce\n  rules:\n    - name: require-non-root\n      match:\n        resources:\n          kinds:\n            - Pod\n      validate:\n        message: \"Run as non-root user\"\n        pattern:\n          spec:\n            securityContext:\n              runAsUser: 1000"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Kyverno installation, first uninstall the Helm release using the following command. This will remove the deployment and associated resources:\n```bash\nhelm uninstall kyverno --namespace kyverno\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any Custom Resource Definitions (CRDs) that were created during the installation. This ensures that no leftover resources remain:\n```bash\nkubectl delete crd clusterpolicies.kyverno.io\nkubectl delete crd policies.kyverno.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the Kyverno namespace to clean up any remaining resources. Verify that the namespace has been deleted:\n```bash\nkubectl delete namespace kyverno\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Kyverno installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace kyverno -o yaml > kyverno-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade your Kyverno installation to the desired version:\n```bash\nhelm repo update\nhelm upgrade kyverno kyverno/kyverno --namespace kyverno --version v1.18.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, check that the Kyverno pods are running the new version successfully:\n```bash\nkubectl get pods --namespace kyverno\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that Kyverno pods are in a CrashLoopBackOff state, check the logs for more details on the failure:\n```bash\nkubectl logs <pod-name> --namespace kyverno\n```\nCommon issues include misconfigured policies or resource limits."
+      },
+      {
+        "title": "Kyverno policies not applying",
+        "description": "If your policies are not being enforced, verify that the policies are correctly applied and check the status:\n```bash\nkubectl get cpol --namespace kyverno\nkubectl describe cpol <policy-name> --namespace kyverno\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the upgrade, ensure that the version you are trying to upgrade to is compatible with your current installation. You can check the installed version with:\n```bash\nhelm list --namespace kyverno\n```"
+      },
+      {
+        "title": "Namespace not found error",
+        "description": "If you receive an error indicating that the namespace 'kyverno' is not found, ensure that the namespace exists and is correctly specified in your commands:\n```bash\nkubectl get namespaces\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-linkerd-viz.json
+++ b/solutions/cncf-install/install-linkerd-viz.json
@@ -44,7 +44,53 @@
         "kubectl get pods -n linkerd",
         "kubectl port-forward -n linkerd svc/linkerd-viz 8085:8085"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Linkerd Viz Helm release",
+        "description": "To cleanly remove the Linkerd Viz installation, first uninstall the Helm release using the following command:\n```bash\nhelm uninstall linkerd-viz --namespace linkerd\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any custom resource definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd --all\nkubectl delete pvc --all --namespace linkerd\n```"
+      },
+      {
+        "title": "Remove the Linkerd namespace and verify",
+        "description": "Finally, delete the Linkerd namespace and verify that it has been removed:\n```bash\nkubectl delete namespace linkerd\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of the Linkerd Viz release:\n```bash\nhelm get values linkerd-viz --namespace linkerd > linkerd-viz-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository and run the upgrade command",
+        "description": "Update the Helm repository and then upgrade the Linkerd Viz release to the latest version:\n```bash\nhelm repo update\nhelm upgrade linkerd-viz linkerd/linkerd-viz --namespace linkerd --version edge-26.3.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Linkerd Viz components are running correctly:\n```bash\nkubectl get pods -n linkerd\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that the Linkerd Viz pods are in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> -n linkerd\n``` \nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Linkerd Viz dashboard not accessible",
+        "description": "If you cannot access the Linkerd Viz dashboard, ensure that the port-forward command is running. You can restart it with:\n```bash\nkubectl port-forward -n linkerd svc/linkerd-viz 8085:8085\n``` \nThen, try accessing it again at http://localhost:8085."
+      },
+      {
+        "title": "Resource limits causing pod evictions",
+        "description": "If pods are being evicted due to resource limits, check the events in the namespace:\n```bash\nkubectl get events -n linkerd\n``` \nConsider adjusting the resource requests and limits in your values.yaml file and upgrading the release."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that the version specified is available in the Helm repository:\n```bash\nhelm search repo linkerd/linkerd-viz --versions\n``` \nThen, specify a valid version in the upgrade command."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-linkerd.json
+++ b/solutions/cncf-install/install-linkerd.json
@@ -40,7 +40,53 @@
         "linkerd dashboard --namespace linkerd",
         "helm upgrade linkerd-control-plane linkerd/linkerd-control-plane --namespace linkerd --values values.yaml"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Linkerd control plane, first uninstall the Helm release using the following command:\n```bash\nhelm uninstall linkerd-control-plane --namespace linkerd\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation. Run the following commands:\n```bash\nkubectl delete crd --all\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the Linkerd namespace and verify that it has been removed:\n```bash\nkubectl delete namespace linkerd\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of the Linkerd control plane. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace linkerd -o yaml > linkerd-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade the Linkerd control plane to the latest version:\n```bash\nhelm repo update\nhelm upgrade linkerd-control-plane linkerd/linkerd-control-plane --namespace linkerd --version edge-26.2.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the Linkerd control plane is running with the new version:\n```bash\nkubectl get pods --namespace linkerd\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see pods in the CrashLoopBackOff state, check the logs for more details:\n```bash\nkubectl logs <pod-name> --namespace linkerd\n``` \nLook for any error messages that might indicate configuration issues or resource constraints."
+      },
+      {
+        "title": "Linkerd dashboard not accessible",
+        "description": "If the Linkerd dashboard is not accessible, ensure that the dashboard service is running:\n```bash\nkubectl get svc --namespace linkerd\n``` \nIf the service is not running, check the logs of the dashboard pod for errors."
+      },
+      {
+        "title": "Control plane components not running",
+        "description": "If any control plane components are not running, check their status and logs:\n```bash\nkubectl get pods --namespace linkerd\nkubectl logs <pod-name> --namespace linkerd\n``` \nInvestigate any errors in the logs to identify the root cause."
+      },
+      {
+        "title": "Issues with service communication",
+        "description": "If you experience issues with service communication, check the Linkerd proxy logs for the affected services:\n```bash\nkubectl logs <pod-name> -c linkerd-proxy --namespace <service-namespace>\n``` \nLook for any indications of misconfiguration or network issues."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-litmus.json
+++ b/solutions/cncf-install/install-litmus.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment litmus-operator --namespace litmus",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Litmus release from the cluster using Helm. This will remove the deployment and associated resources created by the installation. Run the following command:\n```bash\nhelm uninstall litmus --namespace litmus\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. Execute the following commands:\n```bash\nkubectl delete crd experiments.litmuschaos.io\nkubectl delete crd chaosengines.litmuschaos.io\nkubectl delete crd chaosresults.litmuschaos.io\nkubectl delete pvc --all --namespace litmus\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'litmus' namespace to clean up any remaining resources. After deletion, verify that the namespace has been removed. Use the following commands:\n```bash\nkubectl delete namespace litmus\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Litmus installation. You can use the following command to export the current configuration:\n```bash\nkubectl get all --namespace litmus -o yaml > litmus-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Litmus release to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade litmus litmuschaos/litmus --namespace litmus --version 3.27.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the Litmus pods are running correctly with the new version. Execute the following command:\n```bash\nkubectl get pods --namespace litmus\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Litmus pods are stuck in a CrashLoopBackOff state, check the logs of the affected pod to diagnose the issue. Use the following command:\n```bash\nkubectl logs <pod-name> --namespace litmus\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Litmus dashboard not accessible",
+        "description": "If you cannot access the Litmus dashboard, ensure that the port forwarding is set up correctly. Verify the service status with:\n```bash\nkubectl get svc --namespace litmus\n```\nIf the service is not running, check the deployment status and logs for errors."
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If pods are being evicted due to resource limits, check the events in the namespace to identify the cause. Run:\n```bash\nkubectl get events --namespace litmus\n```\nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found when trying to uninstall or upgrade, verify the release name and namespace. List all Helm releases with:\n```bash\nhelm list --namespace litmus\n```\nEnsure that 'litmus' is listed and check for any typos."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-logging-operator-kube-logging.json
+++ b/solutions/cncf-install/install-logging-operator-kube-logging.json
@@ -40,7 +40,53 @@
         "kubectl create role logging-operator-role --verb=get,list,watch,create,update,patch,delete --resource=logs --namespace=logging\nkubectl create rolebinding logging-operator-rolebinding --role=logging-operator-role --serviceaccount=logging:default --namespace=logging",
         "helm upgrade logging-operator kube-logging/logging-operator --namespace logging --set resources.limits.cpu=500m --set resources.limits.memory=512Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Logging Operator Helm release from the specified namespace to stop all associated resources and deployments."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'logging' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources of the Logging Operator."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and execute the upgrade command to install the latest version of the Logging Operator."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Logging Operator pods are running the new version correctly in the specified namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Logging Operator pods are in a CrashLoopBackOff state, check the logs for errors using the following command:\n```bash\nkubectl logs <pod-name> -n logging\n```"
+      },
+      {
+        "title": "RBAC permission issues",
+        "description": "If you encounter permission errors, ensure that the Role and RoleBinding are correctly set up. Verify with:\n```bash\nkubectl get role -n logging\nkubectl get rolebinding -n logging\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to Out Of Memory (OOM) issues, consider increasing the memory limits. Check current resource usage with:\n```bash\nkubectl top pods -n logging\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for version compatibility and ensure that the Helm repository is updated. Run:\n```bash\nhelm repo update\nhelm history logging-operator -n logging\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-longhorn.json
+++ b/solutions/cncf-install/install-longhorn.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/longhorn-frontend -n longhorn-system 8080:80",
         "kubectl edit deployment longhorn-manager -n longhorn-system"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Longhorn installation, first uninstall the Helm release using the following command:\n```bash\nhelm uninstall longhorn --namespace longhorn-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove the Custom Resource Definitions (CRDs) and any persistent volume claims (PVCs) that were created by Longhorn:\n```bash\nkubectl delete crd volumes.longhorn.io\nkubectl delete crd engines.longhorn.io\nkubectl delete crd replicas.longhorn.io\nkubectl delete crd settings.longhorn.io\nkubectl delete pvc --all -n longhorn-system\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the Longhorn namespace and verify that it has been removed:\n```bash\nkubectl delete namespace longhorn-system\nkubectl get namespaces | grep longhorn-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading Longhorn, it's important to back up your current state. You can create a backup of your existing Longhorn volumes using:\n```bash\nkubectl get volumes.longhorn.io -n longhorn-system -o yaml > longhorn-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Longhorn Helm repository and upgrade the installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version v1.12.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that all Longhorn pods are running the new version:\n```bash\nkubectl get pods -n longhorn-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see Longhorn pods in a CrashLoopBackOff state, check the logs for the failing pod:\n```bash\nkubectl logs <pod-name> -n longhorn-system\n```\nLook for error messages that indicate the cause of the crash."
+      },
+      {
+        "title": "Longhorn UI not accessible",
+        "description": "If you cannot access the Longhorn UI, ensure that the port-forward command is running. If it is, check if the service is up:\n```bash\nkubectl get svc longhorn-frontend -n longhorn-system\n```"
+      },
+      {
+        "title": "Volume not attaching",
+        "description": "If a volume is not attaching to a pod, check the volume status:\n```bash\nkubectl get volumes.longhorn.io -n longhorn-system\n```\nEnsure that the volume is in 'attached' state and check for any events related to the volume."
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you encounter an 'insufficient resources' error, verify the resource limits set for Longhorn components and adjust them if necessary:\n```bash\nkubectl describe deployment longhorn-manager -n longhorn-system\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-loxilb.json
+++ b/solutions/cncf-install/install-loxilb.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment loxilb --namespace loxilb",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the loxilb Helm release from the 'loxilb' namespace using the following command:\n```bash\nhelm uninstall loxilb --namespace loxilb\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with loxilb. First, delete the CRDs:\n```bash\nkubectl delete crd loxilb.*\n```\nThen, delete any PVCs in the 'loxilb' namespace:\n```bash\nkubectl delete pvc --all --namespace loxilb\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'loxilb' namespace to clean up all resources:\n```bash\nkubectl delete namespace loxilb\n```\nVerify that the namespace has been removed:\n```bash\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it is important to back up the current state of the loxilb installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace loxilb -o yaml > loxilb-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the loxilb installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade loxilb loxilb/loxilb --namespace loxilb --version v0.9.8.5\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check if the loxilb pods are running the new version successfully:\n```bash\nkubectl get pods --namespace loxilb\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the loxilb pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace loxilb\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the loxilb service, ensure that the port forwarding is set up correctly. Check the service status:\n```bash\nkubectl get svc --namespace loxilb\n```\nVerify that the correct ports are being forwarded."
+      },
+      {
+        "title": "High resource usage",
+        "description": "If you notice high CPU or memory usage, check the resource limits set for the loxilb deployment:\n```bash\nkubectl describe deployment loxilb --namespace loxilb\n```\nConsider adjusting the resource limits in the deployment configuration."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure that you are using the correct namespace:\n```bash\nhelm list --namespace loxilb\n```\nIf the release does not appear, it may not have been installed correctly."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-meshery.json
+++ b/solutions/cncf-install/install-meshery.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/meshery --namespace meshery 9081:9081",
         "kubectl edit deployment meshery --namespace meshery"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Meshery installation, first uninstall the Helm release with the following command:\n```bash\nhelm uninstall meshery --namespace meshery\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Meshery:\n```bash\nkubectl delete crd mesheryconfigs.meshery.io\nkubectl delete crd mesherypatterns.meshery.io\nkubectl delete crd mesheryservices.meshery.io\nkubectl delete pvc --all --namespace meshery\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'meshery' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace meshery\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Meshery installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace meshery -o yaml > meshery-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Meshery to the latest version:\n```bash\nhelm repo update\nhelm upgrade meshery meshery/meshery --namespace meshery --version v0.8.206\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Meshery pods are running the new version:\n```bash\nkubectl get pods --namespace meshery\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Meshery pods are in a 'CrashLoopBackOff' state, check the logs for the specific pod:\n```bash\nkubectl logs <pod-name> --namespace meshery\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Meshery UI, ensure that the service is running and the port-forwarding command is active:\n```bash\nkubectl get svc --namespace meshery\n```\nIf the service is not running, check the pod status and logs for issues."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource usage of the Meshery pods:\n```bash\nkubectl top pods --namespace meshery\n```\nConsider adjusting the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade fails, check the output for specific error messages. You can also check the current Helm release status:\n```bash\nhelm status meshery --namespace meshery\n```\nIf needed, you can roll back to the previous version:\n```bash\nhelm rollback meshery <revision-number> --namespace meshery\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-metal3-io.json
+++ b/solutions/cncf-install/install-metal3-io.json
@@ -40,7 +40,53 @@
         "cat <<EOF | kubectl apply -f -\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: metal3\n  name: baremetal-operator-role\nrules:\n- apiGroups: [\"metal3.io\"]\n  resources: [\"baremetalhosts\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"delete\"]\nEOF\n\ncat <<EOF | kubectl apply -f -\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: baremetal-operator-rolebinding\n  namespace: metal3\nsubjects:\n- kind: ServiceAccount\n  name: default\n  namespace: metal3\nroleRef:\n  kind: Role\n  name: baremetal-operator-role\n  apiGroup: rbac.authorization.k8s.io\nEOF",
         "kubectl logs -l app=baremetal-operator -n metal3"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Bare Metal Operator release using Helm to remove the deployment from the cluster. This command will also remove the associated resources created by the release.\n```bash\nhelm uninstall baremetal-operator --namespace metal3\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) related to the Bare Metal Operator and clean up any persistent volume claims (PVCs) if applicable. Use the following commands:\n```bash\nkubectl delete crd baremetalhosts.metal3.io\nkubectl delete pvc --all -n metal3\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Remove the namespace used for the Bare Metal Operator and verify that it has been deleted. Use the following commands:\n```bash\nkubectl delete namespace metal3\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Bare Metal Operator and any associated resources. You can use the following command to export the current configuration:\n```bash\nkubectl get all -n metal3 -o yaml > baremetal-operator-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Bare Metal Operator to the latest version. Use the following commands:\n```bash\nhelm repo update\nhelm upgrade baremetal-operator metal3/baremetal-operator --namespace metal3 --version v0.12.3\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Bare Metal Operator pods are running the new version successfully. Use the following command to verify:\n```bash\nkubectl get pods -n metal3\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Bare Metal Operator pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command to diagnose:\n```bash\nkubectl logs -l app=baremetal-operator -n metal3\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission denied errors, ensure that the Role and RoleBinding are correctly configured. Check the Role and RoleBinding with:\n```bash\nkubectl get role -n metal3\nkubectl get rolebinding -n metal3\n```\nIf necessary, recreate them using the provided configuration."
+      },
+      {
+        "title": "Operator not responding",
+        "description": "If the Bare Metal Operator is not responding, check the status of the deployment and pods:\n```bash\nkubectl get deployment baremetal-operator -n metal3\nkubectl get pods -n metal3\n```\nEnsure that the pods are running and not in a failed state."
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you receive errors related to missing Custom Resource Definitions (CRDs), ensure that the CRDs were installed correctly. Check the CRDs with:\n```bash\nkubectl get crd\n```\nIf the CRDs are missing, reinstall them using the Helm chart or manually apply the CRD definitions."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-metallb.json
+++ b/solutions/cncf-install/install-metallb.json
@@ -40,7 +40,53 @@
         "cat <<EOF | kubectl apply -f -\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: metallb-system\n  name: config\ndata:\n  config: |\n    address-pools:\n    - name: default\n      protocol: layer2\n      addresses:\n      - <YOUR_IP_RANGE>\nEOF",
         "kubectl get svc --namespace metallb-system"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the MetalLB release from the `metallb-system` namespace using Helm to remove all associated resources.\n```bash\nhelm uninstall metallb --namespace metallb-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete the Custom Resource Definitions (CRDs) associated with MetalLB to ensure no lingering resources remain.\n```bash\nkubectl delete crd configmaps.metallb.io\nkubectl delete crd addresspools.metallb.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `metallb-system` namespace and verify that it has been removed successfully.\n```bash\nkubectl delete namespace metallb-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration of MetalLB by exporting the ConfigMap.\n```bash\nkubectl get configmap config -n metallb-system -o yaml > metallb-config-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade MetalLB to the latest version. Ensure you specify the desired version.\n```bash\nhelm repo update\nhelm upgrade metallb metallb/metallb --namespace metallb-system --version v0.15.4\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the MetalLB pods are running the new version and are healthy after the upgrade.\n```bash\nkubectl get pods --namespace metallb-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If MetalLB pods are in a CrashLoopBackOff state, check the logs for errors that may indicate configuration issues.\n```bash\nkubectl logs <pod-name> --namespace metallb-system\n```"
+      },
+      {
+        "title": "IP address not allocated",
+        "description": "If MetalLB is not allocating IP addresses, verify that the ConfigMap is correctly configured and that the IP range is valid.\n```bash\nkubectl describe configmap config -n metallb-system\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If services exposed by MetalLB are not reachable, check the service configuration and ensure that the MetalLB pods are running.\n```bash\nkubectl get svc --namespace metallb-system\nkubectl get pods --namespace metallb-system\n```"
+      },
+      {
+        "title": "MetalLB not responding to ARP requests",
+        "description": "If MetalLB is not responding to ARP requests, ensure that your network configuration allows ARP broadcasts and that MetalLB is configured correctly.\n```bash\nkubectl get pods --namespace metallb-system -o wide\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-microcks.json
+++ b/solutions/cncf-install/install-microcks.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/microcks --namespace microcks 8080:80",
         "kubectl edit deployment microcks --namespace microcks"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Microcks release from the Kubernetes cluster with the following command:\n```bash\nhelm uninstall microcks --namespace microcks\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Microcks:\n```bash\nkubectl delete crd microcks.microcks.io\nkubectl delete pvc --all --namespace microcks\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'microcks' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace microcks\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Microcks configuration and resources:\n```bash\nkubectl get all --namespace microcks -o yaml > microcks-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Microcks to the latest version:\n```bash\nhelm repo update\nhelm upgrade microcks microcks/microcks --namespace microcks --version 1.14.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Microcks pods are running and verify the upgrade:\n```bash\nkubectl get pods --namespace microcks\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Microcks pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace microcks\n```\nLook for any error messages that indicate what might be wrong."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Microcks service is not reachable, verify that the service is running:\n```bash\nkubectl get svc --namespace microcks\n```\nEnsure that the service is correctly configured and that the port-forwarding command is still active."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being OOMKilled, check the resource usage:\n```bash\nkubectl top pods --namespace microcks\n```\nConsider increasing the memory limits in the deployment configuration."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure you are using the correct namespace:\n```bash\nhelm list --namespace microcks\n```\nIf the release is not listed, it may need to be installed again."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-monocle.json
+++ b/solutions/cncf-install/install-monocle.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment monocle --namespace monocle\n# Add the following under spec.containers.resources:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"\n#   requests:\n#     cpu: \"250m\"\n#     memory: \"256Mi\"",
         "# In your application code, import and set up Monocle:\nfrom monocle_apptrace.instrumentor import setup_monocle_telemetry\nsetup_monocle_telemetry()"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Monocle Helm release from your Kubernetes cluster to remove the deployment and associated resources."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Monocle namespace and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Monocle installation to ensure you can roll back if necessary."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Monocle Helm repository and run the upgrade command to install the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Monocle pods to ensure they are running the upgraded version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This indicates that the Monocle pods are failing to start. Check the logs for errors using the following command: \n```bash\nkubectl logs <pod-name> --namespace monocle\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the Monocle service is not reachable, verify the service configuration and check for any network policies that might be blocking access. Use: \n```bash\nkubectl get svc --namespace monocle\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource requests and limits set for the Monocle deployment. Use: \n```bash\nkubectl describe deployment monocle --namespace monocle\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade fails, check for any version compatibility issues or existing resources that may conflict. Use: \n```bash\nhelm history monocle --namespace monocle\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-nats.json
+++ b/solutions/cncf-install/install-nats.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment nats --namespace nats",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the NATS installation, uninstall the Helm release using the following command. This will delete all associated Kubernetes resources created by the release.\n```bash\nhelm uninstall nats --namespace nats\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) created by NATS, clean them up using the following commands:\n```bash\nkubectl delete crd natsclusters.nats.io\nkubectl delete pvc --all --namespace nats\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'nats' namespace to remove any remaining resources and verify that it has been deleted:\n```bash\nkubectl delete namespace nats\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's crucial to back up the current state of your NATS deployment. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace nats -o yaml > nats-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the NATS release to the desired version. Replace '2.12.5' with the version you wish to upgrade to:\n```bash\nhelm repo update\nhelm upgrade nats nats/nats --version 2.12.5 --namespace nats\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the NATS pods are running the new version successfully:\n```bash\nkubectl get pods --namespace nats\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your NATS pods are in a CrashLoopBackOff state, check the pod logs for errors:\n```bash\nkubectl logs <pod-name> --namespace nats\n```\nCommon issues may include misconfigured resource limits or insufficient permissions."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the NATS service, ensure that the service is running and the correct ports are exposed:\n```bash\nkubectl get svc --namespace nats\n```\nIf the service is not running, check the deployment status for errors."
+      },
+      {
+        "title": "High memory usage",
+        "description": "If you notice high memory usage, review the resource limits set for the NATS deployment. You can check the current resource usage with:\n```bash\nkubectl top pods --namespace nats\n```\nConsider adjusting the resource limits in the deployment."
+      },
+      {
+        "title": "Unable to connect to NATS",
+        "description": "If you are unable to connect to the NATS server, verify the port-forwarding command is running correctly:\n```bash\nkubectl port-forward svc/nats --namespace nats 4222:4222\n```\nEnsure there are no firewall rules blocking the connection."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-node-exporter.json
+++ b/solutions/cncf-install/install-node-exporter.json
@@ -40,7 +40,53 @@
         "kubectl port-forward service/node-exporter 9100:9100 --namespace monitoring",
         "kubectl edit deployment node-exporter --namespace monitoring\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     cpu: 100m\n#     memory: 128Mi\n#   requests:\n#     cpu: 50m\n#     memory: 64Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Node Exporter Helm release from the monitoring namespace to remove the deployment and associated resources."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Node Exporter."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the monitoring namespace and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Node Exporter deployment."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of Node Exporter."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Node Exporter pod is running the new version properly in the monitoring namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when the Node Exporter pod fails to start repeatedly. Check the pod logs for errors using the following command:\n```bash\nkubectl logs <pod-name> --namespace monitoring\n```"
+      },
+      {
+        "title": "Metrics not being collected",
+        "description": "If metrics are not being collected, verify that the Node Exporter service is running and accessible. Check the service status with:\n```bash\nkubectl get services --namespace monitoring\n```"
+      },
+      {
+        "title": "Port forwarding not working",
+        "description": "If you cannot access Node Exporter metrics via port forwarding, ensure that the port forwarding command is still running and check for any firewall rules that may be blocking access."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the Node Exporter pod is being terminated due to Out Of Memory (OOM) errors, consider adjusting the resource limits set in the deployment. Check the pod status with:\n```bash\nkubectl describe pod <pod-name> --namespace monitoring\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-notary-project.json
+++ b/solutions/cncf-install/install-notary-project.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment notation --namespace notation",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Notation release, execute the following command to uninstall it from the 'notation' namespace:\n```bash\nhelm uninstall notation --namespace notation\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volume claims (PVCs) associated with Notation, clean them up using:\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace notation\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'notation' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace notation\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, create a backup of the current Notation release configuration:\n```bash\nhelm get values notation --namespace notation > notation-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Notation to the latest version:\n```bash\nhelm repo update\nhelm upgrade notation notary/notation --namespace notation --version v1.3.3\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Notation pod is running the new version successfully:\n```bash\nkubectl get pods --namespace notation\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Notation pod is in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace notation\n``` \nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Notation service, ensure that the port-forwarding is set up correctly:\n```bash\nkubectl port-forward svc/notation --namespace notation 8080:80\n``` \nAlso, verify that the service is running:\n```bash\nkubectl get svc --namespace notation\n```"
+      },
+      {
+        "title": "Insufficient resource limits",
+        "description": "If the Notation pod is failing due to resource limits, check the resource usage:\n```bash\nkubectl top pod --namespace notation\n``` \nConsider increasing the resource limits in the deployment."
+      },
+      {
+        "title": "Version mismatch errors",
+        "description": "If you encounter version mismatch errors, verify the installed version of Notation:\n```bash\nhelm list --namespace notation\n``` \nEnsure that the version you are trying to upgrade to is compatible with your current setup."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-oauth2-proxy.json
+++ b/solutions/cncf-install/install-oauth2-proxy.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/oauth2-proxy --namespace oauth2-proxy --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward svc/oauth2-proxy --namespace oauth2-proxy 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the OAuth2 Proxy release, use the following command to uninstall it from the specified namespace:\n```bash\nhelm uninstall oauth2-proxy --namespace oauth2-proxy\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent resources that were created during the installation, you can remove them with the following commands:\n```bash\nkubectl delete crd oauth2proxies.oauth2-proxy.github.com\nkubectl delete pvc --all --namespace oauth2-proxy\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the namespace if it is no longer needed and verify that it has been deleted:\n```bash\nkubectl delete namespace oauth2-proxy\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it is a good practice to back up the current configuration and state of the OAuth2 Proxy. You can do this by exporting the current values:\n```bash\nhelm get values oauth2-proxy --namespace oauth2-proxy > oauth2-proxy-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and then upgrade the OAuth2 Proxy to the latest version:\n```bash\nhelm repo update\nhelm upgrade oauth2-proxy oauth2-proxy/oauth2-proxy --version 7.15.0 --namespace oauth2-proxy\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the OAuth2 Proxy pod is running the new version:\n```bash\nkubectl get pods --namespace oauth2-proxy\nkubectl describe deployment oauth2-proxy --namespace oauth2-proxy | grep Image\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the OAuth2 Proxy pods are stuck in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace oauth2-proxy\n```\nLook for configuration issues or missing environment variables."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, ensure that the port forwarding is set up correctly. You can check the service status with:\n```bash\nkubectl get svc --namespace oauth2-proxy\n```\nVerify that the correct ports are being forwarded."
+      },
+      {
+        "title": "Authentication errors",
+        "description": "If you encounter authentication errors, check the OAuth2 Proxy configuration. Review the logs for any authentication-related messages:\n```bash\nkubectl logs <pod-name> --namespace oauth2-proxy | grep 'authentication'\n```"
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If your pods are being evicted due to resource limits, check the events in the namespace:\n```bash\nkubectl get events --namespace oauth2-proxy\n```\nConsider adjusting the resource limits set for the deployment."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-open-policy-agent-opa.json
+++ b/solutions/cncf-install/install-open-policy-agent-opa.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment opa --namespace <your-namespace>",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\"\n  requests:\n    memory: \"256Mi\"\n    cpu: \"250m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the OPA release from your Kubernetes cluster, use the following command, replacing `<your-namespace>` with your actual namespace:\n```bash\nhelm uninstall opa --namespace <your-namespace>\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent resources associated with OPA, remove them using the following commands:\n```bash\nkubectl delete crd <crd-name>\n# Replace <crd-name> with the actual CRD name if applicable\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "To remove the namespace created for OPA and verify that all resources are deleted, run the following commands:\n```bash\nkubectl delete namespace <your-namespace>\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading OPA, it's a good practice to back up the current configuration and state. You can export the current Helm release with:\n```bash\nhelm get all opa --namespace <your-namespace> > opa-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade OPA to the desired version. Use the following commands:\n```bash\nhelm repo update\nhelm upgrade opa open-policy-agent/opa --namespace <your-namespace> --version v1.15.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the OPA pod is running the new version successfully:\n```bash\nkubectl get pods --namespace <your-namespace>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the OPA pod is in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace <your-namespace>\n# Replace <pod-name> with the actual pod name\n``` \nLook for any configuration errors or resource limit issues."
+      },
+      {
+        "title": "RBAC permissions issue",
+        "description": "If OPA cannot access required resources, verify the Role and RoleBinding:\n```bash\nkubectl get role opa-role --namespace <your-namespace> -o yaml\nkubectl get rolebinding opa-role-binding --namespace <your-namespace> -o yaml\n``` \nEnsure that the permissions are correctly set."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure that you are using the correct namespace:\n```bash\nhelm list --namespace <your-namespace>\n``` \nThis command will show all releases in the specified namespace."
+      },
+      {
+        "title": "Resource limits causing OPA to be evicted",
+        "description": "If OPA is being evicted due to resource limits, check the events for the pod:\n```bash\nkubectl describe pod <pod-name> --namespace <your-namespace>\n``` \nLook for eviction messages and consider adjusting the resource limits."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-opencost.json
+++ b/solutions/cncf-install/install-opencost.json
@@ -40,7 +40,53 @@
         "helm upgrade opencost opencost/opencost --namespace opencost --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "kubectl port-forward svc/opencost-ui --namespace opencost 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenCost release from your Kubernetes cluster using the following command. This will remove all resources associated with the release, but not CRDs or persistent volumes:\n```bash\nhelm uninstall opencost --namespace opencost\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources that were created during the installation. Use the following commands:\n```bash\nkubectl delete crd opencosts.opencost.dev\nkubectl delete pvc --all --namespace opencost\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the OpenCost namespace and verify that it has been removed. Use the following commands:\n```bash\nkubectl delete namespace opencost\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your OpenCost installation. You can do this by exporting the current configuration:\n```bash\nhelm get values opencost --namespace opencost > opencost-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the OpenCost Helm repository and upgrade the OpenCost release to the latest version. Use the following commands:\n```bash\nhelm repo update\nhelm upgrade opencost opencost/opencost --namespace opencost --version v1.120.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the OpenCost pods are running successfully with the following command:\n```bash\nkubectl get pods --namespace opencost\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that OpenCost pods are stuck in a CrashLoopBackOff state, you can diagnose the issue by checking the logs of the pod:\n```bash\nkubectl logs <pod-name> --namespace opencost\n```\nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the OpenCost UI, ensure that the service is running and check the service details:\n```bash\nkubectl get svc --namespace opencost\nkubectl describe svc opencost-ui --namespace opencost\n```\nMake sure the port-forward command is still active."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If OpenCost is unable to start due to insufficient resources, check the resource requests and limits set for the deployment:\n```bash\nkubectl get deployment opencost --namespace opencost -o yaml\n```\nYou may need to adjust the resource limits or allocate more resources to your cluster."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check the error message for details. You can also review the current Helm release status:\n```bash\nhelm status opencost --namespace opencost\n```\nIf necessary, you can roll back to the previous version using:\n```bash\nhelm rollback opencost --namespace opencost\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-openebs.json
+++ b/solutions/cncf-install/install-openebs.json
@@ -40,7 +40,53 @@
         "kubectl apply -f https://openebs.github.io/charts/openebs-rbac.yaml -n openebs",
         "helm upgrade openebs openebs/openebs --namespace openebs --set openebs-crds.csi.volumeSnapshots.enabled=true --set localpv-provisioner.rbac.create=true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenEBS release from the 'openebs' namespace using Helm. This will remove all associated resources managed by Helm.\n```bash\nhelm uninstall openebs --namespace openebs\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete the Custom Resource Definitions (CRDs) and any persistent volume claims (PVCs) that were created by OpenEBS to ensure a complete cleanup.\n```bash\nkubectl delete crd --all\nkubectl delete pvc --all -n openebs\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'openebs' namespace to remove any remaining resources and verify that it has been deleted.\n```bash\nkubectl delete namespace openebs\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your OpenEBS installation by exporting the existing configurations and resources.\n```bash\nkubectl get all -n openebs -o yaml > openebs-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the OpenEBS Helm repository and then upgrade the OpenEBS installation to the latest version.\n```bash\nhelm repo update\nhelm upgrade openebs openebs/openebs --version 4.5.0 --namespace openebs\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the OpenEBS pods to ensure that they are running the new version and are healthy.\n```bash\nkubectl get pods -n openebs\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that OpenEBS pods are stuck in a CrashLoopBackOff state, check the logs of the affected pod for errors.\n```bash\nkubectl logs <pod-name> -n openebs\n```"
+      },
+      {
+        "title": "Persistent Volume Claims not binding",
+        "description": "If PVCs are not binding, verify that the storage class is correctly configured and available. Check the PVC status and describe it for more details.\n```bash\nkubectl get pvc -n openebs\nkubectl describe pvc <pvc-name> -n openebs\n```"
+      },
+      {
+        "title": "RBAC issues preventing pod creation",
+        "description": "If you encounter RBAC-related errors, ensure that the RBAC resources are applied correctly. Check the roles and role bindings.\n```bash\nkubectl get roles -n openebs\nkubectl get rolebindings -n openebs\n```"
+      },
+      {
+        "title": "High resource usage by OpenEBS components",
+        "description": "If OpenEBS components are consuming too many resources, review the resource limits set in the Helm values and adjust them accordingly.\n```bash\nkubectl top pods -n openebs\nhelm get values openebs --namespace openebs\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-openfga.json
+++ b/solutions/cncf-install/install-openfga.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment openfga --namespace openfga --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward service/openfga --namespace openfga 8080:8080"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenFGA release from the cluster using Helm. This will remove the deployment and associated resources, but not CRDs or persistent resources yet.\n```bash\nhelm uninstall openfga --namespace openfga\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation of OpenFGA. This ensures that all resources are cleaned up.\n```bash\nkubectl delete crd openfgas.openfga.dev\nkubectl delete pvc --all --namespace openfga\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'openfga' namespace to remove any remaining resources and verify that it has been deleted successfully.\n```bash\nkubectl delete namespace openfga\nkubectl get namespaces | grep openfga\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and any important data. You can use the following command to export the current Helm release configuration.\n```bash\nhelm get values openfga --namespace openfga > openfga-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts and then upgrade OpenFGA to the desired version.\n```bash\nhelm repo update\nhelm upgrade openfga openfga/openfga --version 1.12.0 --namespace openfga\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check if the OpenFGA pods are running the new version successfully in the 'openfga' namespace.\n```bash\nkubectl get pods --namespace openfga\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the OpenFGA pods are in a CrashLoopBackOff state, check the logs for more details on the failure.\n```bash\nkubectl logs <pod-name> --namespace openfga\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the OpenFGA service, ensure that the port forwarding is set up correctly and that the service is running.\n```bash\nkubectl get svc --namespace openfga\nkubectl port-forward service/openfga --namespace openfga 8080:8080\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the OpenFGA pods are not starting due to insufficient resources, check the resource requests and limits set on the deployment. You may need to adjust them based on your cluster capacity.\n```bash\nkubectl describe deployment openfga --namespace openfga\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade fails, check for any errors in the output. You can also check the current Helm release status and rollback if necessary.\n```bash\nhelm status openfga --namespace openfga\nhelm rollback openfga <revision-number> --namespace openfga\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-openfunction.json
+++ b/solutions/cncf-install/install-openfunction.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment openfunction --namespace openfunction",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenFunction release from the 'openfunction' namespace using the following command:\n```bash\nhelm uninstall openfunction --namespace openfunction\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with OpenFunction:\n```bash\nkubectl delete crd $(kubectl get crd | grep openfunction | awk '{print $1}')\nkubectl delete pvc --all --namespace openfunction\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'openfunction' namespace and verify its removal:\n```bash\nkubectl delete namespace openfunction\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of OpenFunction by exporting the configuration:\n```bash\nkubectl get all --namespace openfunction -o yaml > openfunction-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade OpenFunction to the latest version:\n```bash\nhelm repo update\nhelm upgrade openfunction openfunction/openfunction --namespace openfunction --version v1.3.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the OpenFunction pods are running the new version successfully:\n```bash\nkubectl get pods --namespace openfunction\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the OpenFunction pods are in a CrashLoopBackOff state, check the logs for more details:\n```bash\nkubectl logs <pod-name> --namespace openfunction\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, verify that the service is running and check the endpoints:\n```bash\nkubectl get svc --namespace openfunction\nkubectl get endpoints <service-name> --namespace openfunction\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If you encounter resource allocation issues, check the resource usage and limits:\n```bash\nkubectl describe deployment openfunction --namespace openfunction\nkubectl top pods --namespace openfunction\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, ensure you are using the correct namespace:\n```bash\nhelm list --namespace openfunction\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-opengemini.json
+++ b/solutions/cncf-install/install-opengemini.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment opengemini --namespace opengemini",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the openGemini release from the Kubernetes cluster using the following command:\n```bash\nhelm uninstall opengemini --namespace opengemini\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with openGemini:\n```bash\nkubectl delete crd opengemini.*\nkubectl delete pvc --all --namespace opengemini\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'opengemini' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace opengemini\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, create a backup of the current release configuration:\n```bash\nhelm get values opengemini --namespace opengemini > opengemini-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the openGemini release to the latest version:\n```bash\nhelm repo update\nhelm upgrade opengemini opengemini/opengemini --namespace opengemini --version v1.5.3\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the openGemini pods are running the new version:\n```bash\nkubectl get pods --namespace opengemini\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the openGemini pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace opengemini\n``` \nLook for any error messages that indicate configuration issues or resource limits."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access openGemini through port-forwarding, ensure the service is running:\n```bash\nkubectl get svc --namespace opengemini\n``` \nIf the service is not running, check the deployment status and logs."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If pods are failing due to insufficient resources, check the resource requests and limits:\n```bash\nkubectl describe deployment opengemini --namespace opengemini\n``` \nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace opengemini\n``` \nEnsure you are using the correct release name 'opengemini'."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-openkruise.json
+++ b/solutions/cncf-install/install-openkruise.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment kruise-controller-manager -n kruise-system",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenKruise release from the Kubernetes cluster using Helm with the following command:\n```bash\nhelm uninstall kruise --namespace kruise-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) associated with OpenKruise and any persistent volumes if applicable:\n```bash\nkubectl delete crd kruise*.kruise.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'kruise-system' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace kruise-system\nkubectl get namespaces | grep kruise-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the OpenKruise installation. You can use the following command to export the current configuration:\n```bash\nkubectl get all -n kruise-system -o yaml > kruise-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade OpenKruise to the latest version:\n```bash\nhelm repo update\nhelm upgrade kruise kruise/kruise --namespace kruise-system --version v1.9.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the OpenKruise pods are running the new version successfully:\n```bash\nkubectl get pods -n kruise-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If OpenKruise pods are stuck in a CrashLoopBackOff state, check the logs for the failing pod:\n```bash\nkubectl logs <pod-name> -n kruise-system\n```\nInvestigate the logs for errors and adjust the configuration as necessary."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, check the currently installed version:\n```bash\nhelm list --namespace kruise-system\n```\nEnsure that the version you are trying to upgrade to is compatible with the existing installation."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you experience RBAC permission issues, verify the applied RBAC configuration:\n```bash\nkubectl get clusterrolebindings | grep kruise\nkubectl get roles -n kruise-system\n```"
+      },
+      {
+        "title": "Resource limits causing pod evictions",
+        "description": "If pods are being evicted due to resource limits, check the resource usage:\n```bash\nkubectl top pods -n kruise-system\n```\nAdjust the resource limits in the deployment configuration as necessary."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-opentelemetry-collector.json
+++ b/solutions/cncf-install/install-opentelemetry-collector.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment otel-collector --namespace otel-collector",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenTelemetry Collector release using Helm to remove the deployment and associated resources:\n```bash\nhelm uninstall otel-collector --namespace otel-collector\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If any Custom Resource Definitions (CRDs) were created during the installation, you can delete them with the following command:\n```bash\nkubectl delete crd <crd-name>\n```\nReplace `<crd-name>` with the actual name of the CRDs. Additionally, if there are any persistent volume claims (PVCs) associated with the deployment, remove them:\n```bash\nkubectl delete pvc --all --namespace otel-collector\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "If the namespace was created specifically for the OpenTelemetry Collector and is no longer needed, delete it:\n```bash\nkubectl delete namespace otel-collector\n```\nVerify that the namespace has been removed:\n```bash\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current configuration and state of the OpenTelemetry Collector:\n```bash\nkubectl get all --namespace otel-collector -o yaml > otel-collector-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the OpenTelemetry Collector to the latest version:\n```bash\nhelm repo update\nhelm upgrade otel-collector open-telemetry/opentelemetry-collector --namespace otel-collector --version v0.147.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the OpenTelemetry Collector pod is running the new version:\n```bash\nkubectl get pods --namespace otel-collector\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the OpenTelemetry Collector pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace otel-collector\n```\nReplace `<pod-name>` with the name of the pod. Look for configuration errors or resource issues."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the OpenTelemetry Collector service, ensure that the service is running:\n```bash\nkubectl get svc --namespace otel-collector\n```\nIf the service is not running, check the deployment and pod status for errors."
+      },
+      {
+        "title": "High memory usage",
+        "description": "If you notice high memory usage in the OpenTelemetry Collector, check the resource limits and requests:\n```bash\nkubectl describe deployment otel-collector --namespace otel-collector\n```\nConsider adjusting the resource limits in the deployment configuration."
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If configuration changes are not reflected in the OpenTelemetry Collector, ensure you have updated the correct deployment:\n```bash\nkubectl get deployment otel-collector --namespace otel-collector -o yaml\n```\nVerify that the configuration matches your intended changes."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-opentelemetry-operator.json
+++ b/solutions/cncf-install/install-opentelemetry-operator.json
@@ -40,7 +40,53 @@
         "kubectl apply -f - <<EOF\napiVersion: opentelemetry.io/v1beta1\nkind: OpenTelemetryCollector\nmetadata:\n  name: simplest\nspec:\n  config:\n    receivers:\n      otlp:\n        protocols:\n          grpc:\n            endpoint: 0.0.0.0:4317\n          http:\n            endpoint: 0.0.0.0:4318\n    processors:\n      memory_limiter:\n        check_interval: 1s\n        limit_percentage: 75\n        spike_limit_percentage: 15\n    exporters:\n      debug: {}\n    service:\n      pipelines:\n        traces:\n          receivers: [otlp]\n          processors: [memory_limiter]\n          exporters: [debug]\nEOF",
         "kubectl get pods -n observability"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the OpenTelemetry Operator, use the following command to uninstall the Helm release from the specified namespace. This will delete the operator and its associated resources.\n```bash\nhelm uninstall opentelemetry-operator --namespace observability\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the Helm release, you should clean up any Custom Resource Definitions (CRDs) that were created. This command will delete the OpenTelemetry CRDs from your cluster.\n```bash\nkubectl delete crd opentelemetrycollectors.opentelemetry.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "If you no longer need the 'observability' namespace, you can delete it. This will remove all resources within that namespace. Verify that the namespace has been deleted successfully.\n```bash\nkubectl delete namespace observability\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up your current configurations and resources. You can export the current OpenTelemetry Collector configuration as follows:\n```bash\nkubectl get otelcol simplest -n observability -o yaml > otelcol-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the OpenTelemetry Operator to the desired version. Replace 'v0.146.0' with the target version you wish to upgrade to.\n```bash\nhelm repo update\nhelm upgrade opentelemetry-operator open-telemetry/opentelemetry-operator --namespace observability --version v0.146.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the OpenTelemetry Operator pods to ensure they are running the new version correctly.\n```bash\nkubectl get pods -n observability\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that your OpenTelemetry Collector pod is in a CrashLoopBackOff state, check the logs for more information on the failure.\n```bash\nkubectl logs <pod-name> -n observability\n``` \nLook for errors in the logs that may indicate configuration issues or resource constraints."
+      },
+      {
+        "title": "Collector not receiving data",
+        "description": "If the OpenTelemetry Collector is not receiving data, verify that the application is correctly configured to send telemetry data to the collector's endpoints. Check the collector's configuration for any misconfigurations:\n```bash\nkubectl get otelcol simplest -n observability -o yaml\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, ensure that the version you are trying to upgrade to is compatible with your current Kubernetes version. You can check the available versions with:\n```bash\nhelm search repo open-telemetry/opentelemetry-operator --versions\n```"
+      },
+      {
+        "title": "Namespace does not exist",
+        "description": "If you receive an error that the 'observability' namespace does not exist, ensure that you are specifying the correct namespace in your commands. List all namespaces to verify:\n```bash\nkubectl get namespaces\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-opentelemetry.json
+++ b/solutions/cncf-install/install-opentelemetry.json
@@ -40,7 +40,53 @@
         "kubectl patch deployment opentelemetry-collector --namespace observability --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'",
         "kubectl port-forward svc/opentelemetry-collector --namespace observability 55680:55680"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenTelemetry Collector Helm release from the 'observability' namespace to remove the deployment and associated resources."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with the OpenTelemetry installation."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'observability' namespace and verify that it has been removed successfully."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the OpenTelemetry Collector."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to upgrade the OpenTelemetry Collector to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the OpenTelemetry Collector pod is running the new version and is functioning correctly."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the OpenTelemetry Collector pods are in a CrashLoopBackOff state, check the logs for errors using the following command:\n```bash\nkubectl logs <pod-name> --namespace observability\n```"
+      },
+      {
+        "title": "Collector not receiving data",
+        "description": "If the OpenTelemetry Collector is not receiving data, verify the configuration and check the service endpoints with:\n```bash\nkubectl get svc --namespace observability\n```"
+      },
+      {
+        "title": "Port forwarding not working",
+        "description": "If port forwarding is not functioning, ensure the service is running and check for any errors in the command output. Use:\n```bash\nkubectl get pods --namespace observability\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the OpenTelemetry Collector pod is being OOMKilled, consider adjusting the resource limits. Check the current resource usage with:\n```bash\nkubectl top pod <pod-name> --namespace observability\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-opentofu.json
+++ b/solutions/cncf-install/install-opentofu.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment opentofu --namespace opentofu\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"",
         "kubectl port-forward svc/opentofu --namespace opentofu 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OpenTofu Helm release to remove the deployment from your cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with OpenTofu."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'opentofu' namespace and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Take a backup of the current OpenTofu configuration and resources before proceeding with the upgrade."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the OpenTofu Helm repository and run the upgrade command to install the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the OpenTofu pods to ensure they are running the new version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start repeatedly. Check the pod logs for errors using the command: \n```bash\nkubectl logs <pod-name> --namespace opentofu\n``` \nFix the underlying issue causing the failure."
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If the OpenTofu service is not accessible, verify that the port forwarding is set up correctly. Run: \n```bash\nkubectl get svc --namespace opentofu\n``` \nEnsure the service is running and the correct ports are exposed."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, check the installed version with: \n```bash\nhelm list --namespace opentofu\n``` \nYou may need to specify a compatible version or rollback to a previous version."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being terminated due to Out of Memory (OOM) errors, check the resource limits set on the deployment. Use: \n```bash\nkubectl describe pod <pod-name> --namespace opentofu\n``` \nAdjust the resource limits accordingly in the deployment."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-openyurt.json
+++ b/solutions/cncf-install/install-openyurt.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment yurt-iot-dock -n openyurt\n# Add the following lines under spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"",
         "kubectl port-forward svc/yurt-iot-dock -n openyurt 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the yurt-iot-dock release using Helm to remove the deployment from the cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with OpenYurt."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'openyurt' namespace and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the yurt-iot-dock release."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to upgrade to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the yurt-iot-dock pods are running the new version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue may occur if the application fails to start. Check the pod logs for errors using the following command: \n```bash\nkubectl logs <pod-name> -n openyurt\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not accessible, ensure that the port forwarding is set up correctly. Verify the service status with: \n```bash\nkubectl get svc -n openyurt\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If pods are not starting due to resource constraints, check the resource requests and limits. Use: \n```bash\nkubectl describe deployment yurt-iot-dock -n openyurt\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to CRDs, ensure that they are installed correctly. List CRDs with: \n```bash\nkubectl get crds\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-operator-framework.json
+++ b/solutions/cncf-install/install-operator-framework.json
@@ -40,7 +40,53 @@
         "kubectl create role operator-sdk-role --verb=get,list,watch,create,update,patch,delete --resource=pods --namespace=operator-sdk\nkubectl create rolebinding operator-sdk-rolebinding --role=operator-sdk-role --user=system:serviceaccount:operator-sdk:default --namespace=operator-sdk",
         "kubectl patch deployment operator-sdk -n operator-sdk --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Operator SDK release using Helm to remove the deployment from the cluster. Run the following command:\n```bash\nhelm uninstall operator-sdk --namespace operator-sdk\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were created by the Operator SDK. Execute the following commands:\n```bash\nkubectl delete crd <crd-name>\n# Replace <crd-name> with the actual CRD names associated with the Operator SDK.\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for the Operator SDK and verify that it has been removed. Use the following commands:\n```bash\nkubectl delete namespace operator-sdk\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources. You can export the current deployment and any relevant CRDs with:\n```bash\nkubectl get deployment operator-sdk -n operator-sdk -o yaml > operator-sdk-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Operator SDK to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade operator-sdk operator-sdk/operator-sdk --namespace operator-sdk --version v1.43.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Operator SDK pod is running the new version successfully after the upgrade:\n```bash\nkubectl get pods -n operator-sdk\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Operator SDK pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command:\n```bash\nkubectl logs <pod-name> -n operator-sdk\n# Replace <pod-name> with the name of the pod in question.\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If the Operator SDK cannot access certain resources, verify the Role and RoleBinding. Check the current roles with:\n```bash\nkubectl get role -n operator-sdk\nkubectl get rolebinding -n operator-sdk\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the pod is being killed due to out-of-memory (OOM) issues, consider increasing the memory limits. Check the current resource usage with:\n```bash\nkubectl top pod -n operator-sdk\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to version conflicts, ensure that the specified version exists in the repository. Check available versions with:\n```bash\nhelm search repo operator-sdk/operator-sdk --versions\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-oras.json
+++ b/solutions/cncf-install/install-oras.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment oras --namespace oras",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the ORAS deployment, use the following command to uninstall the Helm release:\n```bash\nhelm uninstall oras --namespace oras\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volumes associated with ORAS, you can remove them with:\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace oras\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the namespace and verify that it has been removed:\n```bash\nkubectl delete namespace oras\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your ORAS deployment. You can do this by exporting the current configuration:\n```bash\nkubectl get deployment oras --namespace oras -o yaml > oras-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade ORAS to the latest version:\n```bash\nhelm repo update\nhelm upgrade oras oras/oras --version v1.4.0 --namespace oras\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the ORAS pods to ensure they are running correctly:\n```bash\nkubectl get pods --namespace oras\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the ORAS pods are in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> --namespace oras\n``` \nLook for any error messages that indicate what might be wrong."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the ORAS CLI, ensure that the service is running and the port-forwarding is set up correctly:\n```bash\nkubectl get svc --namespace oras\nkubectl port-forward service/oras --namespace oras 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If you encounter issues related to resource limits, check the resource usage of the pods:\n```bash\nkubectl top pods --namespace oras\n``` \nConsider adjusting the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, check the installed version and the available versions:\n```bash\nhelm list --namespace oras\nhelm search repo oras/oras --versions\n``` \nMake sure you are specifying a valid version in your upgrade command."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-oscal-compass.json
+++ b/solutions/cncf-install/install-oscal-compass.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/trestle --namespace compliance --limits=cpu=500m,memory=512Mi",
         "kubectl port-forward service/trestle --namespace compliance 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Compliance Trestle release from the Kubernetes cluster using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Compliance Trestle."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'compliance' namespace and verify that all resources have been cleaned up."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Compliance Trestle release."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Compliance Trestle release to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Compliance Trestle pods are running the new version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when pods repeatedly crash. Check the logs of the pod to diagnose the issue."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not accessible, ensure that the port forwarding is set up correctly and the service is running."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are failing due to resource limits, consider increasing the resource limits set for the deployment."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating the Helm release is not found, verify that you are using the correct namespace and release name."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-ovn-kubernetes.json
+++ b/solutions/cncf-install/install-ovn-kubernetes.json
@@ -35,7 +35,53 @@
         "kubectl get pods --namespace ovn-kubernetes",
         "helm upgrade ovn-kubernetes ovn-kubernetes/ovn-kubernetes --namespace ovn-kubernetes --set resources.limits.cpu=500m --set resources.limits.memory=512Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OVN-Kubernetes Helm release from the cluster using the following command:\n```bash\nhelm uninstall ovn-kubernetes --namespace ovn-kubernetes\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with OVN-Kubernetes:\n```bash\nkubectl delete crd -l app=ovn-kubernetes\nkubectl delete pvc --all --namespace ovn-kubernetes\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'ovn-kubernetes' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace ovn-kubernetes\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources:\n```bash\nkubectl get all --namespace ovn-kubernetes -o yaml > ovn-kubernetes-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade OVN-Kubernetes to the latest version:\n```bash\nhelm repo update\nhelm upgrade ovn-kubernetes ovn-kubernetes/ovn-kubernetes --namespace ovn-kubernetes --version 1.2.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that all OVN-Kubernetes pods are running after the upgrade:\n```bash\nkubectl get pods --namespace ovn-kubernetes\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that OVN-Kubernetes pods are in a CrashLoopBackOff state, check the logs of the affected pod:\n```bash\nkubectl logs <pod-name> --namespace ovn-kubernetes\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If services are not reachable, verify the service configuration and check the endpoints:\n```bash\nkubectl get svc --namespace ovn-kubernetes\nkubectl get endpoints --namespace ovn-kubernetes\n```"
+      },
+      {
+        "title": "High resource usage",
+        "description": "If you experience high resource usage, check the resource limits and current usage:\n```bash\nkubectl top pods --namespace ovn-kubernetes\nkubectl describe deployment ovn-kubernetes --namespace ovn-kubernetes\n```"
+      },
+      {
+        "title": "Network connectivity issues",
+        "description": "For network connectivity issues, check the OVN-Kubernetes network configuration and logs:\n```bash\nkubectl get pods --namespace ovn-kubernetes -o wide\nkubectl logs <ovn-controller-pod-name> --namespace ovn-kubernetes\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-oxia.json
+++ b/solutions/cncf-install/install-oxia.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/oxia --namespace oxia --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward svc/oxia --namespace oxia 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Oxia release from the cluster using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall oxia --namespace oxia\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. Ensure that all resources are cleaned up to avoid orphaned resources.\n```bash\nkubectl delete crd $(kubectl get crd | grep oxia | awk '{print $1}')\nkubectl delete pvc --all --namespace oxia\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'oxia' namespace to remove all remaining resources and verify that it has been removed successfully.\n```bash\nkubectl delete namespace oxia\nkubectl get namespaces | grep oxia\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Oxia deployment. This can include exporting configurations or taking snapshots of persistent volumes if necessary.\n```bash\nkubectl get all --namespace oxia -o yaml > oxia-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and perform the upgrade to the latest version of Oxia. Replace 'v0.15.3' with the desired version if necessary.\n```bash\nhelm repo update\nhelm upgrade oxia oxia/oxia --version v0.15.4 --namespace oxia\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Oxia pods to ensure they are running the upgraded version without issues.\n```bash\nkubectl get pods --namespace oxia\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Oxia pods are in a CrashLoopBackOff state, check the logs to diagnose the issue. This may indicate a misconfiguration or resource limits being exceeded.\n```bash\nkubectl logs <pod-name> --namespace oxia\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Oxia service, ensure that the port forwarding is set up correctly and that the service is running. Check the service status and logs.\n```bash\nkubectl get svc --namespace oxia\nkubectl logs <pod-name> --namespace oxia\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the deployment fails due to insufficient resources, check the resource requests and limits set for the Oxia deployment and adjust them accordingly.\n```bash\nkubectl describe deployment oxia --namespace oxia\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify that the release name and namespace are correct. List all releases in the namespace to confirm.\n```bash\nhelm list --namespace oxia\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-paralus.json
+++ b/solutions/cncf-install/install-paralus.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment paralus --namespace paralus",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Paralus release from the Kubernetes cluster using Helm. This will remove the deployment and associated resources created by the Helm chart.\n```bash\nhelm uninstall paralus --namespace paralus\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources related to Paralus are removed.\n```bash\nkubectl delete crd $(kubectl get crd | grep paralus | awk '{print $1}')\nkubectl delete pvc --all --namespace paralus\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Paralus namespace and verify that it has been removed from the cluster. This step is crucial for cleaning up the environment.\n```bash\nkubectl delete namespace paralus\nkubectl get namespaces | grep paralus\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Paralus deployment. You can use the following command to export the current configuration.\n```bash\nkubectl get all --namespace paralus -o yaml > paralus-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Paralus installation to the latest version. Make sure to specify the desired version.\n```bash\nhelm repo update\nhelm upgrade paralus paralus/paralus --namespace paralus --version v0.4.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Paralus pods are running the new version successfully after the upgrade. This ensures that the upgrade was successful.\n```bash\nkubectl get pods --namespace paralus\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Paralus pods are in a CrashLoopBackOff state, check the logs for errors that may indicate the cause. Use the following command to view the logs:\n```bash\nkubectl logs <pod-name> --namespace paralus\n```"
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Paralus GUI, ensure that the port forwarding is set up correctly. Check the service status with:\n```bash\nkubectl get svc --namespace paralus\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to resource constraints, check the resource limits and requests set in the deployment. You can view the current configuration with:\n```bash\nkubectl get deployment paralus --namespace paralus -o yaml\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure that you are using the correct namespace. List all releases in the namespace with:\n```bash\nhelm list --namespace paralus\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-parsec.json
+++ b/solutions/cncf-install/install-parsec.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment parsec --namespace parsec",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Parsec installation, first uninstall the Helm release using the following command. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall parsec --namespace parsec\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any Custom Resource Definitions (CRDs) and persistent volumes that may have been created during the installation. Use the following commands to delete the CRDs and any persistent volume claims (PVCs).\n```bash\nkubectl delete crd parsec.*\nkubectl delete pvc --all --namespace parsec\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the namespace used for Parsec to ensure all resources are cleaned up. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace parsec\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your Parsec installation. You can do this by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace parsec -o yaml > parsec-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then run the upgrade command to update your Parsec installation to the latest version.\n```bash\nhelm repo update\nhelm upgrade parsec parallaxsecond/parsec --namespace parsec --version 1.5.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Parsec pods are running the new version successfully. Check the status of the pods in the parsec namespace.\n```bash\nkubectl get pods --namespace parsec\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your Parsec pods are in a CrashLoopBackOff state, check the logs for the pod to diagnose the issue. This may indicate a misconfiguration or resource limits being too low.\n```bash\nkubectl logs <pod-name> --namespace parsec\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Parsec service, ensure that the port forwarding is set up correctly and that the service is running. Check the service status with:\n```bash\nkubectl get svc --namespace parsec\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter errors related to insufficient resources, check the resource usage and limits set for the Parsec deployment. You can view the current resource usage with:\n```bash\nkubectl top pods --namespace parsec\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, ensure that you are using the correct namespace and release name. List all Helm releases in the namespace with:\n```bash\nhelm list --namespace parsec\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-perses.json
+++ b/solutions/cncf-install/install-perses.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/perses --namespace perses 8080:80",
         "helm upgrade perses perses/perses --namespace perses --set resources.limits.cpu=500m --set resources.limits.memory=512Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Perses release from the 'perses' namespace using Helm to remove the deployment and associated resources."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) related to Perses to ensure a clean removal."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'perses' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and any important data related to the Perses installation."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to install the latest version of Perses."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Perses pods are running the new version successfully in the 'perses' namespace."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue indicates that the Perses pods are failing to start. Use the following command to check the logs for more details: \n```bash\nkubectl logs <pod-name> --namespace perses\n```"
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Perses dashboard, ensure that the port-forwarding is set up correctly. Check the service status with: \n```bash\nkubectl get svc --namespace perses\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the pods are not starting due to resource constraints, check the resource requests and limits set in the deployment. You can view the current resource usage with: \n```bash\nkubectl top pods --namespace perses\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any breaking changes in the new version. You can view the Helm release history with: \n```bash\nhelm history perses --namespace perses\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-pipecd.json
+++ b/solutions/cncf-install/install-pipecd.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/pipecd-api --namespace pipecd 8080:80",
         "kubectl edit deployment pipecd --namespace pipecd"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the PipeCD installation, first uninstall the Helm release with the following command:\n```bash\nhelm uninstall pipecd --namespace pipecd\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Next, remove any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation:\n```bash\nkubectl delete crd pipelineruns.pipecd.dev\nkubectl delete crd applications.pipecd.dev\nkubectl delete crd environments.pipecd.dev\nkubectl delete crd deployments.pipecd.dev\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'pipecd' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace pipecd\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your PipeCD installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace pipecd -o yaml > pipecd-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to apply the latest version of PipeCD:\n```bash\nhelm repo update\nhelm upgrade pipecd pipecd/pipecd --namespace pipecd --version v0.56.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the PipeCD pods are running the new version:\n```bash\nkubectl get pods --namespace pipecd\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you notice that the PipeCD pods are stuck in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> --namespace pipecd\n```\nLook for any error messages that might indicate what is causing the crash."
+      },
+      {
+        "title": "API server not accessible",
+        "description": "If you are unable to access the PipeCD API server, ensure that the port-forwarding command is running. You can check the service status with:\n```bash\nkubectl get svc --namespace pipecd\n```\nIf the service is not running, try restarting the port-forward command."
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If your pods are being evicted due to resource limits, check the events for the namespace:\n```bash\nkubectl get events --namespace pipecd\n```\nYou may need to adjust the resource limits in your deployment."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, ensure that you are using a compatible version of the chart. Check the available versions with:\n```bash\nhelm search repo pipecd/pipecd --versions\n```\nThen, specify a valid version in your upgrade command."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-pixie.json
+++ b/solutions/cncf-install/install-pixie.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment pixie --namespace pixie",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Pixie release from the cluster using Helm with the following command:\n```bash\nhelm uninstall pixie --namespace pixie\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Pixie. Run the following commands:\n```bash\nkubectl delete crd $(kubectl get crd | grep pixie | awk '{print $1}')\nkubectl delete pvc --all --namespace pixie\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Pixie namespace and verify that it has been removed:\n```bash\nkubectl delete namespace pixie\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Pixie installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace pixie -o yaml > pixie-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Pixie installation to the latest version:\n```bash\nhelm repo update\nhelm upgrade pixie pixie/pixie --namespace pixie --version release/cloud/v0.1.10\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Pixie pods are running successfully after the upgrade:\n```bash\nkubectl get pods --namespace pixie\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Pixie pods are in a CrashLoopBackOff state, check the logs for any errors:\n```bash\nkubectl logs <pod-name> --namespace pixie\n```\nLook for any error messages that might indicate the cause of the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Pixie UI, verify that the service is running:\n```bash\nkubectl get services --namespace pixie\n```\nEnsure the service is correctly configured and the port-forward command is running."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If Pixie is not starting due to resource constraints, check the resource usage:\n```bash\nkubectl top pods --namespace pixie\n```\nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any existing Helm releases and their status:\n```bash\nhelm list --namespace pixie\n```\nYou may need to resolve any conflicts or issues before retrying the upgrade."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-porter.json
+++ b/solutions/cncf-install/install-porter.json
@@ -36,7 +36,53 @@
         "kubectl edit deployment porter --namespace porter",
         "resources:\n  limits:\n    cpu: 500m\n    memory: 512Mi\n  requests:\n    cpu: 250m\n    memory: 256Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Porter release from your Kubernetes cluster using the following command. This will remove the deployment and associated resources created by Helm.\n```bash\nhelm uninstall porter --namespace porter\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. Use the following commands:\n```bash\nkubectl delete crd porters.getporter.io\nkubectl delete pvc --all --namespace porter\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'porter' namespace to clean up any remaining resources. Verify that the namespace has been removed with the following commands:\n```bash\nkubectl delete namespace porter\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and any important data. You can use the following command to export the current release configuration:\n```bash\nhelm get values porter --namespace porter > porter-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Porter release to the latest version with the following commands:\n```bash\nhelm repo update\nhelm upgrade porter porter/porter --version v1.5.0 --namespace porter\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Porter pods are running successfully after the upgrade. Use the following command to verify:\n```bash\nkubectl get pods --namespace porter\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Porter pods are in a CrashLoopBackOff state, check the logs for more information. Use the following command to view the logs:\n```bash\nkubectl logs <pod-name> --namespace porter\n```\nReplace `<pod-name>` with the name of the crashing pod. Look for any errors that indicate what might be causing the crash."
+      },
+      {
+        "title": "Helm upgrade fails with 'release not found'",
+        "description": "If you encounter an error stating 'release not found' during the upgrade, ensure that the release name is correct and that it exists in the specified namespace. You can list the releases with:\n```bash\nhelm list --namespace porter\n```"
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you see an error related to insufficient resources, check the resource requests and limits set for the Porter deployment. You can view the current deployment configuration with:\n```bash\nkubectl get deployment porter -o yaml --namespace porter\n```"
+      },
+      {
+        "title": "Namespace still exists after uninstall",
+        "description": "If the 'porter' namespace still exists after attempting to uninstall, ensure that all resources have been deleted. You can force delete the namespace with:\n```bash\nkubectl delete namespace porter --grace-period=0 --force\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-prometheus.json
+++ b/solutions/cncf-install/install-prometheus.json
@@ -40,7 +40,53 @@
         "kubectl port-forward svc/prometheus-server --namespace monitoring 9090:80",
         "helm upgrade prometheus prometheus-community/prometheus --namespace monitoring --set server.resources.limits.cpu=500m --set server.resources.limits.memory=512Mi"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Prometheus release, run the following command to uninstall it from the 'monitoring' namespace:\n```bash\nhelm uninstall prometheus --namespace monitoring\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the release, remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Use the following commands:\n```bash\nkubectl delete crd prometheuses.monitoring.coreos.com\nkubectl delete crd prometheusrules.monitoring.coreos.com\nkubectl delete pvc --all --namespace monitoring\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'monitoring' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace monitoring\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Prometheus installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all --namespace monitoring -o yaml > prometheus-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update your Helm repository and then upgrade the Prometheus release to the latest version:\n```bash\nhelm repo update\nhelm upgrade prometheus prometheus-community/prometheus --namespace monitoring --version 15.0.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check that the Prometheus pods are running with the new version:\n```bash\nkubectl get pods --namespace monitoring\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If you see that the Prometheus pods are in a 'CrashLoopBackOff' state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace monitoring\n```\nLook for any configuration issues or resource limits that might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Prometheus UI, ensure that the service is running:\n```bash\nkubectl get svc --namespace monitoring\n```\nIf the service is not running, check the pod status and logs for issues."
+      },
+      {
+        "title": "High memory usage",
+        "description": "If Prometheus is consuming too much memory, consider adjusting the resource limits. You can check the current resource usage with:\n```bash\nkubectl top pods --namespace monitoring\n```\nThen, update the resource limits as needed."
+      },
+      {
+        "title": "Alerts not firing",
+        "description": "If alerts are not firing as expected, verify the alerting rules:\n```bash\nkubectl get prometheusrules --namespace monitoring\n```\nCheck the rules for any misconfigurations or errors in the alert definitions."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-pushgateway.json
+++ b/solutions/cncf-install/install-pushgateway.json
@@ -44,7 +44,53 @@
         "kubectl get pods --namespace monitoring",
         "kubectl port-forward svc/pushgateway --namespace monitoring 9091:9091"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Pushgateway Helm release from the monitoring namespace with the following command:\n```bash\nhelm uninstall pushgateway --namespace monitoring\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Pushgateway. Use the following commands:\n```bash\nkubectl delete pvc --all --namespace monitoring\nkubectl delete crd pushgateway --namespace monitoring\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the monitoring namespace and verify its removal with the following commands:\n```bash\nkubectl delete namespace monitoring\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of the Pushgateway release. You can do this by exporting the current configuration:\n```bash\nhelm get values pushgateway --namespace monitoring > pushgateway-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update your Helm repositories and upgrade the Pushgateway release to the latest version with the following commands:\n```bash\nhelm repo update\nhelm upgrade pushgateway prometheus-community/prometheus-pushgateway --namespace monitoring --version 1.11.3\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Pushgateway pod is running after the upgrade with the following command:\n```bash\nkubectl get pods --namespace monitoring\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Pushgateway pods are in a CrashLoopBackOff state, check the pod logs for errors:\n```bash\nkubectl logs <pod-name> --namespace monitoring\n```\nLook for any configuration issues or resource constraints."
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Pushgateway service, ensure that the port-forward command is running. Check the service status with:\n```bash\nkubectl get svc --namespace monitoring\n```\nMake sure the service is correctly configured and the port is open."
+      },
+      {
+        "title": "Metrics not being pushed",
+        "description": "If metrics are not being pushed to Pushgateway, verify that your jobs are configured to send metrics to the correct Pushgateway URL. Check the job configuration and ensure it points to:\n```text\nhttp://<pushgateway-ip>:9091\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, check the currently installed version with:\n```bash\nhelm list --namespace monitoring\n```\nIf necessary, rollback to the previous version using:\n```bash\nhelm rollback pushgateway <revision-number> --namespace monitoring\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-radius.json
+++ b/solutions/cncf-install/install-radius.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment radius --namespace radius\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     cpu: '500m'\n#     memory: '512Mi'",
         "kubectl port-forward svc/radius --namespace radius 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Radius deployment, use the following command to uninstall the Helm release. This will delete all resources associated with the release in the specified namespace.\n```bash\nhelm uninstall radius --namespace radius\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If there are any Custom Resource Definitions (CRDs) or persistent volumes created by Radius, you can remove them with the following commands. Ensure to check for any remaining resources before deletion.\n```bash\nkubectl delete crd <crd-name>\nkubectl delete pvc --all --namespace radius\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the 'radius' namespace to clean up all remaining resources. Verify that the namespace has been deleted successfully.\n```bash\nkubectl delete namespace radius\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up your current Radius configuration and data. You can export the current configuration using the following command:\n```bash\nhelm get values radius --namespace radius > radius-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, and then upgrade the Radius installation to the desired version. Replace `<new-version>` with the version you want to upgrade to.\n```bash\nhelm repo update\nhelm upgrade radius radius/radius --version <new-version> --namespace radius\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Radius pods are running the new version successfully. Check the status of the pods in the 'radius' namespace.\n```bash\nkubectl get pods --namespace radius\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your Radius pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue. Use the following command to view the logs:\n```bash\nkubectl logs <pod-name> --namespace radius\n```"
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Radius service, ensure that the port forwarding is set up correctly. Check if the service is running and the correct ports are exposed:\n```bash\nkubectl get svc --namespace radius\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource requests and limits set for the deployment. You can view the current configuration with:\n```bash\nkubectl describe deployment radius --namespace radius\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error indicating that the Helm release was not found, ensure that you are using the correct namespace and release name. List all releases in the namespace with:\n```bash\nhelm list --namespace radius\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-rook.json
+++ b/solutions/cncf-install/install-rook.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment rook-operator -n rook",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Rook Helm release from the 'rook' namespace using the following command:\n```bash\nhelm uninstall rook -n rook\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete the Custom Resource Definitions (CRDs) associated with Rook and any persistent volume claims (PVCs) that were created:\n```bash\nkubectl delete crd $(kubectl get crd | grep rook.io | awk '{print $1}')\nkubectl delete pvc --all -n rook\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'rook' namespace and verify that it has been removed:\n```bash\nkubectl delete namespace rook\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Rook installation. You can do this by exporting the current configuration:\n```bash\nkubectl get all -n rook -o yaml > rook-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Rook to the latest version:\n```bash\nhelm repo update\nhelm upgrade rook-release/rook --namespace rook --version v1.19.3\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Rook operator pod is running after the upgrade:\n```bash\nkubectl get pods -n rook\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Rook operator pod is in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs -l app=rook-operator -n rook\n``` \nLook for any error messages that indicate configuration issues or resource limits."
+      },
+      {
+        "title": "Rook operator not starting",
+        "description": "If the Rook operator pod is not starting, ensure that the necessary permissions are set. Check the events for the pod:\n```bash\nkubectl describe pod -l app=rook-operator -n rook\n``` \nLook for any permission denied errors or missing resources."
+      },
+      {
+        "title": "StorageClass not found",
+        "description": "If you encounter issues with the StorageClass, verify that it exists and is correctly configured:\n```bash\nkubectl get storageclass\n``` \nEnsure that the StorageClass used by Rook is present and correctly defined."
+      },
+      {
+        "title": "Ceph cluster not healthy",
+        "description": "If the Ceph cluster is reported as unhealthy, check the status of the Ceph cluster:\n```bash\nkubectl -n rook exec -it deploy/rook-ceph-tools -- ceph status\n``` \nInvestigate any warnings or errors reported in the Ceph status output."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-runme-notebooks.json
+++ b/solutions/cncf-install/install-runme-notebooks.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment runme --namespace <namespace>",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Runme release from your Kubernetes cluster using Helm. Replace `<namespace>` with your actual namespace:\n```bash\nhelm uninstall runme --namespace <namespace>\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Runme. Execute the following commands:\n```bash\nkubectl delete crd runmes.runme.dev\nkubectl delete pvc --all --namespace <namespace>\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace if it is no longer needed and verify that it has been removed. Use the following commands:\n```bash\nkubectl delete namespace <namespace>\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Runme deployment. You can use the following command to export the current configuration:\n```bash\nkubectl get deployment runme --namespace <namespace> -o yaml > runme-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Runme installation to the latest version. Execute the following commands:\n```bash\nhelm repo update\nhelm upgrade runme runme/runme --namespace <namespace> --version v3.16.6\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Runme pods are running the new version successfully. Use the following command:\n```bash\nkubectl get pods --namespace <namespace>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Runme pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command to view the logs:\n```bash\nkubectl logs <pod-name> --namespace <namespace>\n``` \nLook for any error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Runme service, verify that the service is running and correctly configured. Check the service status with:\n```bash\nkubectl get svc --namespace <namespace>\n``` \nEnsure that the port-forward command is running and that you are using the correct port."
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If the pods are being killed due to Out Of Memory (OOM) errors, you may need to adjust the resource limits. Check the pod status with:\n```bash\nkubectl describe pod <pod-name> --namespace <namespace>\n``` \nLook for OOMKilled messages and consider increasing the memory limit in the deployment."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that you are using a compatible version. Check the current version with:\n```bash\nhelm list --namespace <namespace>\n``` \nYou may need to roll back to the previous version if the new version is incompatible:\n```bash\nhelm rollback runme <revision-number> --namespace <namespace>\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-score.json
+++ b/solutions/cncf-install/install-score.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment score --namespace score",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Score Helm release from your Kubernetes cluster using the following command. This will remove the deployment and associated resources but not CRDs or persistent volumes.\n```bash\nhelm uninstall score --namespace score\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "If you have created any custom resource definitions (CRDs) or persistent volume claims (PVCs) that are no longer needed, you can delete them with the following commands. Replace 'score' with your specific CRD name if necessary.\n```bash\nkubectl delete crd scores.score.dev\nkubectl delete pvc --all --namespace score\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, delete the 'score' namespace to clean up any remaining resources. Verify that the namespace has been removed.\n```bash\nkubectl delete namespace score\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up your current Helm release configuration. You can do this by exporting the current values.\n```bash\nhelm get values score --namespace score > score-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Score release to the latest version. Ensure you specify the correct version if needed.\n```bash\nhelm repo update\nhelm upgrade score score/score --version 0.4.0 --namespace score\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Score pods are running the new version in the 'score' namespace. You can also check the release history for confirmation.\n```bash\nkubectl get pods --namespace score\nhelm history score --namespace score\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your Score pods are in a CrashLoopBackOff state, you can check the logs to diagnose the issue. Use the following command to view the logs of a specific pod:\n```bash\nkubectl logs <pod-name> --namespace score\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Score service, ensure that the service is running and check the port-forwarding command. Verify the service status with:\n```bash\nkubectl get svc --namespace score\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the Helm upgrade, ensure that you are using a compatible version of the Score chart. You can check the available versions with:\n```bash\nhelm search repo score --versions\n```"
+      },
+      {
+        "title": "Insufficient resources for Score pods",
+        "description": "If the Score pods are failing to start due to insufficient resources, you may need to adjust the resource limits in the deployment. Check the events for the pods to see resource-related errors:\n```bash\nkubectl describe pod <pod-name> --namespace score\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-slimfaas.json
+++ b/solutions/cncf-install/install-slimfaas.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment slimfaas --namespace slimfaas",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the SlimFaas release from the Kubernetes cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall slimfaas --namespace slimfaas\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation. This ensures that no leftover resources remain in the cluster.\n```bash\nkubectl delete crd slimfaasfunctions.slimfaas.dev\nkubectl delete crd slimfaasfunctionruntimes.slimfaas.dev\nkubectl delete pvc --all --namespace slimfaas\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'slimfaas' namespace to clean up any remaining resources. After deletion, verify that the namespace has been removed.\n```bash\nkubectl delete namespace slimfaas\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of your SlimFaas installation. You can do this by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace slimfaas -o yaml > slimfaas-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the SlimFaas Helm repository and run the upgrade command to apply the latest version. Ensure you specify the desired version.\n```bash\nhelm repo update\nhelm upgrade slimfaas slimfaas/slimfaas --namespace slimfaas --version 0.61.15\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, check the status of the SlimFaas pods to ensure they are running the new version without issues.\n```bash\nkubectl get pods --namespace slimfaas\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your SlimFaas pods are stuck in a CrashLoopBackOff state, check the logs for errors. This can indicate issues with the application configuration or resource limits.\n```bash\nkubectl logs <pod-name> --namespace slimfaas\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the SlimFaas service, ensure that the service is running and the port-forwarding command is active. Check the service status and logs.\n```bash\nkubectl get svc --namespace slimfaas\nkubectl port-forward service/slimfaas 8080:80 --namespace slimfaas\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter errors related to insufficient resources, check the resource limits set in the deployment and the available resources in your cluster.\n```bash\nkubectl describe deployment slimfaas --namespace slimfaas\nkubectl get nodes --namespace slimfaas\n```"
+      },
+      {
+        "title": "Configuration errors",
+        "description": "If there are issues with the configuration, review the deployment configuration and ensure all required parameters are set correctly. You can edit the deployment to fix any issues.\n```bash\nkubectl edit deployment slimfaas --namespace slimfaas\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-slimtoolkit.json
+++ b/solutions/cncf-install/install-slimtoolkit.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/slim --namespace slim --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
         "kubectl port-forward service/slim --namespace slim 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the SlimToolkit release from your Kubernetes cluster using the following command:\n```bash\nhelm uninstall slim --namespace slim\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims associated with SlimToolkit:\n```bash\nkubectl delete crd slimtoolkits.slimtoolkit.io\nkubectl delete pvc --all --namespace slim\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Slim namespace and verify that it has been removed:\n```bash\nkubectl delete namespace slim\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources of SlimToolkit:\n```bash\nhelm get values slim --namespace slim > slim-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade SlimToolkit to the latest version:\n```bash\nhelm repo update\nhelm upgrade slim slim/slim --namespace slim --version 1.40.12\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the SlimToolkit pods are running the new version successfully:\n```bash\nkubectl get pods --namespace slim\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the SlimToolkit pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace slim\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access SlimToolkit, ensure the service is running and check the port-forward command:\n```bash\nkubectl get svc --namespace slim\nkubectl port-forward service/slim --namespace slim 8080:80\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter resource-related issues, verify the resource limits and requests:\n```bash\nkubectl describe deployment slim --namespace slim\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you receive an error stating that the Helm release is not found, ensure you are using the correct namespace:\n```bash\nhelm list --namespace slim\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-spiderpool.json
+++ b/solutions/cncf-install/install-spiderpool.json
@@ -40,7 +40,53 @@
         "kubectl get pods -n kube-system | grep spiderpool",
         "kubectl edit configmap spiderpool-conf -n kube-system"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Spiderpool Helm release from the kube-system namespace using the following command:\n```bash\nhelm uninstall spiderpool --namespace kube-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Spiderpool. Use the following commands:\n```bash\nkubectl delete crd spiderpoolconfigs.spidernet.io\nkubectl delete crd spiderpoolnets.spidernet.io\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the kube-system namespace if it is no longer needed and verify the removal:\n```bash\nkubectl delete namespace kube-system\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of Spiderpool. You can use the following command to export the current ConfigMap:\n```bash\nkubectl get configmap spiderpool-conf -n kube-system -o yaml > spiderpool-conf-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update your Helm repository and upgrade the Spiderpool release to the latest version:\n```bash\nhelm repo update\nhelm upgrade spiderpool spiderpool/spiderpool --version 1.0.6 --namespace kube-system\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Spiderpool pods are running the new version successfully:\n```bash\nkubectl get pods -n kube-system | grep spiderpool\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Spiderpool pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> -n kube-system\n```\nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Network connectivity issues",
+        "description": "If you experience network connectivity issues, verify the Spiderpool configuration:\n```bash\nkubectl get configmap spiderpool-conf -n kube-system -o yaml\n```\nEnsure that the settings are correct and that the necessary network policies are applied."
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace kube-system\n```\nEnsure that 'spiderpool' is listed in the output."
+      },
+      {
+        "title": "Insufficient resources for pods",
+        "description": "If the pods are not scheduling due to insufficient resources, check the resource requests and limits:\n```bash\nkubectl describe pod <pod-name> -n kube-system\n```\nAdjust the resource requests in the configuration if necessary."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-spiffe.json
+++ b/solutions/cncf-install/install-spiffe.json
@@ -40,7 +40,53 @@
         "helm upgrade spire spire/spire --namespace spire -f values.yaml",
         "kubectl edit configmap spire-server-config -n spire"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the SPIRE release using Helm to remove the deployed resources from the cluster."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with SPIRE."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'spire' namespace and verify that all resources have been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Create a backup of the current SPIRE release to ensure you can restore it if needed."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and run the upgrade command to apply the latest version of SPIRE."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the SPIRE server and agent pods are running the new version successfully."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when the SPIRE server or agent pods fail to start. Check the pod logs for errors using the following command:\n```bash\nkubectl logs <pod-name> --namespace spire\n```"
+      },
+      {
+        "title": "SPIRE server not responding",
+        "description": "If the SPIRE server is not responding, verify that it is running and check its logs for any errors:\n```bash\nkubectl logs spire-server-<pod-id> --namespace spire\n```"
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If changes to the SPIRE configuration are not taking effect, ensure that you have correctly edited the ConfigMap and restarted the SPIRE server:\n```bash\nkubectl delete pod spire-server-<pod-id> --namespace spire\n```"
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade command fails, check for any version mismatches or required values in your values.yaml file. You can view the current release status with:\n```bash\nhelm status spire --namespace spire\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-spire.json
+++ b/solutions/cncf-install/install-spire.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment spire-server --namespace spire",
         "resources:\n  limits:\n    memory: \"512Mi\"\n    cpu: \"500m\"\n  requests:\n    memory: \"256Mi\"\n    cpu: \"250m\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the SPIRE release from the cluster using the following command to remove the deployment and associated resources:\n```bash\nhelm uninstall spire --namespace spire\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation:\n```bash\nkubectl delete crd $(kubectl get crd | grep spire | awk '{print $1}')\nkubectl delete pvc --all --namespace spire\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'spire' namespace to clean up all remaining resources and verify the deletion:\n```bash\nkubectl delete namespace spire\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and data of the SPIRE installation. You can export the current Helm release values:\n```bash\nhelm get values spire --namespace spire > spire-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the SPIRE release to the latest version:\n```bash\nhelm repo update\nhelm upgrade spire spire/spire --namespace spire --version v1.15.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the SPIRE server and agent pods are running and verify the upgrade:\n```bash\nkubectl get pods --namespace spire\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the SPIRE server or agent pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace spire\n```\nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Unable to connect to SPIRE server",
+        "description": "If you cannot connect to the SPIRE server, ensure that the port forwarding is set up correctly. Check the service status:\n```bash\nkubectl get svc --namespace spire\n```\nMake sure the service is running and the correct port is being forwarded."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you encounter a version conflict during the upgrade, ensure that the version you are trying to upgrade to is compatible with your current installation. Check the current version:\n```bash\nhelm list --namespace spire\n```\nThen, specify a compatible version in the upgrade command."
+      },
+      {
+        "title": "Resource limits causing pod eviction",
+        "description": "If pods are being evicted due to resource limits, check the events for the namespace:\n```bash\nkubectl get events --namespace spire\n```\nAdjust the resource limits in the deployment if necessary to allocate more resources."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-stacker.json
+++ b/solutions/cncf-install/install-stacker.json
@@ -40,7 +40,53 @@
         "kubectl set resources deployment/stacker --namespace stacker --limits=cpu=500m,memory=512Mi",
         "kubectl port-forward svc/stacker --namespace stacker 8080:80"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Stacker release from the cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall stacker --namespace stacker\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation. This ensures that no leftover resources remain.\n```bash\nkubectl delete crd stackers.stackerbuild.io\nkubectl delete pvc --all --namespace stacker\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'stacker' namespace to clean up any remaining resources. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace stacker\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Stacker deployment. This can be done by exporting the current Helm release values.\n```bash\nhelm get values stacker --namespace stacker > stacker-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the Stacker release to the desired version.\n```bash\nhelm repo update\nhelm upgrade stacker stacker/stacker --version 1.1.7 --namespace stacker\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the Stacker pods to ensure they are running with the new version.\n```bash\nkubectl get pods --namespace stacker\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Stacker pods are in a CrashLoopBackOff state, check the logs for the specific pod to diagnose the issue.\n```bash\nkubectl logs <pod-name> --namespace stacker\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Stacker service, ensure that the port forwarding is set up correctly and that the service is running. Check the service status.\n```bash\nkubectl get svc --namespace stacker\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the Stacker deployment fails due to insufficient resources, check the resource requests and limits set on the deployment. You may need to adjust them or allocate more resources to the cluster.\n```bash\nkubectl describe deployment stacker --namespace stacker\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that you are using a compatible version of the Stacker chart. Check the available versions in the Helm repo.\n```bash\nhelm search repo stacker --namespace stacker\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-strimzi.json
+++ b/solutions/cncf-install/install-strimzi.json
@@ -44,7 +44,53 @@
         "kubectl apply -f https://strimzi.io/examples/latest/kafka/kafka-persistent.yaml --namespace kafka",
         "kubectl get pods --namespace kafka"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Strimzi Kafka Operator release from the 'kafka' namespace using Helm."
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove the Custom Resource Definitions (CRDs) and any persistent volume claims (PVCs) associated with the Kafka cluster."
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'kafka' namespace and verify that it has been removed."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Kafka cluster configuration and any important data."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Strimzi Kafka Operator to the latest version."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Strimzi Kafka Operator and Kafka cluster are running correctly after the upgrade."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start repeatedly. Check the pod logs for errors using the following command:\n```bash\nkubectl logs <pod-name> --namespace kafka\n```"
+      },
+      {
+        "title": "Kafka cluster not responding",
+        "description": "If the Kafka cluster is not responding, check the status of the Kafka pods:\n```bash\nkubectl get pods --namespace kafka\n```"
+      },
+      {
+        "title": "Persistent volume claims not bound",
+        "description": "If PVCs are not bound, check the status of the PVCs using:\n```bash\nkubectl get pvc --namespace kafka\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, verify the release name and namespace:\n```bash\nhelm list --namespace kafka\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-submariner.json
+++ b/solutions/cncf-install/install-submariner.json
@@ -40,7 +40,53 @@
         "subctl deploy-broker --kubeconfig=<path-to-your-kubeconfig>",
         "subctl validate --kubeconfig=<path-to-your-kubeconfig>"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Submariner Helm release from the 'submariner' namespace to remove all associated resources.\n```bash\nhelm uninstall submariner --namespace submariner\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volumes that were created during the installation of Submariner.\n```bash\nkubectl delete crd submariners.submariner.io\nkubectl delete crd gateways.submariner.io\nkubectl delete crd connections.submariner.io\nkubectl delete pvc --all --namespace submariner\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'submariner' namespace and verify that it has been removed successfully.\n```bash\nkubectl delete namespace submariner\nkubectl get namespaces | grep submariner\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of Submariner by exporting the existing configurations and resources.\n```bash\nkubectl get all -n submariner -o yaml > submariner-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade Submariner to the latest version.\n```bash\nhelm repo update\nhelm upgrade submariner submariner/submariner --namespace submariner --version v0.22.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Submariner pods are running the new version and verify the upgrade was successful.\n```bash\nkubectl get pods -n submariner\nsubctl validate --kubeconfig=<path-to-your-kubeconfig>\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Submariner pods are in a CrashLoopBackOff state, check the logs for errors and diagnose the issue.\n```bash\nkubectl logs <pod-name> -n submariner\n```"
+      },
+      {
+        "title": "Submariner not connecting clusters",
+        "description": "If Submariner is unable to connect clusters, verify the configuration and network settings. Check the status of the broker.\n```bash\nsubctl validate --kubeconfig=<path-to-your-kubeconfig>\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version mismatch",
+        "description": "If the Helm upgrade fails due to version mismatch, ensure that the correct version is specified and that the Helm repository is updated.\n```bash\nhelm repo update\nhelm upgrade submariner submariner/submariner --namespace submariner --version v0.22.2\n```"
+      },
+      {
+        "title": "Service discovery issues",
+        "description": "If there are issues with service discovery across clusters, check the Submariner configuration and ensure that the required services are exposed correctly.\n```bash\nkubectl get svc -n submariner\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-telepresence.json
+++ b/solutions/cncf-install/install-telepresence.json
@@ -40,7 +40,53 @@
         "helm upgrade telepresence-traffic-manager telepresence-oss/telepresence-oss --namespace telepresence --set resources.limits.cpu=500m --set resources.limits.memory=256Mi",
         "kubectl port-forward svc/telepresence-traffic-manager --namespace telepresence 8081:8081"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Telepresence Traffic Manager release from your Kubernetes cluster using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall telepresence-traffic-manager --namespace telepresence\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that may have been created during the installation. This ensures that all resources are properly cleaned up.\n```bash\nkubectl delete crd telepresence.*\nkubectl delete pvc --all --namespace telepresence\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Telepresence namespace to remove any remaining resources. Verify that the namespace has been deleted successfully.\n```bash\nkubectl delete namespace telepresence\nkubectl get namespaces | grep telepresence\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the Telepresence Traffic Manager. This can be done by exporting the current Helm values.\n```bash\nhelm get values telepresence-traffic-manager --namespace telepresence > telepresence-backup-values.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the Telepresence Traffic Manager to the latest version. Replace '1.1.2' with the desired version.\n```bash\nhelm repo update\nhelm upgrade telepresence-traffic-manager telepresence-oss/telepresence-oss --namespace telepresence --version 1.1.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Telepresence Traffic Manager pod is running the new version and is operational. This ensures that the upgrade was successful.\n```bash\nkubectl get pods --namespace telepresence\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Telepresence Traffic Manager pods are stuck in a CrashLoopBackOff state, check the logs for errors. This can indicate issues with the configuration or resource limits.\n```bash\nkubectl logs <pod-name> --namespace telepresence\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Telepresence Traffic Manager service, ensure that the port-forwarding command is running and check the service status. Verify that the correct ports are being forwarded.\n```bash\nkubectl get svc --namespace telepresence\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, check the currently installed version and ensure that the version you are trying to upgrade to is compatible. You can view the installed version with:\n```bash\nhelm list --namespace telepresence\n```"
+      },
+      {
+        "title": "Insufficient resources error",
+        "description": "If you encounter an insufficient resources error, it may indicate that the resource limits set for the Traffic Manager are too high for your cluster. Adjust the resource limits and try again.\n```bash\nkubectl describe pod <pod-name> --namespace telepresence\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-tikv.json
+++ b/solutions/cncf-install/install-tikv.json
@@ -40,7 +40,53 @@
         "helm upgrade tikv tikv/tikv --namespace tikv --set resources.limits.cpu=2000m --set resources.limits.memory=4Gi",
         "helm upgrade tikv tikv/tikv --namespace tikv --set monitoring.enabled=true"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the TiKV deployment, use the following command to uninstall the Helm release from the specified namespace:\n```bash\nhelm uninstall tikv --namespace tikv\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the Helm release, you should clean up any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Run the following commands:\n```bash\nkubectl delete crd tikvclusters.pingcap.com\nkubectl delete pvc --all --namespace tikv\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the namespace used for TiKV and verify that it has been deleted:\n```bash\nkubectl delete namespace tikv\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up your current state. You can create a backup of your existing TiKV data by exporting it or taking snapshots, depending on your setup."
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the TiKV release to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade tikv tikv/tikv --namespace tikv --version v8.5.6\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After upgrading, verify that the TiKV pods are running the new version successfully:\n```bash\nkubectl get pods --namespace tikv\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your TiKV pods are stuck in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace tikv\n```\nLook for any configuration issues or resource constraints that may be causing the crash."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to insufficient resources, check the resource requests and limits set for the TiKV deployment:\n```bash\nkubectl describe deployment tikv --namespace tikv\n```\nAdjust the resource limits in your Helm upgrade command if necessary."
+      },
+      {
+        "title": "Failed to connect to TiKV",
+        "description": "If your application fails to connect to TiKV, ensure that the service is running and accessible:\n```bash\nkubectl get svc --namespace tikv\n```\nCheck for any network policies or firewall rules that might be blocking access."
+      },
+      {
+        "title": "Persistent volume issues",
+        "description": "If there are issues with persistent volumes, check the status of the PVCs:\n```bash\nkubectl get pvc --namespace tikv\n```\nEnsure that the PVCs are bound and that the underlying storage is available."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-tokenetes.json
+++ b/solutions/cncf-install/install-tokenetes.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment tokenetes --namespace tokenetes",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To cleanly remove the Tokenetes release, use the following command to uninstall it from the cluster:\n```bash\nhelm uninstall tokenetes --namespace tokenetes\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "After uninstalling the release, you should clean up any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created. Run the following commands:\n```bash\nkubectl delete crd $(kubectl get crd | grep tokenetes | awk '{print $1}')\nkubectl delete pvc --all --namespace tokenetes\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Finally, remove the 'tokenetes' namespace and verify that it has been deleted:\n```bash\nkubectl delete namespace tokenetes\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up the current state of your Tokenetes installation. You can use the following command to export the current configuration:\n```bash\nhelm get values tokenetes --namespace tokenetes > tokenetes-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Tokenetes release to the latest version:\n```bash\nhelm repo update\nhelm upgrade tokenetes tokenetes/tokenetes --version v1.1.0 --namespace tokenetes\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, verify that the Tokenetes pods are running the new version:\n```bash\nkubectl get pods --namespace tokenetes\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Tokenetes pods are in a CrashLoopBackOff state, check the logs for more information:\n```bash\nkubectl logs <pod-name> --namespace tokenetes\n``` \nLook for any error messages that could indicate configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not accessible",
+        "description": "If you cannot access the Tokenetes service, ensure that the port forwarding is set up correctly. Verify the service status:\n```bash\nkubectl get svc --namespace tokenetes\n``` \nIf the service is not running, check the deployment for issues."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter errors related to insufficient resources, check the resource limits and requests set for the deployment:\n```bash\nkubectl describe deployment tokenetes --namespace tokenetes\n``` \nAdjust the resource limits in the deployment if necessary."
+      },
+      {
+        "title": "Helm upgrade fails",
+        "description": "If the Helm upgrade fails, check for any error messages in the command output. You can also view the current release status:\n```bash\nhelm status tokenetes --namespace tokenetes\n``` \nIf needed, you can rollback to the previous version using:\n```bash\nhelm rollback tokenetes <revision-number> --namespace tokenetes\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-trickster.json
+++ b/solutions/cncf-install/install-trickster.json
@@ -40,7 +40,53 @@
         "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: trickster\n  namespace: trickster\nspec:\n  template:\n    spec:\n      containers:\n      - name: trickster\n        resources:\n          limits:\n            memory: \"512Mi\"\n            cpu: \"500m\"",
         "kubectl apply -f trickster-limits.yaml"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Trickster release from the Kubernetes cluster using Helm with the following command:\n```bash\nhelm uninstall trickster --namespace trickster\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Trickster. Use the following commands:\n```bash\nkubectl delete pvc --all --namespace trickster\nkubectl delete crd tricksters.trickstercache.org\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the Trickster namespace and verify that it has been removed:\n```bash\nkubectl delete namespace trickster\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current Trickster configuration and data. You can use the following command to export the current deployment:\n```bash\nkubectl get deployment trickster --namespace trickster -o yaml > trickster-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Trickster Helm repository and upgrade Trickster to the latest version:\n```bash\nhelm repo update\nhelm upgrade trickster trickster/trickster --namespace trickster --version v2.0.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Trickster pods are running the new version successfully:\n```bash\nkubectl get pods --namespace trickster\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Trickster pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace trickster\n``` \nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Trickster service, ensure that the service is running and the port forwarding is set up correctly:\n```bash\nkubectl get svc --namespace trickster\nkubectl port-forward service/trickster --namespace trickster 8080:80\n```"
+      },
+      {
+        "title": "High memory usage",
+        "description": "If Trickster is consuming too much memory, check the resource limits and adjust them if necessary. You can view the resource usage with:\n```bash\nkubectl top pods --namespace trickster\n```"
+      },
+      {
+        "title": "Configuration changes not applied",
+        "description": "If changes to the Trickster configuration are not reflected, ensure that the deployment was updated correctly. Reapply the configuration file:\n```bash\nkubectl apply -f trickster-limits.yaml --namespace trickster\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-vineyard.json
+++ b/solutions/cncf-install/install-vineyard.json
@@ -40,7 +40,53 @@
         "helm upgrade vineyard-operator vineyard/vineyard-operator --namespace vineyard --set controllerManager.manager.resources.limits.cpu=500m --set controllerManager.manager.resources.limits.memory=500Mi",
         "kubectl port-forward svc/vineyard-metrics --namespace vineyard 8443:8443"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Vineyard Operator Helm release to remove the deployment from your cluster. Use the following command:\n```bash\nhelm uninstall vineyard-operator --namespace vineyard\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Vineyard. Run the following commands:\n```bash\nkubectl delete crd vineyards.vineyard.io\nkubectl delete pvc --all --namespace vineyard\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the namespace used for the Vineyard Operator and verify that it has been removed. Use the following commands:\n```bash\nkubectl delete namespace vineyard\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current state of your Vineyard installation. You can export the current configuration with:\n```bash\nkubectl get all --namespace vineyard -o yaml > vineyard-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Vineyard Operator to the latest version. Execute the following commands:\n```bash\nhelm repo update\nhelm upgrade vineyard-operator vineyard/vineyard-operator --version 0.25.0 --namespace vineyard\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Vineyard Operator pod is running with the new version after the upgrade. Use the following command:\n```bash\nkubectl get pods --namespace vineyard\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If your Vineyard Operator pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command to view the logs:\n```bash\nkubectl logs <pod-name> --namespace vineyard\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Vineyard service, ensure that the service is running and check the endpoints. Use the following commands:\n```bash\nkubectl get svc --namespace vineyard\nkubectl describe svc vineyard-metrics --namespace vineyard\n```"
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If the Vineyard Operator fails to start due to insufficient resources, check the resource requests and limits. You can view the current configuration with:\n```bash\nkubectl get deployment vineyard-operator --namespace vineyard -o yaml\n```"
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter issues related to missing CRDs, verify that the CRDs are installed correctly. Check the CRDs with:\n```bash\nkubectl get crd --namespace vineyard\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-virtual-kubelet.json
+++ b/solutions/cncf-install/install-virtual-kubelet.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment virtual-kubelet -n virtual-kubelet",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Virtual Kubelet Helm release from the cluster using the following command:\n```bash\nhelm uninstall virtual-kubelet --namespace virtual-kubelet\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent resources associated with Virtual Kubelet. Execute the following commands:\n```bash\nkubectl delete crd virtualkubelets.virtual-kubelet.io\nkubectl delete pvc --all --namespace virtual-kubelet\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the `virtual-kubelet` namespace and verify its removal:\n```bash\nkubectl delete namespace virtual-kubelet\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of Virtual Kubelet. You can export the deployment configuration with:\n```bash\nkubectl get deployment virtual-kubelet -n virtual-kubelet -o yaml > virtual-kubelet-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Virtual Kubelet release to the latest version:\n```bash\nhelm repo update\nhelm upgrade virtual-kubelet virtual-kubelet/virtual-kubelet --namespace virtual-kubelet --version v1.12.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check if the Virtual Kubelet pod is running the new version by executing:\n```bash\nkubectl get pods -n virtual-kubelet -o wide\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods not scheduling on Virtual Kubelet",
+        "description": "If pods are not scheduling on the Virtual Kubelet, check the logs for errors:\n```bash\nkubectl logs -l app=virtual-kubelet -n virtual-kubelet\n``` \nEnsure that the Virtual Kubelet is correctly configured and that the cloud provider is reachable."
+      },
+      {
+        "title": "Virtual Kubelet pod in CrashLoopBackOff",
+        "description": "If the Virtual Kubelet pod is in a CrashLoopBackOff state, check the pod events and logs:\n```bash\nkubectl describe pod virtual-kubelet -n virtual-kubelet\nkubectl logs virtual-kubelet -n virtual-kubelet\n``` \nInvestigate any configuration issues or resource limits that may be causing the crash."
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter RBAC permission errors, verify the Role and RoleBinding configurations:\n```bash\nkubectl get role virtual-kubelet-role -n virtual-kubelet -o yaml\nkubectl get rolebinding virtual-kubelet-binding -n virtual-kubelet -o yaml\n``` \nEnsure that the Role has the necessary permissions for the resources being accessed."
+      },
+      {
+        "title": "Network connectivity issues",
+        "description": "If there are connectivity issues with the cloud provider, check the network configuration and logs:\n```bash\nkubectl logs virtual-kubelet -n virtual-kubelet\n``` \nMake sure that the Virtual Kubelet can reach the necessary endpoints and that there are no firewall rules blocking access."
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-vitess.json
+++ b/solutions/cncf-install/install-vitess.json
@@ -40,7 +40,53 @@
         "kubectl edit deployment vitess --namespace vitess",
         "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\""
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Vitess release from the Kubernetes cluster using Helm. This will remove all associated resources except for CRDs and persistent volumes.\n```bash\nhelm uninstall vitess --namespace vitess\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that no leftover resources remain.\n```bash\nkubectl delete crd vitessclusters.vitess.io\nkubectl delete pvc --all --namespace vitess\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'vitess' namespace to clean up all resources associated with the installation. Verify that the namespace has been removed successfully.\n```bash\nkubectl delete namespace vitess\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of the Vitess installation. You can use the following command to export the current configuration.\n```bash\nhelm get values vitess --namespace vitess > vitess-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository and upgrade the Vitess installation to the latest version. Replace 'v23.0.4' with the desired version if necessary.\n```bash\nhelm repo update\nhelm upgrade vitess vitess/vitess --namespace vitess --version v23.0.4\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "After the upgrade, check the status of the Vitess pods to ensure they are running the new version without issues.\n```bash\nkubectl get pods --namespace vitess\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Vitess pods are in a CrashLoopBackOff state, check the logs for errors that may indicate what is causing the crash.\n```bash\nkubectl logs <pod-name> --namespace vitess\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Vitess service, ensure that the port forwarding is set up correctly and that the service is running. Check the service status with:\n```bash\nkubectl get svc --namespace vitess\n```"
+      },
+      {
+        "title": "Insufficient resources allocated",
+        "description": "If you encounter issues related to insufficient resources, verify the resource limits set in the deployment. You can check the current resource allocation with:\n```bash\nkubectl describe deployment vitess --namespace vitess\n```"
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If the Helm upgrade fails due to a version conflict, ensure that you are using a compatible version of the Vitess chart. Check the available versions with:\n```bash\nhelm search repo vitess --namespace vitess\n```"
+      }
+    ]
   },
   "metadata": {
     "tags": [

--- a/solutions/cncf-install/install-wasmcloud.json
+++ b/solutions/cncf-install/install-wasmcloud.json
@@ -40,7 +40,53 @@
         "helm upgrade wasmcloud wasmcloud/benchmark --namespace wasmcloud --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
         "kubectl port-forward svc/wasmcloud 8080:80 --namespace wasmcloud"
       ]
-    }
+    },
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the wasmCloud release from the specified namespace using Helm. This will remove the deployment and associated resources managed by Helm.\n```bash\nhelm uninstall wasmcloud --namespace wasmcloud\n```"
+      },
+      {
+        "title": "Clean up CRDs and persistent resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources are cleaned up.\n```bash\nkubectl delete crd wasmclouds.wasmcloud.net\nkubectl delete pvc --all --namespace wasmcloud\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the wasmcloud namespace and verify that it has been removed. This step ensures that all resources associated with the namespace are cleaned up.\n```bash\nkubectl delete namespace wasmcloud\nkubectl get namespaces | grep wasmcloud\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's important to back up the current state of the release. This can be done by exporting the current configuration.\n```bash\nhelm get values wasmcloud --namespace wasmcloud > wasmcloud-backup.yaml\n```"
+      },
+      {
+        "title": "Update repo and run upgrade command",
+        "description": "Update the Helm repository to ensure you have the latest charts, then upgrade the wasmCloud release to the new version.\n```bash\nhelm repo update\nhelm upgrade wasmcloud wasmcloud/benchmark --namespace wasmcloud --version 0.2.2\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the pods to ensure that the upgrade was successful and that all pods are running as expected.\n```bash\nkubectl get pods --namespace wasmcloud\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "This issue occurs when a pod fails to start properly and keeps crashing. To diagnose, check the logs of the pod:\n```bash\nkubectl logs <pod-name> --namespace wasmcloud\n```\nLook for error messages that indicate what might be causing the crash."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the wasmCloud service is not reachable, verify that the port forwarding is set up correctly. Check the service status:\n```bash\nkubectl get svc --namespace wasmcloud\n```\nEnsure that the correct ports are being forwarded and that the service is running."
+      },
+      {
+        "title": "Insufficient resources",
+        "description": "If you encounter issues related to resource limits, check the resource usage of the pods:\n```bash\nkubectl top pods --namespace wasmcloud\n```\nIf necessary, adjust the resource limits in the Helm values and upgrade the release."
+      },
+      {
+        "title": "Helm upgrade fails with version conflict",
+        "description": "If you receive an error about version conflicts during an upgrade, ensure that you are using a compatible version of the chart. Check the available versions:\n```bash\nhelm search repo wasmcloud/benchmark --versions\n```\nIf needed, specify a different version in the upgrade command."
+      }
+    ]
   },
   "metadata": {
     "tags": [


### PR DESCRIPTION
Adds uninstall, upgrade, and troubleshooting sections to all 164 existing CNCF install missions.

**New script:** `scripts/enrich-install-missions.mjs` — reads existing install JSON, calls LLM to generate 3 missing sections, merges them back. Supports batching, concurrency, and dry-run mode.

**Results:** All 164 missions now have:
- **Uninstall:** 3 steps (remove release, clean CRDs/PVCs, remove namespace)
- **Upgrade:** 3 steps (backup state, update + upgrade, verify)
- **Troubleshooting:** 4 common issues with diagnostic commands

These sections are already rendered in the console's InstallerCard coverage icons and MissionDetailView tabs.