### PR TITLE
✨ Add 13 CNCF install missions (batch consolidation)

### DIFF
--- a/solutions/cncf-install/install-confidential-containers.json
+++ b/solutions/cncf-install/install-confidential-containers.json
@@ -1,0 +1,141 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-confidential-containers",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Confidential Containers on Kubernetes",
+    "description": "Confidential Containers is an open-source community project that leverages Trusted Execution Environments (TEEs) to enhance the security of containers and protect sensitive data in cloud-native applications. Installing it allows you to enforce application security requirements while maintaining transparency in deploying unmodified containers.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Confidential Containers Helm repository",
+        "description": "First, add the Helm chart repository for Confidential Containers to your Helm client. This will allow you to install the necessary components easily.\n\n```bash\nhelm repo add confidential-containers https://confidential-containers.github.io/charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install the Confidential Containers Helm chart",
+        "description": "Now, install the Confidential Containers chart with the specified version and create a namespace for it.\n\n```bash\nhelm install confidential-containers confidential-containers/confidential-containers --version v0.17.0 --namespace confidential --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check if the pods are running successfully in the confidential namespace.\n\n```bash\nkubectl get pods --namespace confidential\n```"
+      },
+      {
+        "title": "Post-install configuration",
+        "description": "Configure resource limits for the Confidential Containers deployment to ensure optimal performance and resource utilization.\n\n```bash\nkubectl set resources deployment confidential-containers --namespace confidential --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi\n```"
+      },
+      {
+        "title": "Set up RBAC for security",
+        "description": "Create a Role and RoleBinding to ensure that the Confidential Containers can operate with the least privilege necessary.\n\n```bash\nkubectl create role confidential-containers-role --verb=get,list,watch --resource=pods --namespace=confidential\nkubectl create rolebinding confidential-containers-rolebinding --role=confidential-containers-role --serviceaccount=confidential:default --namespace=confidential\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Confidential Containers release using Helm.\n\n```bash\nhelm uninstall confidential-containers --namespace confidential\n```"
+      },
+      {
+        "title": "Clean up CRDs and resources",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were installed with the release.\n\n```bash\nkubectl delete crd confidentialcontainers.confidentialcontainers.io\n```"
+      },
+      {
+        "title": "Delete the namespace",
+        "description": "Finally, delete the namespace used for the installation to clean up all associated resources.\n\n```bash\nkubectl delete namespace confidential\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and state of the deployment.\n\n```bash\nkubectl get all --namespace confidential -o yaml > backup-confidential-containers.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Update the Helm repository to ensure you have the latest charts available.\n\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade the Confidential Containers installation",
+        "description": "Upgrade the installation to the latest version available in the Helm repository.\n\n```bash\nhelm upgrade confidential-containers confidential-containers/confidential-containers --version v0.17.0 --namespace confidential\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the pods to ensure they are running the new version.\n\n```bash\nkubectl get pods --namespace confidential\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "If your pods are stuck in Pending, check for resource availability in your cluster.\n\n```bash\nkubectl describe pod <pod-name> --namespace confidential\n``` \nEnsure that there are enough resources available in the cluster or adjust the resource requests in your deployment."
+      },
+      {
+        "title": "CrashLoopBackOff errors",
+        "description": "If you see CrashLoopBackOff errors, check the logs of the affected pod to diagnose the issue.\n\n```bash\nkubectl logs <pod-name> --namespace confidential\n``` \nLook for any application errors or misconfigurations."
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If the service is not reachable, verify that the service is correctly configured and the endpoints are available.\n\n```bash\nkubectl get svc --namespace confidential\nkubectl describe svc <service-name> --namespace confidential\n``` \nEnsure that the service type and ports are correctly set."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Confidential Containers will result in all pods running without errors in the 'confidential' namespace. You should also be able to access the deployed services as intended.",
+      "codeSnippets": [
+        "helm repo add confidential-containers https://confidential-containers.github.io/charts\nhelm repo update",
+        "helm install confidential-containers confidential-containers/confidential-containers --version v0.17.0 --namespace confidential --create-namespace",
+        "kubectl get pods --namespace confidential",
+        "kubectl set resources deployment confidential-containers --namespace confidential --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
+        "kubectl create role confidential-containers-role --verb=get,list,watch --resource=pods --namespace=confidential\nkubectl create rolebinding confidential-containers-rolebinding --role=confidential-containers-role --serviceaccount=confidential:default --namespace=confidential"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "security",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "confidential-containers"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace",
+      "Serviceaccount"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v0.17.0",
+    "containerImages": [
+      "confidentialcontainers/coco:v0.17.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://confidentialcontainers.org/",
+      "repo": "https://github.com/confidential-containers/confidential-containers"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running version 1.24 or higher, and have Helm and kubectl installed on your local machine."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T20:01:48.705Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-containerssh.json
+++ b/solutions/cncf-install/install-containerssh.json
@@ -1,0 +1,144 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-containerssh",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Containerssh on Kubernetes",
+    "description": "ContainerSSH is an SSH server that launches containers on demand in Kubernetes and Docker, providing dynamic access for various use cases such as lab environments, debugging, and honeypots. Installing ContainerSSH allows you to manage containerized environments efficiently and securely.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the ContainerSSH Helm repository",
+        "description": "Add the official ContainerSSH Helm repository to your Helm configuration. This allows you to install ContainerSSH using Helm.\n```bash\nhelm repo add containerssh https://containerssh.github.io/charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install ContainerSSH using Helm",
+        "description": "Install ContainerSSH with a specific version and create a namespace for it.\n```bash\nhelm install containerssh containerssh/containerssh --version v0.5.2 --namespace containerssh --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check if the ContainerSSH pods are running successfully in the namespace.\n```bash\nkubectl get pods -n containerssh\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Edit the deployment to set resource limits for the ContainerSSH pods.\n```bash\nkubectl edit deployment containerssh -n containerssh\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"\n```"
+      },
+      {
+        "title": "Set up port forwarding for access",
+        "description": "Forward a local port to the ContainerSSH service to access it.\n```bash\nkubectl port-forward svc/containerssh -n containerssh 2222:22\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the ContainerSSH Helm release to remove the application from your cluster.\n```bash\nhelm uninstall containerssh --namespace containerssh\n```"
+      },
+      {
+        "title": "Clean up CRDs and resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) and other resources that were created during the installation.\n```bash\nkubectl delete crd containersshs.containerssh.io\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Delete the namespace used for ContainerSSH to clean up any remaining resources.\n```bash\nkubectl delete namespace containerssh\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, backup the current configuration and state of ContainerSSH.\n```bash\nkubectl get all -n containerssh -o yaml > containerssh-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Ensure you have the latest version of the ContainerSSH Helm chart.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade ContainerSSH",
+        "description": "Upgrade the ContainerSSH installation to the latest version.\n```bash\nhelm upgrade containerssh containerssh/containerssh --version v0.5.2 --namespace containerssh\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the pods to ensure they are running the new version.\n```bash\nkubectl get pods -n containerssh\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "This may indicate insufficient resources in the cluster. Check the events for the pods to diagnose.\n```bash\nkubectl describe pod <pod-name> -n containerssh\n```"
+      },
+      {
+        "title": "ContainerSSH service not reachable",
+        "description": "Ensure that the port forwarding is set up correctly and the service is running. Check the service status.\n```bash\nkubectl get svc -n containerssh\n```"
+      },
+      {
+        "title": "Authentication failures",
+        "description": "Check the logs of the ContainerSSH pod for any authentication-related errors.\n```bash\nkubectl logs <pod-name> -n containerssh\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to out-of-memory errors, consider increasing the memory limits in the deployment.\n```bash\nkubectl edit deployment containerssh -n containerssh\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of ContainerSSH will have all pods running in the 'containerssh' namespace, and you will be able to SSH into the service using the forwarded port. You can also verify that resource limits are correctly configured.",
+      "codeSnippets": [
+        "helm repo add containerssh https://containerssh.github.io/charts\nhelm repo update",
+        "helm install containerssh containerssh/containerssh --version v0.5.2 --namespace containerssh --create-namespace",
+        "kubectl get pods -n containerssh",
+        "kubectl edit deployment containerssh -n containerssh\n# Add the following under spec.containers:\n# resources:\n#   limits:\n#     cpu: \"500m\"\n#     memory: \"512Mi\"",
+        "kubectl port-forward svc/containerssh -n containerssh 2222:22"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "containerssh"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v0.5.2",
+    "containerImages": [
+      "containerssh/containerssh:v0.5.2"
+    ],
+    "sourceUrls": {
+      "docs": "https://containerssh.io/",
+      "repo": "https://github.com/containerssh/containerssh"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running and both Helm and kubectl installed on your local machine."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T20:08:26.155Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-dex.json
+++ b/solutions/cncf-install/install-dex.json
@@ -1,0 +1,140 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-dex",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Dex on Kubernetes",
+    "description": "Dex is an OpenID Connect (OIDC) identity and OAuth 2.0 provider that allows applications to authenticate users through various identity providers. Installing Dex provides a centralized authentication service that can integrate with existing identity systems, enhancing security and user management.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Helm repository",
+        "description": "Add the Dex Helm chart repository to your Helm client.\n```bash\nhelm repo add dex https://charts.dexidp.io\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Dex using Helm",
+        "description": "Install Dex with the specified version and create a namespace for it.\n```bash\nhelm install dex dex/dex --version v2.45.0 --namespace dex --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check if the Dex pods are running successfully.\n```bash\nkubectl get pods -n dex\n```"
+      },
+      {
+        "title": "Port-forward to access Dex",
+        "description": "Set up port forwarding to access the Dex service locally.\n```bash\nkubectl port-forward svc/dex 5556:5556 -n dex\n```"
+      },
+      {
+        "title": "Post-install configuration",
+        "description": "Configure resource limits for Dex by editing the deployment.\n```bash\nkubectl edit deployment dex -n dex\n# Add the following under spec.template.spec.containers.resources:\n# resources:\n#   limits:\n#     cpu: 500m\n#     memory: 512Mi\n#   requests:\n#     cpu: 250m\n#     memory: 256Mi\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Dex Helm release from the cluster.\n```bash\nhelm uninstall dex --namespace dex\n```"
+      },
+      {
+        "title": "Clean up CRDs and resources",
+        "description": "Delete any custom resources associated with Dex.\n```bash\nkubectl delete crd authrequests.dex.idp.io\nkubectl delete crd connectors.dex.idp.io\nkubectl delete crd oauth2clients.dex.idp.io\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Delete the namespace created for Dex.\n```bash\nkubectl delete namespace dex\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Backup the current configuration and state of Dex.\n```bash\nkubectl get all -n dex -o yaml > dex-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Update the Helm repository to fetch the latest charts.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade Dex",
+        "description": "Upgrade the Dex installation to the latest version.\n```bash\nhelm upgrade dex dex/dex --version v2.45.0 --namespace dex\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Dex pods to ensure they are running the new version.\n```bash\nkubectl get pods -n dex\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If Dex pods are in a CrashLoopBackOff state, check the logs for errors.\n```bash\nkubectl logs <pod-name> -n dex\n# Look for any configuration errors or missing dependencies.\n```"
+      },
+      {
+        "title": "Service not reachable",
+        "description": "If you cannot access the Dex service, ensure the service is running and the port-forwarding is set up correctly.\n```bash\nkubectl get svc -n dex\n# Check if the service is listed and then re-run the port-forward command.\n```"
+      },
+      {
+        "title": "Authentication failures",
+        "description": "If authentication fails, verify the connectors and configuration in the Dex deployment.\n```bash\nkubectl get configmap -n dex\n# Check the configuration for any misconfigurations in connectors.\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Dex will have all pods running in the 'dex' namespace, and you will be able to access the Dex service via port 5556. You should also be able to authenticate users through the configured identity providers.",
+      "codeSnippets": [
+        "helm repo add dex https://charts.dexidp.io\nhelm repo update",
+        "helm install dex dex/dex --version v2.45.0 --namespace dex --create-namespace",
+        "kubectl get pods -n dex",
+        "kubectl port-forward svc/dex 5556:5556 -n dex",
+        "kubectl edit deployment dex -n dex\n# Add the following under spec.template.spec.containers.resources:\n# resources:\n#   limits:\n#     cpu: 500m\n#     memory: 512Mi\n#   requests:\n#     cpu: 250m\n#     memory: 256Mi"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "security",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "dex"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v2.45.0",
+    "containerImages": [
+      "dexidp/dex:v2.45.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://dexidp.io",
+      "repo": "https://github.com/dexidp/dex"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running and Helm installed on your local machine."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T20:22:14.837Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-eraser.json
+++ b/solutions/cncf-install/install-eraser.json
@@ -1,0 +1,139 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-eraser",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Eraser on Kubernetes",
+    "description": "Eraser is a tool designed to help Kubernetes administrators clean up non-running images from all nodes in a cluster, ensuring efficient resource usage and management. Installing Eraser allows you to automate the cleanup process and maintain a tidy environment.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Helm repository",
+        "description": "First, add the Eraser Helm chart repository to your local Helm configuration. This allows you to install Eraser using Helm.\n```bash\nhelm repo add eraser https://eraser-dev.github.io/eraser/charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Eraser using Helm",
+        "description": "Now, install the Eraser Helm chart. This command will create the necessary namespace and deploy the application.\n```bash\nhelm install eraser eraser/eraser --namespace eraser-system --create-namespace --version 1.5.0-beta.0\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check if the Eraser pods are running successfully in the eraser-system namespace.\n```bash\nkubectl get pods --namespace eraser-system\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "After installation, you may want to configure resource limits for the Eraser components. Edit the values.yaml file or use the `--set` flag to specify resource limits during installation.\n```bash\nhelm upgrade eraser eraser/eraser --namespace eraser-system --set components.collector.limit.cpu=500m --set components.collector.limit.mem=512Mi\n```"
+      },
+      {
+        "title": "Set up health checks",
+        "description": "To ensure that Eraser is functioning correctly, you can configure health checks. Modify the `healthProbeBindAddress` in the values.yaml file or use the `--set` flag:\n```bash\nhelm upgrade eraser eraser/eraser --namespace eraser-system --set runtimeConfig.health.healthProbeBindAddress=:8081\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "To uninstall Eraser, first remove the Helm release:\n```bash\nhelm uninstall eraser --namespace eraser-system\n```"
+      },
+      {
+        "title": "Delete the Custom Resource Definitions",
+        "description": "Next, clean up the Custom Resource Definitions (CRDs) associated with Eraser:\n```bash\nkubectl delete crd imagejobs.eraser.sh\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Finally, delete the namespace created for Eraser to clean up any remaining resources:\n```bash\nkubectl delete namespace eraser-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to backup the current state of your Eraser installation:\n```bash\nhelm get values eraser --namespace eraser-system > eraser-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Update the Helm repository to ensure you have the latest charts:\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade Eraser",
+        "description": "Now, upgrade your Eraser installation to the latest version:\n```bash\nhelm upgrade eraser eraser/eraser --namespace eraser-system --version 1.5.0-beta.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Eraser pods to ensure the upgrade was successful:\n```bash\nkubectl get pods --namespace eraser-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "If Eraser pods are stuck in the Pending state, check for insufficient resources in your cluster:\n```bash\nkubectl describe pod <pod-name> --namespace eraser-system\n``` \nEnsure your nodes have enough resources available."
+      },
+      {
+        "title": "Eraser not cleaning images",
+        "description": "If Eraser is not cleaning images as expected, check the logs for the collector pod:\n```bash\nkubectl logs <collector-pod-name> --namespace eraser-system\n``` \nLook for any errors or misconfigurations in the logs."
+      },
+      {
+        "title": "Health checks failing",
+        "description": "If health checks are failing, verify the health probe configuration:\n```bash\nkubectl get pods --namespace eraser-system -o jsonpath='{.items[*].status.containerStatuses[*].ready}'\n``` \nEnsure the health probe settings are correctly configured in the values.yaml."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Eraser will result in the Eraser pods running in the 'eraser-system' namespace, with no errors in the pod logs. You should also see the Eraser components actively cleaning up non-running images as per your configuration.",
+      "codeSnippets": [
+        "helm repo add eraser https://eraser-dev.github.io/eraser/charts\nhelm repo update",
+        "helm install eraser eraser/eraser --namespace eraser-system --create-namespace --version 1.5.0-beta.0",
+        "kubectl get pods --namespace eraser-system",
+        "helm upgrade eraser eraser/eraser --namespace eraser-system --set components.collector.limit.cpu=500m --set components.collector.limit.mem=512Mi",
+        "helm upgrade eraser eraser/eraser --namespace eraser-system --set runtimeConfig.health.healthProbeBindAddress=:8081"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "eraser"
+    ],
+    "targetResourceKinds": [
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v1.4.1",
+    "containerImages": [
+      "ghcr.io/eraser-dev/eraser:v1.5.0-beta.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://eraser-dev.github.io/eraser/",
+      "repo": "https://github.com/eraser-dev/eraser",
+      "helm": "https://github.com/eraser-dev/eraser/tree/main/charts/eraser/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have Kubernetes cluster access and Helm installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T20:29:05.882Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-external-secrets.json
+++ b/solutions/cncf-install/install-external-secrets.json
@@ -1,0 +1,143 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-external-secrets",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure External Secrets on Kubernetes",
+    "description": "External Secrets Operator reads information from third-party services like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets. Installing this operator allows you to manage secrets securely and efficiently within your Kubernetes cluster.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Helm repository",
+        "description": "Add the External Secrets Helm chart repository to your Helm configuration.\n```bash\nhelm repo add external-secrets https://charts.external-secrets.io\nhelm repo update\n```"
+      },
+      {
+        "title": "Install the External Secrets Operator",
+        "description": "Install the External Secrets Operator using Helm, creating a namespace if it doesn't exist.\n```bash\nhelm install external-secrets external-secrets/external-secrets --namespace external-secrets --create-namespace --version 2.0.1\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the External Secrets Operator pods are running correctly.\n```bash\nkubectl get pods --namespace external-secrets\n```"
+      },
+      {
+        "title": "Configure RBAC for External Secrets",
+        "description": "Create a Role and RoleBinding for the External Secrets Operator to manage secrets.\n```bash\nkubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: external-secrets\n  name: external-secrets-role\nrules:\n  - apiGroups: [\"*\"]\n    resources: [\"secrets\"]\n    verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"delete\"]\nEOF\n\nkubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: external-secrets-rolebinding\n  namespace: external-secrets\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: external-secrets-role\nsubjects:\n  - kind: ServiceAccount\n    name: default\n    namespace: external-secrets\nEOF\n```"
+      },
+      {
+        "title": "Set resource limits",
+        "description": "Update the deployment to set resource limits for the External Secrets Operator.\n```bash\nkubectl set resources deployment external-secrets --namespace external-secrets --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the External Secrets Operator Helm release.\n```bash\nhelm uninstall external-secrets --namespace external-secrets\n```"
+      },
+      {
+        "title": "Delete CRDs",
+        "description": "Remove the Custom Resource Definitions created by the External Secrets Operator.\n```bash\nkubectl delete crd externalsecrets.external-secrets.io\nkubectl delete crd clusterexternalsecrets.external-secrets.io\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Delete the namespace used for the External Secrets Operator.\n```bash\nkubectl delete namespace external-secrets\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the current configuration of the External Secrets resources before upgrading.\n```bash\nkubectl get externalsecrets --all-namespaces -o yaml > externalsecrets-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Update the Helm repository to ensure you have the latest charts.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade the External Secrets Operator",
+        "description": "Upgrade the External Secrets Operator to the latest version.\n```bash\nhelm upgrade external-secrets external-secrets/external-secrets --namespace external-secrets --version 2.0.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the External Secrets Operator pods are running the new version.\n```bash\nkubectl get pods --namespace external-secrets\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the External Secrets Operator pods are in a CrashLoopBackOff state, check the logs for errors.\n```bash\nkubectl logs <pod-name> --namespace external-secrets\n```\nCommon issues may include misconfigured secret management settings or insufficient permissions."
+      },
+      {
+        "title": "Secrets not being injected",
+        "description": "If secrets are not being injected, verify the configuration of your ExternalSecret resource.\n```bash\nkubectl describe externalsecret <externalsecret-name> --namespace <namespace>\n```\nEnsure that the external secret source is correctly configured and accessible."
+      },
+      {
+        "title": "RBAC issues",
+        "description": "If you encounter permission denied errors, check the RBAC configuration.\n```bash\nkubectl get rolebindings --namespace external-secrets\nkubectl get roles --namespace external-secrets\n```\nMake sure the service account has the necessary permissions to access secrets."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of the External Secrets Operator will result in the operator pods running without errors, and you will be able to create ExternalSecret resources that successfully inject secrets into your Kubernetes cluster. You can verify the functionality by checking the injected secrets in your namespace.",
+      "codeSnippets": [
+        "helm repo add external-secrets https://charts.external-secrets.io\nhelm repo update",
+        "helm install external-secrets external-secrets/external-secrets --namespace external-secrets --create-namespace --version 2.0.1",
+        "kubectl get pods --namespace external-secrets",
+        "kubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: external-secrets\n  name: external-secrets-role\nrules:\n  - apiGroups: [\"*\"]\n    resources: [\"secrets\"]\n    verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"delete\"]\nEOF\n\nkubectl apply -f - <<EOF\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: external-secrets-rolebinding\n  namespace: external-secrets\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: external-secrets-role\nsubjects:\n  - kind: ServiceAccount\n    name: default\n    namespace: external-secrets\nEOF",
+        "kubectl set resources deployment external-secrets --namespace external-secrets --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "security",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "external-secrets"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Secret",
+      "Namespace",
+      "Serviceaccount"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "helm-chart-2.0.1",
+    "containerImages": [
+      "ghcr.io/external-secrets/external-secrets:v2.0.1"
+    ],
+    "sourceUrls": {
+      "docs": "https://external-secrets.io/main",
+      "repo": "https://github.com/external-secrets/external-secrets",
+      "helm": "https://github.com/external-secrets/external-secrets/tree/main/deploy/charts/external-secrets/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have Helm and kubectl installed and configured to interact with your Kubernetes cluster."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T20:35:24.164Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-headlamp.json
+++ b/solutions/cncf-install/install-headlamp.json
@@ -1,0 +1,144 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-headlamp",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Headlamp on Kubernetes",
+    "description": "Headlamp is an easy-to-use and extensible Kubernetes web UI that provides a user-friendly interface for managing Kubernetes resources. Installing Headlamp allows you to visualize and interact with your Kubernetes clusters more effectively.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Helm repository",
+        "description": "Add the Headlamp Helm chart repository to your local Helm setup with the following command:\n```bash\nhelm repo add headlamp https://charts.headlamp.dev\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Headlamp using Helm",
+        "description": "Install Headlamp in your Kubernetes cluster with the following command, creating a new namespace called 'headlamp':\n```bash\nhelm install headlamp headlamp/headlamp --namespace headlamp --create-namespace --version 0.40.1\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the Headlamp pods are running successfully:\n```bash\nkubectl get pods --namespace headlamp\n```"
+      },
+      {
+        "title": "Port-forward to access Headlamp",
+        "description": "Set up port forwarding to access the Headlamp UI from your local machine:\n```bash\nkubectl port-forward svc/headlamp --namespace headlamp 8080:80\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Edit the Headlamp deployment to set resource limits. Use the following command to open the deployment configuration:\n```bash\nkubectl edit deployment headlamp --namespace headlamp\n```\nThen, add the following under the `spec.template.spec.containers.resources` section:\n```yaml\nresources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\"\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Headlamp release from your cluster:\n```bash\nhelm uninstall headlamp --namespace headlamp\n```"
+      },
+      {
+        "title": "Clean up CRDs and resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) related to Headlamp:\n```bash\nkubectl delete crd headlamp.k8s.io\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Delete the 'headlamp' namespace to clean up any remaining resources:\n```bash\nkubectl delete namespace headlamp\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration:\n```bash\nhelm get values headlamp --namespace headlamp > headlamp-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Ensure you have the latest version of the Headlamp chart:\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade Headlamp",
+        "description": "Upgrade Headlamp to the latest version:\n```bash\nhelm upgrade headlamp headlamp/headlamp --namespace headlamp --version 0.40.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Headlamp pods are running successfully after the upgrade:\n```bash\nkubectl get pods --namespace headlamp\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending",
+        "description": "If the Headlamp pods are stuck in Pending, check for insufficient resources:\n```bash\nkubectl describe pod <pod-name> --namespace headlamp\n```\nEnsure that your cluster has enough resources available or adjust the resource requests in the deployment."
+      },
+      {
+        "title": "Headlamp UI not accessible",
+        "description": "If you cannot access the Headlamp UI, ensure that the port-forward command is running. If it is, check the service:\n```bash\nkubectl get svc --namespace headlamp\n```\nMake sure the service is correctly configured and running."
+      },
+      {
+        "title": "Error: ImagePullBackOff",
+        "description": "If you see an ImagePullBackOff error, check the image name and tag:\n```bash\nkubectl describe pod <pod-name> --namespace headlamp\n```\nEnsure that the image exists in the specified registry and that your cluster can access it."
+      },
+      {
+        "title": "CrashLoopBackOff on Headlamp pods",
+        "description": "If the Headlamp pods are in a CrashLoopBackOff state, check the logs:\n```bash\nkubectl logs <pod-name> --namespace headlamp\n```\nLook for any error messages that indicate what might be wrong with the configuration."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Headlamp will result in a running instance of the Headlamp UI, accessible via port-forwarding on your local machine. You should see the Headlamp dashboard when navigating to http://localhost:8080.",
+      "codeSnippets": [
+        "helm repo add headlamp https://charts.headlamp.dev\nhelm repo update",
+        "helm install headlamp headlamp/headlamp --namespace headlamp --create-namespace --version 0.40.1",
+        "kubectl get pods --namespace headlamp",
+        "kubectl port-forward svc/headlamp --namespace headlamp 8080:80",
+        "kubectl edit deployment headlamp --namespace headlamp"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "observability",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "headlamp"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Namespace"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v0.40.1",
+    "containerImages": [
+      "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
+    ],
+    "sourceUrls": {
+      "docs": "https://headlamp.dev",
+      "repo": "https://github.com/kubernetes-sigs/headlamp",
+      "helm": "https://github.com/kubernetes-sigs/headlamp/tree/main/charts/headlamp/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "You need a Kubernetes cluster and the Helm package manager installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T20:49:13.051Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-karmada.json
+++ b/solutions/cncf-install/install-karmada.json
@@ -1,0 +1,149 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-karmada",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Karmada on Kubernetes",
+    "description": "Karmada is an open-source multi-cloud, multi-cluster Kubernetes orchestration tool that enables seamless management of cloud-native applications across various Kubernetes clusters. Installing Karmada allows you to leverage its advanced scheduling capabilities and centralized management for improved application deployment and scaling.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Helm repository",
+        "description": "Add the Karmada Helm chart repository to your local Helm client with the following command:\n```bash\nhelm repo add karmada https://charts.karmada.io\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Karmada using Helm",
+        "description": "Install Karmada with the following command, creating a namespace called 'karmada-system':\n```bash\nhelm install karmada-operator karmada/karmada-operator --namespace karmada-system --create-namespace --version v1.17.0\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check if the Karmada operator pods are running:\n```bash\nkubectl get pods -n karmada-system\n```"
+      },
+      {
+        "title": "Configure Resource Limits",
+        "description": "Edit the Karmada operator configuration to set resource limits. You can do this by updating the values.yaml file or using `kubectl`:\n```bash\nkubectl edit deployment karmada-operator -n karmada-system\n# Add resource limits under spec.containers:\n# resources:\n#   limits:\n#     cpu: 500m\n#     memory: 512Mi\n```"
+      },
+      {
+        "title": "Set up RBAC",
+        "description": "Ensure that the necessary RBAC permissions are set for Karmada to function correctly:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/karmada-io/karmada/master/docs/install/rbac.yaml\n```"
+      },
+      {
+        "title": "Access Karmada Dashboard",
+        "description": "If Karmada provides a dashboard, you can access it using port-forwarding:\n```bash\nkubectl port-forward service/karmada-dashboard -n karmada-system 8080:80\n# Now access the dashboard at http://localhost:8080\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Karmada operator using Helm:\n```bash\nhelm uninstall karmada-operator --namespace karmada-system\n```"
+      },
+      {
+        "title": "Clean up CRDs",
+        "description": "Remove any Custom Resource Definitions (CRDs) that were installed:\n```bash\nkubectl delete crd $(kubectl get crd | grep karmada | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Delete the Karmada namespace to clean up any remaining resources:\n```bash\nkubectl delete namespace karmada-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources:\n```bash\nkubectl get all -n karmada-system -o yaml > karmada-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Ensure your Helm repository is up to date:\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade Karmada",
+        "description": "Upgrade to the latest version of Karmada:\n```bash\nhelm upgrade karmada-operator karmada/karmada-operator --namespace karmada-system --version v1.17.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the Karmada operator pods to ensure they are running:\n```bash\nkubectl get pods -n karmada-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in CrashLoopBackOff",
+        "description": "If the Karmada operator pods are in a CrashLoopBackOff state, check the logs for errors:\n```bash\nkubectl logs <pod-name> -n karmada-system\n# Replace <pod-name> with the actual name of the pod\n```"
+      },
+      {
+        "title": "Karmada services not reachable",
+        "description": "If you cannot reach Karmada services, ensure the services are running:\n```bash\nkubectl get svc -n karmada-system\n```"
+      },
+      {
+        "title": "RBAC permissions issues",
+        "description": "If you encounter permission errors, verify that the RBAC configuration is correctly applied:\n```bash\nkubectl get clusterrolebindings | grep karmada\n```"
+      },
+      {
+        "title": "Resource limits causing OOMKilled",
+        "description": "If pods are being killed due to OOM (Out Of Memory), consider increasing the memory limits in the deployment:\n```bash\nkubectl edit deployment karmada-operator -n karmada-system\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Karmada will result in the Karmada operator running in the 'karmada-system' namespace with all necessary pods in a 'Running' state. You can access the Karmada dashboard if configured.",
+      "codeSnippets": [
+        "helm repo add karmada https://charts.karmada.io\nhelm repo update",
+        "helm install karmada-operator karmada/karmada-operator --namespace karmada-system --create-namespace --version v1.17.0",
+        "kubectl get pods -n karmada-system",
+        "kubectl edit deployment karmada-operator -n karmada-system\n# Add resource limits under spec.containers:\n# resources:\n#   limits:\n#     cpu: 500m\n#     memory: 512Mi",
+        "kubectl apply -f https://raw.githubusercontent.com/karmada-io/karmada/master/docs/install/rbac.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "orchestration",
+      "incubating"
+    ],
+    "cncfProjects": [
+      "karmada"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "incubating",
+    "projectVersion": "v1.17.0",
+    "containerImages": [
+      "docker.io/karmada/karmada-operator:v1.17.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://karmada.io",
+      "repo": "https://github.com/karmada-io/karmada",
+      "helm": "https://github.com/karmada-io/karmada/tree/main/charts/karmada-operator/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have Helm and kubectl installed and configured to interact with your Kubernetes cluster."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T21:11:17.212Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-knative.json
+++ b/solutions/cncf-install/install-knative.json
@@ -1,0 +1,144 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-knative",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Knative on Kubernetes",
+    "description": "Knative Serving is a Kubernetes-based framework that enables the deployment and serving of applications and functions as serverless containers. It allows for rapid deployment, automatic scaling, and advanced routing capabilities, making it a powerful tool for modern cloud-native applications.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Knative Serving Helm repository",
+        "description": "Add the official Knative Serving Helm chart repository to your Helm configuration:\n```bash\nhelm repo add knative https://charts.knative.dev\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Knative Serving",
+        "description": "Install Knative Serving using Helm, creating a namespace called 'knative-serving':\n```bash\nhelm install knative-serving knative/serving --namespace knative-serving --create-namespace --version knative-v1.21.1\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the Knative Serving components are running:\n```bash\nkubectl get pods --namespace knative-serving\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits for the Knative Serving deployment by editing the configuration:\n```bash\nkubectl edit configmap config-autoscaler --namespace knative-serving\n```"
+      },
+      {
+        "title": "Set up monitoring (optional)",
+        "description": "Install Prometheus for monitoring Knative Serving:\n```bash\nkubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.21.1/monitoring.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Knative Serving release:\n```bash\nhelm uninstall knative-serving --namespace knative-serving\n```"
+      },
+      {
+        "title": "Delete the Knative Serving namespace",
+        "description": "Remove the namespace created for Knative Serving:\n```bash\nkubectl delete namespace knative-serving\n```"
+      },
+      {
+        "title": "Clean up CRDs",
+        "description": "Delete the Custom Resource Definitions associated with Knative Serving:\n```bash\nkubectl delete crd $(kubectl get crd | grep 'serving.knative.dev' | awk '{print $1}')\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the current configuration and resources:\n```bash\nkubectl get all --namespace knative-serving -o yaml > knative-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Make sure your Helm repository is up to date:\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade Knative Serving",
+        "description": "Upgrade Knative Serving to the latest version:\n```bash\nhelm upgrade knative-serving knative/serving --namespace knative-serving --version knative-v1.21.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the upgraded components are running:\n```bash\nkubectl get pods --namespace knative-serving\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "This may indicate insufficient resources in your cluster. Diagnose with:\n```bash\nkubectl describe pod <pod-name> --namespace knative-serving\n```\nEnsure your cluster has enough CPU and memory resources available."
+      },
+      {
+        "title": "Knative services not routing traffic",
+        "description": "Check the status of the Knative service:\n```bash\nkubectl get ksvc <service-name> --namespace knative-serving\n```\nEnsure the service is in 'Ready' state and check for any configuration errors."
+      },
+      {
+        "title": "Autoscaler not scaling down",
+        "description": "Verify the autoscaler configuration:\n```bash\nkubectl get configmap config-autoscaler --namespace knative-serving -o yaml\n```\nCheck the 'minScale' setting and adjust it if necessary."
+      },
+      {
+        "title": "Error in Knative Serving logs",
+        "description": "Check the logs of the Knative Serving components:\n```bash\nkubectl logs <pod-name> --namespace knative-serving\n```\nLook for specific error messages to diagnose the issue."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Knative Serving will have all components running in the 'knative-serving' namespace, and you will be able to deploy and serve applications seamlessly. You can verify the installation by checking the status of the pods and accessing the services you've deployed.",
+      "codeSnippets": [
+        "helm repo add knative https://charts.knative.dev\nhelm repo update",
+        "helm install knative-serving knative/serving --namespace knative-serving --create-namespace --version knative-v1.21.1",
+        "kubectl get pods --namespace knative-serving",
+        "kubectl edit configmap config-autoscaler --namespace knative-serving",
+        "kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.21.1/monitoring.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "graduated"
+    ],
+    "cncfProjects": [
+      "knative"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Configmap",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "graduated",
+    "projectVersion": "knative-v1.21.1",
+    "containerImages": [
+      "gcr.io/knative-releases/knative.dev/serving/cmd/activator:knative-v1.21.1"
+    ],
+    "sourceUrls": {
+      "docs": "https://knative.dev/docs/serving/",
+      "repo": "https://github.com/knative/serving"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running version 1.24 or higher, and have Helm and kubectl installed and configured."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T21:18:41.378Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-kubeedge.json
+++ b/solutions/cncf-install/install-kubeedge.json
@@ -1,0 +1,145 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-kubeedge",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Kubeedge on Kubernetes",
+    "description": "KubeEdge is a Kubernetes Native Edge Computing Framework that extends container orchestration and device management to edge hosts. Installing KubeEdge allows you to efficiently manage edge applications and devices while ensuring reliable communication between the cloud and edge environments.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the KubeEdge Helm repository",
+        "description": "Add the official KubeEdge Helm repository to your Helm client to access the KubeEdge charts.\n```bash\nhelm repo add kubeedge https://charts.kubeedge.io\nhelm repo update\n```"
+      },
+      {
+        "title": "Install KubeEdge using Helm",
+        "description": "Install KubeEdge with the specified version, creating a namespace for it.\n```bash\nhelm install kubeedge kubeedge/kubeedge --version v1.22.1 --namespace kubeedge --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the KubeEdge pods are running successfully in the kubeedge namespace.\n```bash\nkubectl get pods --namespace kubeedge\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits for the KubeEdge components to ensure optimal performance.\n```bash\nkubectl set resources deployment kubeedge --namespace kubeedge --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi\n```"
+      },
+      {
+        "title": "Port-forward to access KubeEdge services",
+        "description": "Use port-forwarding to access KubeEdge services locally for testing.\n```bash\nkubectl port-forward svc/kubeedge-cloudhub --namespace kubeedge 8080:8080\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the KubeEdge Helm release",
+        "description": "Uninstall the KubeEdge release using Helm.\n```bash\nhelm uninstall kubeedge --namespace kubeedge\n```"
+      },
+      {
+        "title": "Clean up CRDs and resources",
+        "description": "Delete any Custom Resource Definitions (CRDs) created by KubeEdge.\n```bash\nkubectl delete crd devices.kubeedge.io\nkubectl delete crd nodes.kubeedge.io\nkubectl delete crd pods.kubeedge.io\n```"
+      },
+      {
+        "title": "Remove the KubeEdge namespace",
+        "description": "Delete the namespace used for KubeEdge to clean up all associated resources.\n```bash\nkubectl delete namespace kubeedge\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the current configuration and resources for backup before upgrading.\n```bash\nkubectl get all --namespace kubeedge -o yaml > kubeedge-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Ensure the Helm repository is up to date before upgrading.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade KubeEdge",
+        "description": "Upgrade KubeEdge to the latest version available in the Helm repository.\n```bash\nhelm upgrade kubeedge kubeedge/kubeedge --namespace kubeedge --version v1.22.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the KubeEdge pods are running successfully after the upgrade.\n```bash\nkubectl get pods --namespace kubeedge\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "If KubeEdge pods are stuck in a Pending state, check for resource availability and scheduling issues.\n```bash\nkubectl describe pod <pod-name> --namespace kubeedge\n```"
+      },
+      {
+        "title": "CloudHub not reachable",
+        "description": "If you cannot reach CloudHub, verify the service is running and check the logs for errors.\n```bash\nkubectl logs <cloudhub-pod-name> --namespace kubeedge\n```"
+      },
+      {
+        "title": "EdgeCore not connecting to CloudHub",
+        "description": "If EdgeCore fails to connect to CloudHub, check network policies and firewall settings.\n```bash\nkubectl logs <edgecore-pod-name> --namespace kubeedge\n```"
+      },
+      {
+        "title": "DeviceController not managing devices",
+        "description": "If DeviceController is not managing devices, check the CRDs and ensure they are properly configured.\n```bash\nkubectl get devices.kubeedge.io --namespace kubeedge\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of KubeEdge will have all pods running in the kubeedge namespace, with no errors reported in the logs. You should be able to access the CloudHub service and manage edge devices effectively.",
+      "codeSnippets": [
+        "helm repo add kubeedge https://charts.kubeedge.io\nhelm repo update",
+        "helm install kubeedge kubeedge/kubeedge --version v1.22.1 --namespace kubeedge --create-namespace",
+        "kubectl get pods --namespace kubeedge",
+        "kubectl set resources deployment kubeedge --namespace kubeedge --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
+        "kubectl port-forward svc/kubeedge-cloudhub --namespace kubeedge 8080:8080"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "graduated"
+    ],
+    "cncfProjects": [
+      "kubeedge"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "graduated",
+    "projectVersion": "v1.22.1",
+    "containerImages": [
+      "kubeedge/cloudhub:v1.22.1",
+      "kubeedge/edgecore:v1.22.1"
+    ],
+    "sourceUrls": {
+      "docs": "https://kubeedge.io",
+      "repo": "https://github.com/kubeedge/kubeedge"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running version 1.24 or higher and have Helm and kubectl installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T21:38:24.797Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-kubeslice.json
+++ b/solutions/cncf-install/install-kubeslice.json
@@ -1,0 +1,139 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-kubeslice",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Kubeslice on Kubernetes",
+    "description": "KubeSlice provides secure and highly available connectivity between multiple Kubernetes clusters by creating an overlay network. Installing KubeSlice allows applications to communicate seamlessly across cluster boundaries, making it ideal for multi-cloud and multi-cluster deployments.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Helm repository",
+        "description": "Add the KubeSlice Helm repository to your local Helm setup using the following command:\n```console\nhelm repo add kubeslice https://kubeslice.github.io/kubeslice/\nhelm repo update\n```"
+      },
+      {
+        "title": "Install KubeSlice",
+        "description": "Install KubeSlice with the following command, specifying the version and creating a namespace:\n```console\nhelm install kubeslice kubeslice/kubeslice --version kubeslice-worker-1.5.0 --namespace kubeslice --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the KubeSlice pods are running:\n```console\nkubectl get pods -n kubeslice\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Edit the KubeSlice values to set resource limits. Create a `values.yaml` file with the following content:\n```yaml\nresources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\"\n```\nThen apply the configuration:\n```console\nhelm upgrade kubeslice kubeslice/kubeslice --namespace kubeslice -f values.yaml\n```"
+      },
+      {
+        "title": "Set up RBAC",
+        "description": "Ensure that RBAC is enabled for KubeSlice by adding the following to your `values.yaml`:\n```yaml\nrbac:\n  create: true\n```\nThen upgrade the installation to apply the RBAC settings:\n```console\nhelm upgrade kubeslice kubeslice/kubeslice --namespace kubeslice -f values.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the KubeSlice release using the following command:\n```console\nhelm uninstall kubeslice --namespace kubeslice\n```"
+      },
+      {
+        "title": "Clean up CRDs",
+        "description": "Remove any Custom Resource Definitions (CRDs) created by KubeSlice:\n```console\nkubectl delete crd $(kubectl get crd | grep kubeslice | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Delete the namespace",
+        "description": "Delete the KubeSlice namespace to clean up all resources:\n```console\nkubectl delete namespace kubeslice\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration:\n```console\nhelm get values kubeslice --namespace kubeslice > backup-values.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Ensure your Helm repository is up to date:\n```console\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade KubeSlice",
+        "description": "Upgrade KubeSlice to the latest version:\n```console\nhelm upgrade kubeslice kubeslice/kubeslice --namespace kubeslice --version kubeslice-worker-1.5.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the KubeSlice pods are running after the upgrade:\n```console\nkubectl get pods -n kubeslice\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending",
+        "description": "If pods are stuck in Pending, check for insufficient resources:\n```console\nkubectl describe pod <pod-name> -n kubeslice\n```\nEnsure your cluster has enough resources available or adjust resource requests/limits."
+      },
+      {
+        "title": "KubeSlice pods crash looping",
+        "description": "If KubeSlice pods are in a CrashLoopBackOff state, check the logs:\n```console\nkubectl logs <pod-name> -n kubeslice\n```\nInvestigate the logs for errors and adjust configurations as necessary."
+      },
+      {
+        "title": "Unable to connect between clusters",
+        "description": "If connectivity issues arise, ensure that the overlay network is correctly configured. Check the KubeSlice configuration:\n```console\nkubectl get kubeslice -n kubeslice\n```\nReview the settings and ensure all clusters are properly connected."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of KubeSlice will have all pods running in the 'kubeslice' namespace, and you will be able to verify connectivity between clusters. The configuration for resource limits and RBAC should be applied correctly.",
+      "codeSnippets": [
+        "helm repo add kubeslice https://kubeslice.github.io/kubeslice/\nhelm repo update",
+        "helm install kubeslice kubeslice/kubeslice --version kubeslice-worker-1.5.0 --namespace kubeslice --create-namespace",
+        "kubectl get pods -n kubeslice",
+        "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\"",
+        "helm upgrade kubeslice kubeslice/kubeslice --namespace kubeslice -f values.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "kubeslice"
+    ],
+    "targetResourceKinds": [
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "kubeslice-worker-1.5.0",
+    "containerImages": [
+      "ghcr.io/kubeshop/botkube:v1.0.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://github.com/kubeslice/kubeslice",
+      "repo": "https://github.com/kubeslice/kubeslice",
+      "helm": "https://github.com/kubeslice/kubeslice/tree/main/charts/botkube/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure that Helm and kubectl are installed and configured to interact with your Kubernetes cluster."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T21:45:52.218Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-kudo.json
+++ b/solutions/cncf-install/install-kudo.json
@@ -1,0 +1,142 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-kudo",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Kudo on Kubernetes",
+    "description": "KUDO (Kubernetes Universal Declarative Operator) provides a declarative approach to building production-grade Kubernetes Operators, covering the entire application lifecycle. Installing KUDO allows you to manage your applications on Kubernetes more effectively by leveraging its operator framework.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the KUDO Helm repository",
+        "description": "Add the KUDO Helm chart repository to your local Helm setup with the following command:\n```bash\nhelm repo add kudo https://charts.kudobuilder.dev\nhelm repo update\n```"
+      },
+      {
+        "title": "Install KUDO using Helm",
+        "description": "Install KUDO in the `kudo-system` namespace with the following command:\n```bash\nhelm install kudo kudo/kudo --namespace kudo-system --create-namespace --version v0.19.0\n```"
+      },
+      {
+        "title": "Verify KUDO installation",
+        "description": "Check the status of the KUDO pods to ensure they are running:\n```bash\nkubectl get pods -n kudo-system\n```"
+      },
+      {
+        "title": "Configure resource limits for KUDO",
+        "description": "To set resource limits for KUDO, edit the Helm release:\n```bash\nhelm upgrade kudo kudo/kudo --namespace kudo-system --set resources.limits.cpu=500m --set resources.limits.memory=512Mi\n```"
+      },
+      {
+        "title": "Set up RBAC for KUDO",
+        "description": "Create a ClusterRole and ClusterRoleBinding for KUDO:\n```bash\nkubectl create clusterrole kudo-role --verb=* --resource=* \n\nkubectl create clusterrolebinding kudo-role-binding --clusterrole=kudo-role --serviceaccount=kudo-system:kudo\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the KUDO Helm release",
+        "description": "Uninstall the KUDO release with the following command:\n```bash\nhelm uninstall kudo --namespace kudo-system\n```"
+      },
+      {
+        "title": "Clean up KUDO CRDs",
+        "description": "Delete the Custom Resource Definitions (CRDs) created by KUDO:\n```bash\nkubectl delete crd $(kubectl get crd | grep kudo.dev | awk '{print $1}')\n```"
+      },
+      {
+        "title": "Remove the KUDO namespace",
+        "description": "Delete the `kudo-system` namespace to clean up any remaining resources:\n```bash\nkubectl delete namespace kudo-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current KUDO state",
+        "description": "Export the current state of KUDO resources before upgrading:\n```bash\nkubectl get all -n kudo-system -o yaml > kudo-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Make sure your Helm repository is up to date:\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade KUDO to the latest version",
+        "description": "Upgrade KUDO to the latest version with the following command:\n```bash\nhelm upgrade kudo kudo/kudo --namespace kudo-system --version v0.19.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check the status of the KUDO pods to ensure they are running correctly after the upgrade:\n```bash\nkubectl get pods -n kudo-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "If KUDO pods are stuck in the Pending state, check for insufficient resources in your cluster:\n```bash\nkubectl describe pod <pod-name> -n kudo-system\n``` \nEnsure that your cluster has enough resources available or adjust the resource requests in the Helm chart."
+      },
+      {
+        "title": "KUDO manager pod crashes",
+        "description": "If the KUDO manager pod is crashing, check the logs for errors:\n```bash\nkubectl logs <pod-name> -n kudo-system\n``` \nLook for any configuration issues or missing dependencies."
+      },
+      {
+        "title": "RBAC issues preventing KUDO from functioning",
+        "description": "If you encounter permission errors, verify the RBAC configuration:\n```bash\nkubectl get clusterrolebinding kudo-role-binding -o yaml\n``` \nEnsure that the service account has the necessary permissions."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of KUDO will have all pods running in the `kudo-system` namespace, and you will be able to manage your applications using the KUDO framework. You can verify the installation by checking the pod statuses and ensuring that KUDO is configured correctly.",
+      "codeSnippets": [
+        "helm repo add kudo https://charts.kudobuilder.dev\nhelm repo update",
+        "helm install kudo kudo/kudo --namespace kudo-system --create-namespace --version v0.19.0",
+        "kubectl get pods -n kudo-system",
+        "helm upgrade kudo kudo/kudo --namespace kudo-system --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
+        "kubectl create clusterrole kudo-role --verb=* --resource=* \n\nkubectl create clusterrolebinding kudo-role-binding --clusterrole=kudo-role --serviceaccount=kudo-system:kudo"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "kudo"
+    ],
+    "targetResourceKinds": [
+      "Service",
+      "Namespace",
+      "Serviceaccount",
+      "Clusterrole",
+      "Clusterrolebinding"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v0.19.0",
+    "containerImages": [
+      "kudobuilder/kudo:v0.19.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://kudo.dev",
+      "repo": "https://github.com/kudobuilder/kudo"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a running Kubernetes cluster and the Helm and kubectl command-line tools installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T21:54:52.332Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-network-service-mesh.json
+++ b/solutions/cncf-install/install-network-service-mesh.json
@@ -1,0 +1,133 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-network-service-mesh",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Network Service Mesh on Kubernetes",
+    "description": "Network Service Mesh provides a way to manage and connect network services in a Kubernetes environment. Installing it allows you to leverage its capabilities for service connectivity and management.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Network Service Mesh Helm repository",
+        "description": "Add the official Helm repository for Network Service Mesh to your Helm client.\n```bash\nhelm repo add networkservicemesh https://networkservicemesh.github.io/charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Network Service Mesh",
+        "description": "Install the Network Service Mesh using Helm, specifying the desired namespace.\n```bash\nhelm install nsm networkservicemesh/nsm --namespace nsm-system --create-namespace --version v1.16.0\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the pods are running correctly in the nsm-system namespace.\n```bash\nkubectl get pods -n nsm-system\n```"
+      },
+      {
+        "title": "Post-install configuration",
+        "description": "Configure resource limits for the Network Service Mesh components.\n```bash\nkubectl set resources deployment nsm --namespace nsm-system --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Network Service Mesh release from your cluster.\n```bash\nhelm uninstall nsm --namespace nsm-system\n```"
+      },
+      {
+        "title": "Clean up CRDs",
+        "description": "Remove any Custom Resource Definitions that were created during the installation.\n```bash\nkubectl delete crd networks.networkservicemesh.io\nkubectl delete crd networkservices.networkservicemesh.io\nkubectl delete crd endpoints.networkservicemesh.io\n```"
+      },
+      {
+        "title": "Remove the namespace",
+        "description": "Delete the namespace used for Network Service Mesh.\n```bash\nkubectl delete namespace nsm-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, it's a good practice to back up your current configuration and resources.\n```bash\nkubectl get all -n nsm-system -o yaml > nsm-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Ensure you have the latest version of the Helm charts.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade the Network Service Mesh",
+        "description": "Perform the upgrade to the latest version of Network Service Mesh.\n```bash\nhelm upgrade nsm networkservicemesh/nsm --namespace nsm-system --version v1.16.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the pods are running correctly after the upgrade.\n```bash\nkubectl get pods -n nsm-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "This may occur due to insufficient resources in your cluster. Check the events for the pods.\n```bash\nkubectl describe pod <pod-name> -n nsm-system\n```"
+      },
+      {
+        "title": "Network connectivity issues",
+        "description": "If services cannot communicate, verify that the Network Service Mesh components are running and check their logs.\n```bash\nkubectl logs <nsm-pod-name> -n nsm-system\n```"
+      },
+      {
+        "title": "Helm release not found",
+        "description": "If you encounter an error stating that the Helm release is not found, ensure that you are using the correct namespace and release name.\n```bash\nhelm list --namespace nsm-system\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Network Service Mesh will have all pods running in the nsm-system namespace, and you will be able to manage network services effectively. You should also see no errors in the logs of the Network Service Mesh components.",
+      "codeSnippets": [
+        "helm repo add networkservicemesh https://networkservicemesh.github.io/charts\nhelm repo update",
+        "helm install nsm networkservicemesh/nsm --namespace nsm-system --create-namespace --version v1.16.0",
+        "kubectl get pods -n nsm-system",
+        "kubectl set resources deployment nsm --namespace nsm-system --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "networking",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "network-service-mesh"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v1.16.0",
+    "containerImages": [],
+    "sourceUrls": {
+      "docs": "https://github.com/networkservicemesh/api",
+      "repo": "https://github.com/networkservicemesh/api"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running and both Helm and kubectl installed on your local machine."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T22:02:06.938Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-install/install-open-cluster-management.json
+++ b/solutions/cncf-install/install-open-cluster-management.json
@@ -1,0 +1,140 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-open-cluster-management",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Open Cluster Management on Kubernetes",
+    "description": "Open Cluster Management (OCM) is a CNCF sandbox project aimed at simplifying the management of heterogeneous, multicluster environments for Kubernetes applications. By installing OCM, you can effectively manage multicluster and multicloud scenarios, enhancing your Kubernetes experience.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the OCM Helm repository",
+        "description": "Add the official OCM Helm repository to your Helm client to access the OCM charts.\n```bash\nhelm repo add open-cluster-management https://open-cluster-management.github.io/manifests\nhelm repo update\n```"
+      },
+      {
+        "title": "Install the OCM components",
+        "description": "Install the OCM components using Helm, specifying the namespace for the installation.\n```bash\nhelm install ocm open-cluster-management/cluster-manager --namespace ocm-system --create-namespace --version v1.2.0\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the OCM pods are running successfully in the ocm-system namespace.\n```bash\nkubectl get pods -n ocm-system\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits for the OCM components to ensure optimal performance.\n```bash\nkubectl set resources deployment ocm --limits=cpu=500m,memory=512Mi -n ocm-system\n```"
+      },
+      {
+        "title": "Port-forward to access the OCM API",
+        "description": "Forward a local port to the OCM API service to access it locally.\n```bash\nkubectl port-forward svc/ocm-api -n ocm-system 8080:80\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the OCM Helm release to remove the deployed components.\n```bash\nhelm uninstall ocm --namespace ocm-system\n```"
+      },
+      {
+        "title": "Delete the OCM namespace",
+        "description": "Clean up the namespace created for OCM to remove any remaining resources.\n```bash\nkubectl delete namespace ocm-system\n```"
+      },
+      {
+        "title": "Remove Custom Resource Definitions (CRDs)",
+        "description": "Delete any CRDs that were created during the installation of OCM.\n```bash\nkubectl delete crd clustermanagers.open-cluster-management.io\nkubectl delete crd placementdecisions.open-cluster-management.io\nkubectl delete crd placements.open-cluster-management.io\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Before upgrading, back up the current configuration and resources.\n```bash\nkubectl get all -n ocm-system -o yaml > ocm-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Update the Helm repository to ensure you have the latest charts.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade the OCM components",
+        "description": "Upgrade the OCM components to the latest version available in the Helm repository.\n```bash\nhelm upgrade ocm open-cluster-management/cluster-manager --namespace ocm-system --version v1.2.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the OCM pods are running the upgraded version successfully.\n```bash\nkubectl get pods -n ocm-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending state",
+        "description": "If your OCM pods are stuck in a Pending state, check for insufficient resources in your cluster.\n```bash\nkubectl describe pod <pod-name> -n ocm-system\n```"
+      },
+      {
+        "title": "API service not reachable",
+        "description": "If you cannot access the OCM API, ensure that the port-forward command is running and check the service status.\n```bash\nkubectl get svc -n ocm-system\n```"
+      },
+      {
+        "title": "CrashLoopBackOff errors",
+        "description": "If you see CrashLoopBackOff errors, check the logs of the affected pod for more details.\n```bash\nkubectl logs <pod-name> -n ocm-system\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of OCM will have all pods running in the ocm-system namespace without errors. You should be able to access the OCM API through the port-forwarded service.",
+      "codeSnippets": [
+        "helm repo add open-cluster-management https://open-cluster-management.github.io/manifests\nhelm repo update",
+        "helm install ocm open-cluster-management/cluster-manager --namespace ocm-system --create-namespace --version v1.2.0",
+        "kubectl get pods -n ocm-system",
+        "kubectl set resources deployment ocm --limits=cpu=500m,memory=512Mi -n ocm-system",
+        "kubectl port-forward svc/ocm-api -n ocm-system 8080:80"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "app-definition",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "open-cluster-management"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v1.2.0",
+    "containerImages": [
+      "openclustermanagement/cluster-manager:v1.2.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://open-cluster-management.io",
+      "repo": "https://github.com/open-cluster-management-io/ocm"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running version 1.24 or higher and have Helm and kubectl installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-02T22:12:52.671Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/index.json
+++ b/solutions/index.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generatedAt": "2026-03-02T20:48:39.208Z",
-  "count": 329,
+  "generatedAt": "2026-03-02T22:33:10.566Z",
+  "count": 342,
   "missions": [
     {
       "path": "solutions/cncf-generated/alertmanager/alertmanager-3944-feat-allow-nested-details-fields-in-pagerduty.json",
@@ -3662,6 +3662,41 @@
       ]
     },
     {
+      "path": "solutions/cncf-install/install-confidential-containers.json",
+      "title": "Install and Configure Confidential Containers on Kubernetes",
+      "description": "Confidential Containers is an open-source community project that leverages Trusted Execution Environments (TEEs) to enhance the security of containers and protect sensitive data in cloud-native applic",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "security",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "confidential-containers"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace",
+        "Serviceaccount"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-connect-rpc.json",
       "title": "Install and Configure Connect Rpc on Kubernetes",
       "description": "Connect is a slim library for building browser and gRPC-compatible HTTP APIs using Protocol Buffers. Installing Connect allows you to easily create type-safe clients and servers that support multiple ",
@@ -3781,6 +3816,40 @@
       ],
       "cncfProjects": [
         "containerd"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-containerssh.json",
+      "title": "Install and Configure Containerssh on Kubernetes",
+      "description": "ContainerSSH is an SSH server that launches containers on demand in Kubernetes and Docker, providing dynamic access for various use cases such as lab environments, debugging, and honeypots. Installing",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "containerssh"
       ],
       "targetResourceKinds": [
         "Deployment",
@@ -4136,6 +4205,40 @@
       ]
     },
     {
+      "path": "solutions/cncf-install/install-dex.json",
+      "title": "Install and Configure Dex on Kubernetes",
+      "description": "Dex is an OpenID Connect (OIDC) identity and OAuth 2.0 provider that allows applications to authenticate users through various identity providers. Installing Dex provides a centralized authentication ",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "security",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "dex"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-distribution.json",
       "title": "Install and Configure Distribution on Kubernetes",
       "description": "The Distribution project provides a toolkit to pack, ship, store, and deliver container content, including a robust implementation of the OCI Distribution Specification for container registries. Insta",
@@ -4330,6 +4433,74 @@
         "Namespace"
       ],
       "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-eraser.json",
+      "title": "Install and Configure Eraser on Kubernetes",
+      "description": "Eraser is a tool designed to help Kubernetes administrators clean up non-running images from all nodes in a cluster, ensuring efficient resource usage and management. Installing Eraser allows you to a",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "eraser"
+      ],
+      "targetResourceKinds": [
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-external-secrets.json",
+      "title": "Install and Configure External Secrets on Kubernetes",
+      "description": "External Secrets Operator reads information from third-party services like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets. Installing this operator allows you to manage",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "security",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "external-secrets"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Secret",
+        "Namespace",
+        "Serviceaccount"
+      ],
+      "difficulty": "intermediate",
       "issueTypes": [
         "installation",
         "configuration"
@@ -4638,6 +4809,39 @@
         "Namespace"
       ],
       "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-headlamp.json",
+      "title": "Install and Configure Headlamp on Kubernetes",
+      "description": "Headlamp is an easy-to-use and extensible Kubernetes web UI that provides a user-friendly interface for managing Kubernetes resources. Installing Headlamp allows you to visualize and interact with you",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "observability",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "headlamp"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Namespace"
+      ],
+      "difficulty": "beginner",
       "issueTypes": [
         "installation",
         "configuration"
@@ -5120,6 +5324,40 @@
       ]
     },
     {
+      "path": "solutions/cncf-install/install-karmada.json",
+      "title": "Install and Configure Karmada on Kubernetes",
+      "description": "Karmada is an open-source multi-cloud, multi-cluster Kubernetes orchestration tool that enables seamless management of cloud-native applications across various Kubernetes clusters. Installing Karmada ",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "orchestration",
+        "incubating"
+      ],
+      "cncfProjects": [
+        "karmada"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-kcl.json",
       "title": "Install and Configure Kcl on Kubernetes",
       "description": "KCL is an open-source, constraint-based record and functional programming language designed to enhance the writing of complex configurations, particularly in cloud-native scenarios. Installing KCL all",
@@ -5446,6 +5684,40 @@
         "knative-eventing"
       ],
       "targetResourceKinds": [
+        "Configmap",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-knative.json",
+      "title": "Install and Configure Knative on Kubernetes",
+      "description": "Knative Serving is a Kubernetes-based framework that enables the deployment and serving of applications and functions as serverless containers. It allows for rapid deployment, automatic scaling, and a",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "graduated"
+      ],
+      "cncfProjects": [
+        "knative"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
         "Configmap",
         "Namespace"
       ],
@@ -5804,6 +6076,40 @@
       ]
     },
     {
+      "path": "solutions/cncf-install/install-kubeedge.json",
+      "title": "Install and Configure Kubeedge on Kubernetes",
+      "description": "KubeEdge is a Kubernetes Native Edge Computing Framework that extends container orchestration and device management to edge hosts. Installing KubeEdge allows you to efficiently manage edge application",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "graduated"
+      ],
+      "cncfProjects": [
+        "kubeedge"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-kubeelasti.json",
       "title": "Install and Configure Kubeelasti on Kubernetes",
       "description": "KubeElasti is a Kubernetes-native solution that enables scale-to-zero functionality, allowing services to scale down during periods of low or no traffic without losing requests. Installing KubeElasti ",
@@ -5974,6 +6280,38 @@
       ]
     },
     {
+      "path": "solutions/cncf-install/install-kubeslice.json",
+      "title": "Install and Configure Kubeslice on Kubernetes",
+      "description": "KubeSlice provides secure and highly available connectivity between multiple Kubernetes clusters by creating an overlay network. Installing KubeSlice allows applications to communicate seamlessly acro",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "kubeslice"
+      ],
+      "targetResourceKinds": [
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-kubevela.json",
       "title": "Install and Configure Kubevela on Kubernetes",
       "description": "KubeVela is a modern application delivery platform that simplifies deploying and managing applications across hybrid and multi-cloud environments. By using KubeVela, you can enhance your application d",
@@ -6061,6 +6399,42 @@
       ],
       "targetResourceKinds": [
         "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-kudo.json",
+      "title": "Install and Configure Kudo on Kubernetes",
+      "description": "KUDO (Kubernetes Universal Declarative Operator) provides a declarative approach to building production-grade Kubernetes Operators, covering the entire application lifecycle. Installing KUDO allows yo",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "kudo"
+      ],
+      "targetResourceKinds": [
+        "Service",
+        "Namespace",
+        "Serviceaccount",
+        "Clusterrole",
+        "Clusterrolebinding"
       ],
       "difficulty": "intermediate",
       "issueTypes": [
@@ -6613,6 +6987,40 @@
       ]
     },
     {
+      "path": "solutions/cncf-install/install-network-service-mesh.json",
+      "title": "Install and Configure Network Service Mesh on Kubernetes",
+      "description": "Network Service Mesh provides a way to manage and connect network services in a Kubernetes environment. Installing it allows you to leverage its capabilities for service connectivity and management.",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "networking",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "network-service-mesh"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-node-exporter.json",
       "title": "Install and Configure Node Exporter (Prometheus) on Kubernetes",
       "description": "Node Exporter is a Prometheus exporter that collects and exposes hardware and OS metrics from *NIX kernels. Installing Node Exporter allows you to monitor your machine's performance and resource usage",
@@ -6707,6 +7115,40 @@
         "Namespace"
       ],
       "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/cncf-install/install-open-cluster-management.json",
+      "title": "Install and Configure Open Cluster Management on Kubernetes",
+      "description": "Open Cluster Management (OCM) is a CNCF sandbox project aimed at simplifying the management of heterogeneous, multicluster environments for Kubernetes applications. By installing OCM, you can effectiv",
+      "category": "cncf-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "cncf",
+        "app-definition",
+        "sandbox"
+      ],
+      "cncfProjects": [
+        "open-cluster-management"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Service",
+        "Namespace"
+      ],
+      "difficulty": "intermediate",
       "issueTypes": [
         "installation",
         "configuration"


### PR DESCRIPTION
Cherry-picked 13 mission files from open batch PRs that couldn't auto-merge due to index.json conflicts.

## New missions (13)
- confidential-containers, containerssh, dex, eraser
- external-secrets, headlamp, karmada, knative
- kubeedge, kubeslice, kudo, network-service-mesh
- open-cluster-management

## Summary
- **Previous total**: 165 install missions
- **New total**: 178 install missions  
- **Index**: Regenerated (342 total entries)

Supersedes PRs: #249 #254 #255 #256 #257 #258 #259 #261 #262 #263 #264 #265 #266 #267 #268 #269 #270 #271 #272 #273 #274 #275 #276