### PR TITLE
⚠️ Platform generator: run 4x daily, fix label error

### DIFF
--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -1,7 +1,7 @@
 name: Generate Platform Install Missions
 on:
   schedule:
-    - cron: '0 6 * * 4'  # Weekly Thursday 6am UTC (offset from CNCF install on Wednesday)
+    - cron: '0 0,6,12,18 * * *'  # 4x daily (midnight, 6am, noon, 6pm UTC)
   workflow_dispatch:
     inputs:
       platforms:
@@ -245,4 +245,4 @@ jobs:
             --body "$(cat collect-report.md)" \
             --base master \
             $DRAFT_FLAG \
-            --label "platform-install,automated"
+            --label "automated"


### PR DESCRIPTION
- Schedule changed from weekly Thursday to 4x daily (0:00, 6:00, 12:00, 18:00 UTC)
- Fixed missing 'platform-install' label that caused PR creation to fail