### PR TITLE
✨ Complete platform coverage: 36/37 platforms + fix workflow

### DIFF
--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -244,5 +244,4 @@ jobs:
             --title "✨ Platform install mission generation $(date +%Y-%m-%d)" \
             --body "$(cat collect-report.md)" \
             --base master \
-            $DRAFT_FLAG \
-            --label "automated"
+            $DRAFT_FLAG

--- a/solutions/index.json
+++ b/solutions/index.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generatedAt": "2026-03-03T02:24:07.596Z",
-  "count": 360,
+  "generatedAt": "2026-03-03T12:56:32.210Z",
+  "count": 386,
   "missions": [
     {
       "path": "solutions/cncf-generated/alertmanager/alertmanager-3944-feat-allow-nested-details-fields-in-pagerduty.json",
@@ -3624,6 +3624,39 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-charmed-kubernetes.json",
+      "title": "Install and Configure Charmed Kubernetes",
+      "description": "Charmed Kubernetes is a distribution of Kubernetes designed for deployment on Ubuntu, providing a flexible and scalable solution for managing containerized applications across various cloud environmen",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "distribution",
+        "distribution",
+        "canonical"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "juju"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-cilium.json",
       "title": "Install and Configure Cilium on Kubernetes",
       "description": "Cilium is an eBPF-based networking, security, and observability solution for Kubernetes. It provides advanced networking capabilities and security policies, making it ideal for modern cloud-native app",
@@ -3655,6 +3688,72 @@
       ],
       "type": "deploy",
       "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-postgres-operator.json",
+      "title": "Install and Configure CloudNativePG (PostgreSQL Operator)",
+      "description": "CloudNativePG is an open-source PostgreSQL operator designed to manage PostgreSQL databases within Kubernetes environments, covering the entire operational lifecycle from deployment to maintenance. It",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "cloudnativepg"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-cluster-api.json",
+      "title": "Install and Configure Cluster API (CAPI)",
+      "description": "Cluster API (CAPI) is a Kubernetes subproject that provides declarative APIs and tooling for managing the lifecycle of Kubernetes clusters. It simplifies provisioning, upgrading, and operating multipl",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "cluster-management-operator",
+        "kubernetes-sig"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "kubectl",
         "helm"
       ]
     },
@@ -4336,6 +4435,38 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-doks.json",
+      "title": "Install and Configure DigitalOcean Kubernetes (DOKS)",
+      "description": "DigitalOcean Kubernetes (DOKS) is a managed Kubernetes service designed for simplicity and cost-effectiveness in container orchestration. It is ideal for developers and teams looking to deploy and man",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "managed",
+        "managed-k8s",
+        "digitalocean"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-distribution.json",
       "title": "Install and Configure Distribution on Kubernetes",
       "description": "The Distribution project provides a toolkit to pack, ship, store, and deliver container content, including a robust implementation of the OCI Distribution Specification for container registries. Insta",
@@ -4367,6 +4498,39 @@
       "type": "deploy",
       "installMethods": [
         "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-docker-desktop-k8s.json",
+      "title": "Install and Configure Docker Desktop Kubernetes",
+      "description": "Docker Desktop for Mac provides a seamless local development environment for building and testing containerized applications using Kubernetes. It's ideal for developers who want to run Kubernetes clus",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "local",
+        "local-dev",
+        "docker"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "console"
       ]
     },
     {
@@ -4468,6 +4632,39 @@
       "type": "deploy",
       "installMethods": [
         "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-elastic-cloud-on-k8s.json",
+      "title": "Install and Configure Elastic Cloud on Kubernetes (ECK)",
+      "description": "Elastic Cloud on Kubernetes (ECK) automates the deployment and management of the Elastic Stack on Kubernetes. It is ideal for users who want to run Elasticsearch, Kibana, and other Elastic products in",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "elastic"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
       ]
     },
     {
@@ -4605,6 +4802,39 @@
       "type": "deploy",
       "installMethods": [
         "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-external-dns-operator.json",
+      "title": "Install and Configure ExternalDNS",
+      "description": "ExternalDNS is an operator that synchronizes Kubernetes Services and Ingresses with DNS providers, allowing dynamic DNS management through Kubernetes resources. It is useful when you want to automate ",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "networking-operator",
+        "kubernetes-sig"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
       ]
     },
     {
@@ -4843,6 +5073,39 @@
       "installMethods": [
         "cli",
         "console"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-grafana-operator.json",
+      "title": "Install and Configure Grafana Operator",
+      "description": "The Grafana Operator simplifies the management of Grafana instances, dashboards, and datasources using Kubernetes custom resources. It's ideal for users who prefer GitOps workflows or need to manage m",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "observability-operator",
+        "grafana-labs"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
       ]
     },
     {
@@ -5114,6 +5377,38 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-iks.json",
+      "title": "Install and Configure IBM Cloud Kubernetes Service (IKS)",
+      "description": "IBM Cloud Kubernetes Service (IKS) is a managed Kubernetes service that simplifies the deployment and management of Kubernetes clusters on IBM Cloud. It is ideal for organizations looking to leverage ",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "managed",
+        "managed-k8s",
+        "ibm-cloud"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-inclavare-containers.json",
       "title": "Install and Configure Inclavare Containers on Kubernetes",
       "description": "Inclavare Containers is a novel container runtime designed for confidential computing, providing hardware-enforced isolation for sensitive workloads. Installing Inclavare Containers allows you to run ",
@@ -5313,6 +5608,39 @@
       "type": "deploy",
       "installMethods": [
         "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-k0s.json",
+      "title": "Install and Configure k0s (Zero Friction Kubernetes)",
+      "description": "k0s is a lightweight, all-inclusive Kubernetes distribution designed for ease of use and minimal friction in deployment. It is ideal for cloud, bare metal, edge, and IoT environments, allowing users t",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "distribution",
+        "distribution",
+        "mirantis"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "kubectl"
       ]
     },
     {
@@ -6196,6 +6524,38 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-kubeadm.json",
+      "title": "Install and Configure kubeadm (Kubernetes bootstrapper)",
+      "description": "Kubeadm is a tool designed to simplify the process of creating and managing Kubernetes clusters. It provides best-practice paths for bootstrapping a secure and minimal viable cluster, making it ideal ",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "distribution",
+        "distribution",
+        "kubernetes"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-kubean.json",
       "title": "Install and Configure Kubean on Kubernetes",
       "description": "Kubean is a production-ready cluster lifecycle management toolchain based on Kubespray, designed to simplify the deployment and management of Kubernetes clusters. Installing Kubean allows you to lever",
@@ -6779,6 +7139,39 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-kyverno.json",
+      "title": "Install and Configure Kyverno (Policy Engine)",
+      "description": "Kyverno is a Kubernetes-native policy engine that allows teams to manage security, compliance, and governance through policy-as-code. It is particularly useful for organizations looking to enforce pol",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "security-operator",
+        "kyverno"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-kyverno.json",
       "title": "Install and Configure Kyverno on Kubernetes",
       "description": "Kyverno is a Kubernetes-native policy engine that enables security, compliance, automation, and governance through policy-as-code. Installing Kyverno allows you to enforce policies on your Kubernetes ",
@@ -7082,6 +7475,38 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-metallb.json",
+      "title": "Install and Configure MetalLB (Bare-metal Load Balancer)",
+      "description": "MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, utilizing standard routing protocols. It is ideal for on-premises Kubernetes setups where cloud load balancers are not ava",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "networking-operator",
+        "metallb"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-metallb.json",
       "title": "Install and Configure Metallb on Kubernetes",
       "description": "MetalLB is a network load-balancer implementation for bare metal Kubernetes clusters, utilizing standard routing protocols. Installing MetalLB allows you to expose services externally in a Kubernetes ",
@@ -7149,6 +7574,104 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-microk8s.json",
+      "title": "Install and Configure MicroK8s",
+      "description": "MicroK8s is a lightweight, fully conformant Kubernetes distribution designed for developers, IoT, and edge computing. It is ideal for quick setups and local development environments.",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "distribution",
+        "distribution",
+        "canonical"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "snap"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-minikube.json",
+      "title": "Install and Configure Minikube",
+      "description": "Minikube is a tool that allows you to run Kubernetes locally on your machine. It's ideal for developers who want to test and develop applications in a Kubernetes environment without needing a full clo",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "local",
+        "local-dev",
+        "kubernetes"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-mongodb-community-operator.json",
+      "title": "Install and Configure MongoDB Community Operator",
+      "description": "The MongoDB Community Operator simplifies the deployment and management of MongoDB databases on Kubernetes. It is ideal for users looking to run MongoDB in a Kubernetes environment without the need fo",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "mongodb"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-monocle.json",
       "title": "Install and Configure Monocle on Kubernetes",
       "description": "Monocle is a framework designed for tracing GenAI app code, allowing developers to easily instrument their applications for observability. Installing Monocle enables you to monitor and trace your GenA",
@@ -7178,6 +7701,39 @@
       ],
       "type": "deploy",
       "installMethods": [
+        "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-mysql-operator.json",
+      "title": "Install and Configure MySQL Operator for Kubernetes (Oracle)",
+      "description": "The MySQL Operator for Kubernetes simplifies the management of MySQL InnoDB Cluster setups within Kubernetes, automating tasks such as deployment, upgrades, and backups. It is ideal for users looking ",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "oracle/mysql"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "kubectl",
         "helm"
       ]
     },
@@ -7828,6 +8384,39 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-oke.json",
+      "title": "Install and Configure Oracle Container Engine for Kubernetes (OKE)",
+      "description": "Oracle Container Engine for Kubernetes (OKE) is a managed Kubernetes service that simplifies the deployment and management of Kubernetes clusters on Oracle Cloud Infrastructure. It is ideal for organi",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "managed",
+        "managed-k8s",
+        "oracle-cloud"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "helm"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-oras.json",
       "title": "Install and Configure Oras on Kubernetes",
       "description": "ORAS is an OCI registry client that allows you to manage content like artifacts, images, and packages. Installing ORAS enables you to interact with OCI-compliant registries effectively.",
@@ -8297,6 +8886,38 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-rabbitmq-cluster-operator.json",
+      "title": "Install and Configure RabbitMQ Cluster Operator",
+      "description": "The RabbitMQ Cluster Operator is a Kubernetes operator designed to deploy and manage RabbitMQ clusters efficiently. It automates the lifecycle management of RabbitMQ, making it ideal for applications ",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "rabbitmq-/-broadcom"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "kubectl"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-radius.json",
       "title": "Install and Configure Radius on Kubernetes",
       "description": "Radius is a cloud-native application platform that simplifies app development and management for teams building cloud-native applications. Installing Radius allows you to leverage its features for tea",
@@ -8328,6 +8949,39 @@
       "type": "deploy",
       "installMethods": [
         "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-rancher.json",
+      "title": "Install and Configure Rancher / RKE2",
+      "description": "Rancher is a complete container management platform that simplifies deploying and managing Kubernetes clusters across various environments. It's particularly useful for organizations looking to stream",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "distribution",
+        "distribution",
+        "suse"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "docker"
       ]
     },
     {
@@ -8394,6 +9048,72 @@
       "installMethods": [
         "cli",
         "kubectl"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-redis-operator.json",
+      "title": "Install and Configure Redis Operator (Spotahome / OT-CONTAINER-KIT)",
+      "description": "The Redis Operator by OT-CONTAINER-KIT simplifies the deployment and management of Redis on Kubernetes, supporting standalone, cluster, and sentinel modes. It is ideal for organizations looking to lev",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "ot-container-kit"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-rook-ceph-operator.json",
+      "title": "Install and Configure Rook Ceph Operator",
+      "description": "Rook is a cloud-native storage orchestrator for Kubernetes that automates the deployment and management of Ceph storage. It provides a framework for integrating storage services into Kubernetes, makin",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "storage-operator",
+        "rook"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "kubectl",
+        "helm"
       ]
     },
     {
@@ -8800,6 +9520,39 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-strimzi-kafka-operator.json",
+      "title": "Install and Configure Strimzi Kafka Operator",
+      "description": "Strimzi Kafka Operator allows you to run Apache Kafka clusters on Kubernetes or OpenShift, providing a simple way to manage Kafka instances and their configurations. It's ideal for organizations looki",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "data-operator",
+        "strimzi"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-strimzi.json",
       "title": "Install and Configure Strimzi on Kubernetes",
       "description": "Strimzi provides a way to run an Apache Kafka® cluster on Kubernetes or OpenShift in various deployment configurations. Installing Strimzi allows you to easily manage Kafka clusters and their componen",
@@ -9032,6 +9785,39 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-trivy-operator.json",
+      "title": "Install and Configure Trivy Operator (Aqua Security)",
+      "description": "The Trivy Operator is a Kubernetes-native security toolkit that continuously scans your Kubernetes cluster for security issues, providing automated vulnerability and compliance reports. It is ideal fo",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "operator",
+        "security-operator",
+        "aqua-security"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "helm",
+        "kubectl"
+      ]
+    },
+    {
       "path": "solutions/platform-install/platform-velero.json",
       "title": "Install and Configure Velero (Backup & Restore Operator)",
       "description": "Velero is a powerful backup and restore operator for Kubernetes, allowing users to back up cluster resources and persistent volumes, migrate applications, and replicate environments. It is particularl",
@@ -9167,6 +9953,39 @@
       ]
     },
     {
+      "path": "solutions/platform-install/platform-tanzu.json",
+      "title": "Install and Configure VMware Tanzu Kubernetes Grid",
+      "description": "VMware Tanzu Kubernetes Grid is a Kubernetes distribution that provides a robust platform for deploying and managing Kubernetes clusters in enterprise environments. It is ideal for organizations looki",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "distribution",
+        "distribution",
+        "broadcom/vmware"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli",
+        "kubectl"
+      ]
+    },
+    {
       "path": "solutions/cncf-install/install-volcano.json",
       "title": "Install and Configure Volcano on Kubernetes",
       "description": "Volcano is a Kubernetes-native batch scheduling system that enhances the capabilities of the standard kube-scheduler. It is designed to manage and optimize various batch and elastic workloads, making ",
@@ -9197,6 +10016,38 @@
       "type": "deploy",
       "installMethods": [
         "helm"
+      ]
+    },
+    {
+      "path": "solutions/platform-install/platform-vke.json",
+      "title": "Install and Configure Vultr Kubernetes Engine (VKE)",
+      "description": "Vultr Kubernetes Engine (VKE) is a managed Kubernetes service that simplifies the deployment and management of Kubernetes clusters on Vultr's infrastructure. It is ideal for users looking for a hassle",
+      "category": "platform-install",
+      "missionClass": "install",
+      "author": "KubeStellar Bot",
+      "authorGithub": "kubestellar",
+      "authorAvatar": "https://github.com/kubestellar.png",
+      "tags": [
+        "installation",
+        "configuration",
+        "managed",
+        "managed-k8s",
+        "vultr"
+      ],
+      "cncfProjects": [],
+      "targetResourceKinds": [
+        "Namespace",
+        "Deployment",
+        "Service"
+      ],
+      "difficulty": "beginner",
+      "issueTypes": [
+        "installation",
+        "configuration"
+      ],
+      "type": "deploy",
+      "installMethods": [
+        "cli"
       ]
     },
     {

--- a/solutions/platform-install/platform-charmed-kubernetes.json
+++ b/solutions/platform-install/platform-charmed-kubernetes.json
@@ -1,0 +1,156 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-charmed-kubernetes",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Charmed Kubernetes",
+    "description": "Charmed Kubernetes is a distribution of Kubernetes designed for deployment on Ubuntu, providing a flexible and scalable solution for managing containerized applications across various cloud environments. It is ideal for enterprises looking for a robust Kubernetes setup with modern monitoring and metrics capabilities.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Juju",
+        "description": "First, install Juju, which is required for deploying Charmed Kubernetes. Use the following commands to install Juju on your Ubuntu system:\n```bash\nsudo snap install juju --classic\n```"
+      },
+      {
+        "title": "Bootstrap Juju Controller",
+        "description": "Bootstrap a Juju controller on your cloud provider. Replace `<cloud>` with your desired cloud provider (e.g., aws, gcp, azure):\n```bash\njuju bootstrap <cloud> my-controller\n```"
+      },
+      {
+        "title": "Deploy Charmed Kubernetes",
+        "description": "Deploy Charmed Kubernetes using the following command. This command will install the latest stable bundle:\n```bash\njuju deploy charmed-kubernetes\n```"
+      },
+      {
+        "title": "Verify Deployment",
+        "description": "Check the status of your Kubernetes cluster to ensure all components are running:\n```bash\njuju status\n```"
+      },
+      {
+        "title": "Configure kubectl",
+        "description": "To connect to your new Kubernetes cluster, configure kubectl:\n```bash\njuju config kubernetes-master kubectl-config=~/.kube/config\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Set up metrics and monitoring by enabling the Prometheus charm:\n```bash\njuju deploy prometheus\njuju relate prometheus kubernetes-master\n```"
+      },
+      {
+        "title": "Verify Cluster Info",
+        "description": "Finally, verify that your cluster is operational:\n```bash\nkubectl cluster-info\nkubectl get nodes\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove Charmed Kubernetes",
+        "description": "To uninstall Charmed Kubernetes, run the following commands to destroy the Juju controller and remove all deployed resources:\n```bash\njuju destroy-controller my-controller --destroy-all-models\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Charmed Kubernetes",
+        "description": "To upgrade to a newer version of Charmed Kubernetes, first ensure you have a backup of your current configuration:\n```bash\njuju config kubernetes-master backup=true\n```\nThen, upgrade the bundle:\n```bash\njuju deploy charmed-kubernetes --revision=<new-version>\n```\nReplace `<new-version>` with the version you wish to upgrade to (e.g., 1.30). After the upgrade, verify the status of your deployment:\n```bash\njuju status\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Juju Controller Fails to Bootstrap",
+        "description": "If the Juju controller fails to bootstrap, check the cloud credentials and network connectivity. Use:\n```bash\njuju bootstrap <cloud> my-controller --debug\n```to get detailed logs."
+      },
+      {
+        "title": "Kubernetes Nodes Not Ready",
+        "description": "If nodes are not in a 'Ready' state, check the logs of the Kubernetes components:\n```bash\njuju ssh kubernetes-worker/0\nsudo journalctl -u kubelet\n```"
+      },
+      {
+        "title": "kubectl Access Issues",
+        "description": "If you cannot access the cluster with kubectl, ensure that the kubeconfig is correctly set up. You can regenerate it with:\n```bash\njuju config kubernetes-master kubectl-config=~/.kube/config\n```"
+      },
+      {
+        "title": "Prometheus Not Collecting Metrics",
+        "description": "If Prometheus is not collecting metrics, check the relation with the Kubernetes master:\n```bash\njuju status prometheus\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "1.31",
+        "changes": "Introduced support for Kubernetes 1.31, improved metrics collection, and enhanced security features.",
+        "deprecations": "Deprecated support for Kubernetes 1.28."
+      },
+      {
+        "version": "1.30",
+        "changes": "Added new charms for enhanced monitoring and logging capabilities.",
+        "deprecations": "Some legacy charms have been deprecated in favor of new implementations."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Charmed Kubernetes will have all components running smoothly, with kubectl configured to access the cluster and monitoring tools operational. You should be able to deploy applications and manage the cluster effectively.",
+      "codeSnippets": [
+        "sudo snap install juju --classic",
+        "juju bootstrap <cloud> my-controller",
+        "juju deploy charmed-kubernetes",
+        "juju status",
+        "juju config kubernetes-master kubectl-config=~/.kube/config",
+        "juju deploy prometheus\njuju relate prometheus kubernetes-master"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "distribution",
+      "distribution",
+      "canonical"
+    ],
+    "platform": "charmed-kubernetes",
+    "platformType": "distribution",
+    "platformProvider": "Canonical",
+    "platformVersions": [
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "supportedK8sVersions": [
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "juju"
+    ],
+    "containerImages": [
+      "charmed-kubernetes/k8s:1.31"
+    ],
+    "sourceUrls": {
+      "docs": "https://ubuntu.com/kubernetes/docs",
+      "repo": "https://github.com/charmed-kubernetes/bundle"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.29",
+    "tools": [
+      "juju",
+      "kubectl"
+    ],
+    "cloudCLI": "optional cloud CLI tool (aws, gcloud, azure)",
+    "description": "Ensure you have Juju and kubectl installed, and access to a cloud provider for deployment."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:09:48.820Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-cluster-api.json
+++ b/solutions/platform-install/platform-cluster-api.json
@@ -1,0 +1,136 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-cluster-api",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Cluster API (CAPI)",
+    "description": "Cluster API (CAPI) is a Kubernetes subproject that provides declarative APIs and tooling for managing the lifecycle of Kubernetes clusters. It simplifies provisioning, upgrading, and operating multiple clusters across various infrastructure environments.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Cluster API components",
+        "description": "To install Cluster API, first ensure you have the required tools installed. Then, apply the necessary CRDs and components using the following commands:\n\n```bash\n# Install Cluster API components for v1.9\nkubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.0/cluster-api-components.yaml\n```\n\n**Note:** Replace `v1.9.0` with the desired version if necessary."
+      },
+      {
+        "title": "Bootstrap the management cluster",
+        "description": "Set up a management cluster using the following command:\n\n```bash\n# Create a management cluster using kind\nkind create cluster --name capi-management\n```\n\n**Note:** Ensure you have `kind` installed. You can also use other methods like `kubeadm` if preferred."
+      },
+      {
+        "title": "Verify Cluster API installation",
+        "description": "Check if the Cluster API components are running correctly:\n\n```bash\nkubectl get pods -n capi-system\n```\n\nYou should see the Cluster API controllers running."
+      },
+      {
+        "title": "Post-install configuration",
+        "description": "Configure RBAC for your Cluster API installation:\n\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.0/rbac.yaml\n```\n\nThis will set up necessary permissions for the Cluster API components."
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove Cluster API components",
+        "description": "To uninstall Cluster API, delete the components and CRDs:\n\n```bash\nkubectl delete -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.0/cluster-api-components.yaml\nkubectl delete crd clusters.cluster.x-k8s.io machines.cluster.x-k8s.io\n```\n\nMake sure to clean up any resources created by Cluster API."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Cluster API to v1.9",
+        "description": "Before upgrading, back up your cluster state. Then, upgrade by applying the new components:\n\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.0/cluster-api-components.yaml\n```\n\n**Pre-upgrade check:** Ensure all components are running and healthy. If issues arise, you can roll back by reapplying the previous version's components."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods not starting",
+        "description": "If Cluster API pods are not starting, check the logs:\n\n```bash\nkubectl logs -n capi-system <pod-name>\n```\n\nLook for errors related to configuration or missing permissions."
+      },
+      {
+        "title": "Management cluster not responding",
+        "description": "If the management cluster is unresponsive, verify the cluster status:\n\n```bash\nkubectl cluster-info\n```\n\nEnsure that the control plane components are healthy."
+      },
+      {
+        "title": "CRDs not found",
+        "description": "If you encounter errors regarding missing CRDs, ensure they are applied:\n\n```bash\nkubectl get crd\n```\n\nIf they are missing, reapply the CRDs from the installation YAML."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.9",
+        "changes": "Introduced improved error handling and additional metrics for monitoring.",
+        "deprecations": "The old v1.7 API endpoints are deprecated and will be removed in future releases."
+      },
+      {
+        "version": "v1.8",
+        "changes": "Added support for new infrastructure providers and enhanced documentation.",
+        "deprecations": "Some legacy features have been marked for deprecation."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Cluster API will have all components running in the `capi-system` namespace, with the management cluster responding to commands. You should be able to create and manage Kubernetes clusters declaratively.",
+      "codeSnippets": [
+        "# Install Cluster API components for v1.9\nkubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.0/cluster-api-components.yaml",
+        "# Create a management cluster using kind\nkind create cluster --name capi-management",
+        "kubectl get pods -n capi-system",
+        "kubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.0/rbac.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "cluster-management-operator",
+      "kubernetes-sig"
+    ],
+    "platform": "cluster-api",
+    "platformType": "operator",
+    "platformProvider": "Kubernetes SIG",
+    "platformVersions": [
+      "v1.7",
+      "v1.8",
+      "v1.9"
+    ],
+    "supportedK8sVersions": [
+      "1.26+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "kubectl",
+      "helm"
+    ],
+    "containerImages": [
+      "k8s.gcr.io/cluster-api/cluster-api-controller:v1.9.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://cluster-api.sigs.k8s.io/",
+      "repo": "https://github.com/kubernetes-sigs/cluster-api"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.26",
+    "tools": [
+      "kubectl",
+      "kind"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have kubectl and kind installed for managing Kubernetes clusters."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:08:27.754Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-docker-desktop-k8s.json
+++ b/solutions/platform-install/platform-docker-desktop-k8s.json
@@ -1,0 +1,144 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-docker-desktop-k8s",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Docker Desktop Kubernetes",
+    "description": "Docker Desktop for Mac provides a seamless local development environment for building and testing containerized applications using Kubernetes. It's ideal for developers who want to run Kubernetes clusters on their local machines without the complexity of managing a full cloud infrastructure.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Docker Desktop",
+        "description": "Download and install Docker Desktop for Mac from the official Docker website. Follow the installation prompts. After installation, launch Docker Desktop and enable Kubernetes in the settings.\n\n1. Download Docker Desktop: [Docker Desktop for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac)\n2. Open Docker Desktop, go to Preferences > Kubernetes, and check 'Enable Kubernetes'.\n3. Click 'Apply & Restart' to start the Kubernetes cluster."
+      },
+      {
+        "title": "Verify Kubernetes Installation",
+        "description": "After Docker Desktop restarts, verify that Kubernetes is running by executing:\n```bash\nkubectl cluster-info\n```\nYou should see information about the Kubernetes master and services."
+      },
+      {
+        "title": "Configure kubectl",
+        "description": "Ensure that kubectl is configured to use the Docker Desktop Kubernetes context:\n```bash\nkubectl config use-context docker-desktop\n```\nVerify the context:\n```bash\nkubectl config current-context\n```\nIt should return 'docker-desktop'."
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "To enable resource autoscaling, apply the following configuration:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/kubernetes/examples/master/staging/cluster-autoscaler/cluster-autoscaler.yaml\n```\nMake sure to adjust the parameters according to your needs."
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Docker Desktop",
+        "description": "To completely remove Docker Desktop and its Kubernetes components:\n1. Open Docker Desktop.\n2. Go to Preferences > Uninstall.\n3. Follow the prompts to uninstall.\n4. Optionally, remove Docker Desktop application from the Applications folder and delete any associated files in `~/Library/Containers/com.docker.docker`."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Docker Desktop",
+        "description": "To upgrade Docker Desktop to a newer version, download the latest version from the Docker website and install it over the existing version. Ensure that you back up any important data or configurations before upgrading. After upgrading, verify the Kubernetes version:\n```bash\nkubectl version --short\n```\nIf you encounter issues, you can roll back to the previous version by reinstalling it from the Docker website."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Kubernetes not starting",
+        "description": "If Kubernetes fails to start, check the Docker Desktop logs for errors. You can access logs by going to the Docker Desktop menu > Troubleshoot > Logs. Ensure that your system meets the minimum requirements for Docker Desktop."
+      },
+      {
+        "title": "kubectl command not found",
+        "description": "If you receive a 'command not found' error when running kubectl, ensure that Docker Desktop is installed correctly and that the Docker Desktop binary path is added to your shell's PATH environment variable."
+      },
+      {
+        "title": "Resource limits exceeded",
+        "description": "If you encounter resource limits errors, adjust the resource allocation for Docker Desktop in Preferences > Resources. Increase CPU and memory limits as needed."
+      },
+      {
+        "title": "Kubernetes context issues",
+        "description": "If kubectl commands fail due to context issues, reset the context using:\n```bash\nkubectl config use-context docker-desktop\n```"
+      },
+      {
+        "title": "Networking issues",
+        "description": "If you experience networking issues, ensure that your firewall settings allow Docker Desktop to communicate. You may also need to reset the network settings in Docker Desktop Preferences."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "4.32",
+        "changes": "Improved Kubernetes integration and performance enhancements.",
+        "deprecations": "No major deprecations noted."
+      },
+      {
+        "version": "4.31",
+        "changes": "Added support for Kubernetes 1.30 and various bug fixes.",
+        "deprecations": "Deprecated support for Kubernetes 1.28."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Docker Desktop Kubernetes will allow you to run a local Kubernetes cluster, manage it with kubectl, and deploy applications seamlessly. You should be able to verify the cluster status and configure additional resources as needed.",
+      "codeSnippets": [
+        "kubectl cluster-info",
+        "kubectl config use-context docker-desktop",
+        "kubectl config current-context",
+        "kubectl apply -f https://raw.githubusercontent.com/kubernetes/examples/master/staging/cluster-autoscaler/cluster-autoscaler.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "local",
+      "local-dev",
+      "docker"
+    ],
+    "platform": "docker-desktop-k8s",
+    "platformType": "local",
+    "platformProvider": "Docker",
+    "platformVersions": [
+      "4.30",
+      "4.31",
+      "4.32"
+    ],
+    "supportedK8sVersions": [
+      "1.29",
+      "1.30"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "console"
+    ],
+    "containerImages": [
+      "docker/desktop:4.32"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.docker.com/desktop/kubernetes/",
+      "repo": "https://github.com/docker/for-mac"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.29",
+    "tools": [
+      "kubectl"
+    ],
+    "cloudCLI": "none",
+    "description": "Ensure you have macOS and sufficient resources to run Docker Desktop."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:10:27.864Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-doks.json
+++ b/solutions/platform-install/platform-doks.json
@@ -1,0 +1,133 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-doks",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure DigitalOcean Kubernetes (DOKS)",
+    "description": "DigitalOcean Kubernetes (DOKS) is a managed Kubernetes service designed for simplicity and cost-effectiveness in container orchestration. It is ideal for developers and teams looking to deploy and manage Kubernetes clusters without the overhead of managing the underlying infrastructure.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Create a DOKS Cluster",
+        "description": "Use the DigitalOcean CLI (doctl) to create a Kubernetes cluster. Replace `<cluster-name>`, `<region>`, and `<node-count>` with your desired values.\n\n```bash\n# Install doctl if you haven't already\nbrew install doctl\n\n# Authenticate with your DigitalOcean account\ndoctl auth init\n\n# Create the Kubernetes cluster\ndoctl k8s cluster create <cluster-name> --region <region> --node-pool \"name=default;size=s-2vcpu-4gb;count=<node-count>\"\n```\n\n**Note:** Ensure you select a region that supports your desired Kubernetes version."
+      },
+      {
+        "title": "Connect kubectl to the Cluster",
+        "description": "Once the cluster is created, configure kubectl to connect to it:\n\n```bash\n# Get the kubeconfig for your cluster\ndoctl k8s cluster kubeconfig save <cluster-name>\n\n# Verify kubectl is connected\ngkubectl cluster-info\n```\n"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Set up Horizontal Pod Autoscaler (HPA) for your deployments:\n\n```bash\n# Create a deployment (example)\nkubectl create deployment my-app --image=nginx\n\n# Expose the deployment\ngkubectl expose deployment my-app --port=80 --target-port=80\n\n# Enable HPA\ngkubectl autoscale deployment my-app --cpu-percent=50 --min=1 --max=10\n```\nVerify HPA is working:\n```bash\nkubectl get hpa\n```\n"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Delete the DOKS Cluster",
+        "description": "To uninstall the DOKS cluster, run:\n\n```bash\ndoctl k8s cluster delete <cluster-name>\n```\nThis command will remove the cluster and all associated resources. Ensure you have backed up any necessary data before proceeding."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade DOKS Cluster",
+        "description": "To upgrade your DOKS cluster to a newer version, follow these steps:\n1. Check the current version:\n   ```bash\n   doctl k8s cluster get <cluster-name>\n   ```\n2. Upgrade the cluster:\n   ```bash\n   doctl k8s cluster upgrade <cluster-name> --version <new-version>\n   ```\n3. Verify the upgrade:\n   ```bash\n   kubectl get nodes\n   ```\n4. Backup your data before upgrading, especially if you are moving between major versions. Use tools like Velero for backup.\n5. If issues arise, you can roll back to the previous version using the same upgrade command with the old version number."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "kubectl not connecting to the cluster",
+        "description": "If kubectl cannot connect, ensure your kubeconfig is set up correctly. Run:\n```bash\ncat ~/.kube/config\n```\nCheck for the correct context and cluster name. If incorrect, re-run the kubeconfig command:\ndoctl k8s cluster kubeconfig save <cluster-name>."
+      },
+      {
+        "title": "Cluster status is 'Pending'",
+        "description": "If your cluster is stuck in 'Pending', check for resource availability in your selected region. Use:\n```bash\ndoctl k8s cluster get <cluster-name>\n```\nIf resources are insufficient, consider changing the region or adjusting node pool sizes."
+      },
+      {
+        "title": "HPA not scaling",
+        "description": "If HPA is not scaling as expected, ensure your application is consuming CPU resources. Check with:\n```bash\nkubectl top pods\n```\nIf no metrics are reported, ensure Metrics Server is installed:\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "1.30",
+        "changes": "Improved performance and stability with enhanced autoscaling features.",
+        "deprecations": "Deprecated support for Kubernetes 1.24."
+      },
+      {
+        "version": "1.29",
+        "changes": "Introduced new node pool configurations and improved security features.",
+        "deprecations": "Deprecated legacy API versions for certain resources."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running DOKS cluster with kubectl configured, and the ability to deploy applications with autoscaling enabled. Verify by checking the cluster status and deployed applications.",
+      "codeSnippets": [
+        "# Install doctl if you haven't already\nbrew install doctl\n\n# Authenticate with your DigitalOcean account\ndoctl auth init\n\n# Create the Kubernetes cluster\ndoctl k8s cluster create <cluster-name> --region <region> --node-pool \"name=default;size=s-2vcpu-4gb;count=<node-count>\"",
+        "# Get the kubeconfig for your cluster\ndoctl k8s cluster kubeconfig save <cluster-name>\n\n# Verify kubectl is connected\ngkubectl cluster-info",
+        "# Create a deployment (example)\nkubectl create deployment my-app --image=nginx\n\n# Expose the deployment\ngkubectl expose deployment my-app --port=80 --target-port=80\n\n# Enable HPA\ngkubectl autoscale deployment my-app --cpu-percent=50 --min=1 --max=10",
+        "kubectl get hpa"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "managed",
+      "managed-k8s",
+      "digitalocean"
+    ],
+    "platform": "doks",
+    "platformType": "managed",
+    "platformProvider": "DigitalOcean",
+    "platformVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "supportedK8sVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli"
+    ],
+    "containerImages": [
+      "digitalocean/doks:1.30"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.digitalocean.com/products/kubernetes/",
+      "repo": "https://github.com/digitalocean/DOKS"
+    },
+    "qualityScore": 98
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.28",
+    "tools": [
+      "kubectl",
+      "doctl"
+    ],
+    "cloudCLI": "optional cloud CLI tool (doctl)",
+    "description": "Ensure you have an active DigitalOcean account and the doctl CLI installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:05:43.933Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-elastic-cloud-on-k8s.json
+++ b/solutions/platform-install/platform-elastic-cloud-on-k8s.json
@@ -1,0 +1,138 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-elastic-cloud-on-k8s",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Elastic Cloud on Kubernetes (ECK)",
+    "description": "Elastic Cloud on Kubernetes (ECK) automates the deployment and management of the Elastic Stack on Kubernetes. It is ideal for users who want to run Elasticsearch, Kibana, and other Elastic products in a Kubernetes environment using an operator pattern.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install ECK Operator",
+        "description": "Deploy the ECK operator using Helm. Ensure Helm is installed and configured. Run the following commands:\n\n```bash\n# Add the Elastic Helm repository\nhelm repo add elastic https://helm.elastic.co\n\n# Update your local Helm chart repository cache\nhelm repo update\n\n# Install the ECK operator (version 2.14.0)\nhelm install eck-operator elastic/eck-operator --version 2.14.0 --namespace elastic-system --create-namespace\n```\n\nVerify the installation:\n```bash\nkubectl get pods -n elastic-system\n```"
+      },
+      {
+        "title": "Create Custom Resource Definitions (CRDs)",
+        "description": "After installing the operator, apply the CRDs required for ECK:\n\n```bash\nkubectl apply -f https://download.elastic.co/downloads/eck/2.14.0/crds.yaml\n```\n\nVerify CRDs:\n```bash\nkubectl get crd | grep elasticsearch\n```"
+      },
+      {
+        "title": "Deploy Elasticsearch Cluster",
+        "description": "Create an Elasticsearch cluster by applying a custom resource:\n\n```bash\ncat <<EOF | kubectl apply -f -\napiVersion: elasticsearch.k8s.elastic.co/v1\nkind: Elasticsearch\nmetadata:\n  name: my-elasticsearch\n  namespace: default\nspec:\n  version: 8.5.0\n  nodeSets:\n  - name: default\n    count: 3\n    config:\n      node.store.allow_mmap: false\nEOF\n```\n\nVerify the Elasticsearch cluster:\n```bash\nkubectl get elasticsearch -n default\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Configure autoscaling for the Elasticsearch cluster:\n\n```bash\nkubectl patch elasticsearch my-elasticsearch -n default --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/nodeSets/0/podTemplate/spec/containers/0/resources/requests/cpu\", \"value\": \"500m\"}]'\n```\n\nVerify the autoscaling configuration:\n```bash\nkubectl get elasticsearch my-elasticsearch -n default -o yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall ECK Operator",
+        "description": "Remove the ECK operator and associated resources:\n\n```bash\n# Delete the Elasticsearch cluster\nkubectl delete elasticsearch my-elasticsearch -n default\n\n# Uninstall the ECK operator\nhelm uninstall eck-operator -n elastic-system\n\n# Remove CRDs\nkubectl delete -f https://download.elastic.co/downloads/eck/2.14.0/crds.yaml\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade ECK Operator",
+        "description": "To upgrade from version 2.12 to 2.14, follow these steps:\n1. Backup your Elasticsearch data and configurations.\n2. Upgrade the operator using Helm:\n   ```bash\n   helm upgrade eck-operator elastic/eck-operator --version 2.14.0 -n elastic-system\n   ```\n3. Verify the upgrade:\n   ```bash\n   kubectl get pods -n elastic-system\n   ```\n4. Check the Elasticsearch cluster status:\n   ```bash\n   kubectl get elasticsearch -n default\n   ```\n5. Rollback if necessary:\n   ```bash\n   helm rollback eck-operator -n elastic-system\n   ```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Elasticsearch Cluster Not Starting",
+        "description": "If the Elasticsearch cluster fails to start, check the logs:\n```bash\nkubectl logs -l common.k8s.elastic.co/type=elasticsearch -n default\n```\nCommon issues include insufficient resources or misconfigurations in the custom resource."
+      },
+      {
+        "title": "ECK Operator Not Running",
+        "description": "If the ECK operator pod is not running, check the pod status:\n```bash\nkubectl get pods -n elastic-system\n```\nIf the pod is in a CrashLoopBackOff state, inspect the logs for errors:\n```bash\nkubectl logs <pod-name> -n elastic-system\n```"
+      },
+      {
+        "title": "CRD Not Found",
+        "description": "If you encounter a 'CRD not found' error, ensure that the CRDs were applied correctly:\n```bash\nkubectl get crd | grep elasticsearch\n```\nIf missing, reapply the CRDs using the command provided in the installation steps."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "2.14",
+        "changes": "Improved TLS certificate management and enhanced monitoring capabilities.",
+        "deprecations": "Deprecated support for Elasticsearch versions below 8.0."
+      },
+      {
+        "version": "2.13",
+        "changes": "Added support for new Elasticsearch features and improved resource management.",
+        "deprecations": "No deprecations."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running ECK operator and Elasticsearch cluster, with all resources properly configured. You should be able to access your Elasticsearch instance and manage it through the Kubernetes API.",
+      "codeSnippets": [
+        "# Add the Elastic Helm repository\nhelm repo add elastic https://helm.elastic.co\n\n# Update your local Helm chart repository cache\nhelm repo update\n\n# Install the ECK operator (version 2.14.0)\nhelm install eck-operator elastic/eck-operator --version 2.14.0 --namespace elastic-system --create-namespace",
+        "kubectl get pods -n elastic-system",
+        "kubectl apply -f https://download.elastic.co/downloads/eck/2.14.0/crds.yaml",
+        "kubectl get crd | grep elasticsearch",
+        "cat <<EOF | kubectl apply -f -\napiVersion: elasticsearch.k8s.elastic.co/v1\nkind: Elasticsearch\nmetadata:\n  name: my-elasticsearch\n  namespace: default\nspec:\n  version: 8.5.0\n  nodeSets:\n  - name: default\n    count: 3\n    config:\n      node.store.allow_mmap: false\nEOF",
+        "kubectl get elasticsearch -n default"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "elastic"
+    ],
+    "platform": "elastic-cloud-on-k8s",
+    "platformType": "operator",
+    "platformProvider": "Elastic",
+    "platformVersions": [
+      "2.12",
+      "2.13",
+      "2.14"
+    ],
+    "supportedK8sVersions": [
+      "1.26+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "docker.elastic.co/eck/eck-operator:2.14.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://www.elastic.co/guide/en/cloud-on-k8s/",
+      "repo": "https://github.com/elastic/cloud-on-k8s"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.26",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running version 1.26 or higher and have kubectl and helm installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:10:03.394Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-external-dns-operator.json
+++ b/solutions/platform-install/platform-external-dns-operator.json
@@ -1,0 +1,131 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-external-dns-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure ExternalDNS",
+    "description": "ExternalDNS is an operator that synchronizes Kubernetes Services and Ingresses with DNS providers, allowing dynamic DNS management through Kubernetes resources. It is useful when you want to automate DNS record updates based on your Kubernetes resources.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install ExternalDNS using Helm",
+        "description": "Add the ExternalDNS Helm repository and install the operator. Ensure you are using Helm version 3.0 or higher.\n\n```bash\nhelm repo add external-dns https://charts.bitnami.com/bitnami\nhelm repo update\nhelm install external-dns external-dns/external-dns --namespace kube-system --set provider=aws --set aws.zoneType=public --set aws.accessKey=YOUR_AWS_ACCESS_KEY --set aws.secretKey=YOUR_AWS_SECRET_KEY\n```\n\n**Note:** Replace `YOUR_AWS_ACCESS_KEY` and `YOUR_AWS_SECRET_KEY` with your actual AWS credentials. Ensure the IAM role has permissions to manage Route 53 records."
+      },
+      {
+        "title": "Configure ExternalDNS for your domain",
+        "description": "Create a ConfigMap to specify the domain filter and other settings. This example assumes you want to manage DNS records for the domain `example.com`.\n\n```bash\nkubectl create configmap external-dns-config --from-literal=domain-filter=example.com --namespace kube-system\n```\n\nThen, update the ExternalDNS deployment to use this ConfigMap:\n\n```bash\nkubectl patch deployment external-dns -n kube-system --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/-\", \"value\": {\"name\": \"EXTERNAL_DNS_DOMAIN_FILTER\", \"valueFrom\": {\"configMapKeyRef\": {\"name\": \"external-dns-config\", \"key\": \"domain-filter\"}}}}]'\n```"
+      },
+      {
+        "title": "Verify ExternalDNS installation",
+        "description": "Check if ExternalDNS is running correctly and managing DNS records.\n\n```bash\nkubectl get pods -n kube-system\nkubectl logs -f deployment/external-dns -n kube-system\nkubectl get services --all-namespaces\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall ExternalDNS",
+        "description": "Remove the ExternalDNS Helm release and clean up any associated resources.\n\n```bash\nhelm uninstall external-dns --namespace kube-system\nkubectl delete configmap external-dns-config --namespace kube-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade ExternalDNS to v0.15",
+        "description": "Before upgrading, back up your existing configuration and resources. Check the release notes for breaking changes. To upgrade:\n\n```bash\nhelm repo update\nhelm upgrade external-dns external-dns/external-dns --namespace kube-system --set provider=aws --set aws.zoneType=public --set aws.accessKey=YOUR_AWS_ACCESS_KEY --set aws.secretKey=YOUR_AWS_SECRET_KEY\n```\n\n**Backup:**\n```bash\nkubectl get all -n kube-system > external-dns-backup.yaml\n```\n\n**Rollback:** If the upgrade fails, you can rollback to the previous version using:\n```bash\nhelm rollback external-dns --namespace kube-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "ExternalDNS not updating DNS records",
+        "description": "If DNS records are not being updated, check the logs for errors:\n```bash\nkubectl logs deployment/external-dns -n kube-system\n```\nEnsure that the IAM role has the correct permissions for Route 53. Also, verify that the domain filter is set correctly."
+      },
+      {
+        "title": "Pods in CrashLoopBackOff",
+        "description": "If the ExternalDNS pods are in a CrashLoopBackOff state, check the logs for the root cause:\n```bash\nkubectl logs deployment/external-dns -n kube-system\n```\nCommon issues include misconfigured AWS credentials or incorrect domain filters."
+      },
+      {
+        "title": "Service not found in DNS",
+        "description": "If a service is not found in DNS, ensure that the service is of type LoadBalancer and that the ExternalDNS is configured to watch the correct namespace. Check the service annotations for ExternalDNS:\n```bash\nkubectl describe service <service-name> -n <namespace>\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v0.14",
+        "changes": "Introduced support for additional DNS providers and improved logging.",
+        "deprecations": "Deprecated the old configuration flags for AWS provider."
+      },
+      {
+        "version": "v0.15",
+        "changes": "Added support for new Kubernetes API versions and enhanced error handling.",
+        "deprecations": "Removed deprecated flags from v0.14."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of ExternalDNS will have the operator running in the kube-system namespace, dynamically managing DNS records for your specified domain based on Kubernetes resources. You should see the DNS records in your DNS provider reflecting the services and ingresses defined in your cluster.",
+      "codeSnippets": [
+        "helm repo add external-dns https://charts.bitnami.com/bitnami\nhelm repo update\nhelm install external-dns external-dns/external-dns --namespace kube-system --set provider=aws --set aws.zoneType=public --set aws.accessKey=YOUR_AWS_ACCESS_KEY --set aws.secretKey=YOUR_AWS_SECRET_KEY",
+        "kubectl create configmap external-dns-config --from-literal=domain-filter=example.com --namespace kube-system",
+        "kubectl patch deployment external-dns -n kube-system --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/-\", \"value\": {\"name\": \"EXTERNAL_DNS_DOMAIN_FILTER\", \"valueFrom\": {\"configMapKeyRef\": {\"name\": \"external-dns-config\", \"key\": \"domain-filter\"}}}}]'",
+        "kubectl get pods -n kube-system\nkubectl logs -f deployment/external-dns -n kube-system\nkubectl get services --all-namespaces"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "networking-operator",
+      "kubernetes-sig"
+    ],
+    "platform": "external-dns-operator",
+    "platformType": "operator",
+    "platformProvider": "Kubernetes SIG",
+    "platformVersions": [
+      "v0.14",
+      "v0.15"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "k8s.gcr.io/external-dns/external-dns:v0.15.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://kubernetes-sigs.github.io/external-dns/",
+      "repo": "https://github.com/kubernetes-sigs/external-dns"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "aws",
+    "description": "Ensure you have kubectl and Helm installed, and AWS CLI configured with appropriate permissions."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:07:43.562Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-grafana-operator.json
+++ b/solutions/platform-install/platform-grafana-operator.json
@@ -1,0 +1,146 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-grafana-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Grafana Operator",
+    "description": "The Grafana Operator simplifies the management of Grafana instances, dashboards, and datasources using Kubernetes custom resources. It's ideal for users who prefer GitOps workflows or need to manage multiple Grafana instances efficiently.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Grafana Operator using Helm",
+        "description": "Deploy the Grafana Operator in your cluster using Helm. Ensure you have Helm installed and configured. Run the following command:\n```bash\nhelm repo add grafana https://grafana.github.io/helm-charts\nhelm repo update\nhelm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.22.0\n```\nVerify the installation by checking the operator's status:\n```bash\nkubectl get pods -n default -l app.kubernetes.io/name=grafana-operator\n```"
+      },
+      {
+        "title": "Deploy Grafana Instance",
+        "description": "Create a Grafana instance using a custom resource. Save the following YAML to a file named `grafana-instance.yaml`:\n```yaml\napiVersion: grafana.integreatly.org/v1beta1\nkind: Grafana\nmetadata:\n  name: grafana\n  labels:\n    dashboards: \"grafana\"\nspec:\n  config:\n    log:\n      mode: \"console\"\n    security:\n      admin_user: root\n      admin_password: secret\n```\nApply the configuration:\n```bash\nkubectl apply -f grafana-instance.yaml\n```\nCheck the status:\n```bash\nkubectl get grafana\n```"
+      },
+      {
+        "title": "Deploy a Sample Dashboard",
+        "description": "Create a sample dashboard using a custom resource. Save the following YAML to a file named `sample-dashboard.yaml`:\n```yaml\napiVersion: grafana.integreatly.org/v1beta1\nkind: GrafanaDashboard\nmetadata:\n  name: sample-dashboard\nspec:\n  resyncPeriod: 30s\n  instanceSelector:\n    matchLabels:\n      dashboards: \"grafana\"\n  json: >\n    {\n      \"title\": \"Simple Dashboard\",\n      \"timezone\": \"browser\",\n      \"refresh\": \"5s\",\n      \"panels\": [],\n      \"time\": {\n        \"from\": \"now-6h\",\n        \"to\": \"now\"\n      }\n    }\n```\nApply the dashboard configuration:\n```bash\nkubectl apply -f sample-dashboard.yaml\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Configure RBAC for Grafana. Create a Role and RoleBinding to allow access:\n```yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: default\n  name: grafana-role\nrules:\n- apiGroups: [\"*\"]\n  resources: [\"*\"]\n  verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"delete\"]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: grafana-role-binding\n  namespace: default\nsubjects:\n- kind: User\n  name: your-username\n  apiGroup: rbac.authorization.k8s.io\nroleRef:\n  kind: Role\n  name: grafana-role\n  apiGroup: rbac.authorization.k8s.io\n```\nApply the RBAC configuration:\n```bash\nkubectl apply -f rbac-config.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Grafana Operator",
+        "description": "Remove the Grafana Operator and its resources. Run the following command:\n```bash\nhelm uninstall grafana-operator\n```\nClean up any remaining custom resources:\n```bash\nkubectl delete grafana --all\nkubectl delete grafanadashboard --all\n```\nVerify that all resources are removed:\n```bash\nkubectl get all -l app.kubernetes.io/name=grafana-operator\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Grafana Operator",
+        "description": "To upgrade the Grafana Operator, first check the current version:\n```bash\nhelm list\n```\nBackup your current Grafana instances and dashboards:\n```bash\nkubectl get grafana -o yaml > grafana-backup.yaml\nkubectl get grafanadashboard -o yaml > dashboards-backup.yaml\n```\nUpgrade the operator using Helm:\n```bash\nhelm upgrade grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.22.0\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n default -l app.kubernetes.io/name=grafana-operator\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Grafana Operator Pod Not Starting",
+        "description": "If the Grafana Operator pod is not starting, check the logs:\n```bash\nkubectl logs <pod-name> -n default\n```\nCommon issues include missing permissions or incorrect configurations. Ensure that the service account has the necessary RBAC permissions."
+      },
+      {
+        "title": "Grafana Instance Not Accessible",
+        "description": "If you cannot access your Grafana instance, verify the service:\n```bash\nkubectl get svc -l app.kubernetes.io/name=grafana\n```\nEnsure that the service type is set to LoadBalancer or NodePort for external access."
+      },
+      {
+        "title": "Dashboard Not Loading",
+        "description": "If the dashboard is not loading, check the GrafanaDashboard resource:\n```bash\nkubectl describe grafanadashboard sample-dashboard\n```\nLook for errors in the JSON configuration or issues with the Grafana instance."
+      },
+      {
+        "title": "RBAC Issues",
+        "description": "If you encounter RBAC errors, ensure that your Role and RoleBinding are correctly configured. Check the logs for permission denied errors and adjust the RBAC settings accordingly."
+      },
+      {
+        "title": "Resource Quota Exceeded",
+        "description": "If you receive errors about resource quotas, check the resource usage:\n```bash\nkubectl describe quota\n```\nAdjust your resource requests/limits or increase the quota in your namespace."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v5.12",
+        "changes": "Improved support for Grafana dashboards and data sources management.",
+        "deprecations": "Deprecated the old API version for GrafanaDashboard."
+      },
+      {
+        "version": "v5.11",
+        "changes": "Added new features for better integration with Kubernetes RBAC.",
+        "deprecations": "None."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running Grafana Operator, accessible Grafana instances, and functioning dashboards. You should be able to manage Grafana resources using Kubernetes custom resources.",
+      "codeSnippets": [
+        "helm repo add grafana https://grafana.github.io/helm-charts\nhelm repo update\nhelm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.22.0",
+        "kubectl get pods -n default -l app.kubernetes.io/name=grafana-operator",
+        "apiVersion: grafana.integreatly.org/v1beta1\nkind: Grafana\nmetadata:\n  name: grafana\n  labels:\n    dashboards: \"grafana\"\nspec:\n  config:\n    log:\n      mode: \"console\"\n    security:\n      admin_user: root\n      admin_password: secret",
+        "kubectl apply -f grafana-instance.yaml",
+        "kubectl get grafana",
+        "apiVersion: grafana.integreatly.org/v1beta1\nkind: GrafanaDashboard\nmetadata:\n  name: sample-dashboard\nspec:\n  resyncPeriod: 30s\n  instanceSelector:\n    matchLabels:\n      dashboards: \"grafana\"\n  json: >\n    {\n      \"title\": \"Simple Dashboard\",\n      \"timezone\": \"browser\",\n      \"refresh\": \"5s\",\n      \"panels\": [],\n      \"time\": {\n        \"from\": \"now-6h\",\n        \"to\": \"now\"\n      }\n    }"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "observability-operator",
+      "grafana-labs"
+    ],
+    "platform": "grafana-operator",
+    "platformType": "operator",
+    "platformProvider": "Grafana Labs",
+    "platformVersions": [
+      "v5.10",
+      "v5.11",
+      "v5.12"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "ghcr.io/grafana/helm-charts/grafana-operator:5.22.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://grafana.github.io/grafana-operator/",
+      "repo": "https://github.com/grafana/grafana-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running version 1.25 or higher, and Helm installed for package management."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:09:37.977Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-iks.json
+++ b/solutions/platform-install/platform-iks.json
@@ -1,0 +1,134 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-iks",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure IBM Cloud Kubernetes Service (IKS)",
+    "description": "IBM Cloud Kubernetes Service (IKS) is a managed Kubernetes service that simplifies the deployment and management of Kubernetes clusters on IBM Cloud. It is ideal for organizations looking to leverage Kubernetes without the overhead of managing the underlying infrastructure.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Create an IBM Cloud Kubernetes Cluster",
+        "description": "Use the IBM Cloud CLI to create a Kubernetes cluster. Replace `<cluster-name>` and `<region>` with your desired values.\n\n```bash\nibmcloud ks cluster-create --name <cluster-name> --zone <region> --num-workers 3 --machine-type b3c.4x16\n```\n\nAfter the cluster is created, set the context for kubectl:\n\n```bash\nibmcloud ks cluster-config --cluster <cluster-name>\n```\n```\n\nThis command configures your local kubectl to connect to the new cluster."
+      },
+      {
+        "title": "Verify Cluster Setup",
+        "description": "Check the cluster information and node status to ensure everything is running correctly.\n\n```bash\nkubectl cluster-info\nkubectl get nodes\n```\n\nEnsure all nodes are in 'Ready' status."
+      },
+      {
+        "title": "Post-Install Configuration for Autoscaling",
+        "description": "Enable the Horizontal Pod Autoscaler (HPA) for your deployments. First, ensure metrics-server is installed:\n\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml\n```\n\nThen, create an HPA for your deployment:\n\n```bash\nkubectl autoscale deployment <deployment-name> --cpu-percent=50 --min=1 --max=10\n```\n"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Delete the Kubernetes Cluster",
+        "description": "To remove the Kubernetes cluster and all associated resources, use the following command:\n\n```bash\nibmcloud ks cluster-delete --cluster <cluster-name> --force\n```\n\nThis command will delete the cluster and all resources associated with it."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Kubernetes Cluster Version",
+        "description": "Before upgrading, ensure you have a backup of your workloads and configurations. You can use the following command to upgrade your cluster:\n\n```bash\nibmcloud ks cluster-update --cluster <cluster-name> --kubernetes-version 1.30\n```\n\nAfter the upgrade, verify the cluster status:\n\n```bash\nkubectl get nodes\n```\n\nIf you encounter issues, you can roll back to the previous version using the same command with the old version number."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Nodes Not Ready",
+        "description": "If any nodes are not in 'Ready' status, check the node conditions:\n\n```bash\nkubectl describe node <node-name>\n```\n\nLook for any issues in the events section. Common issues include insufficient resources or network problems."
+      },
+      {
+        "title": "kubectl Not Configured",
+        "description": "If kubectl commands fail, ensure that the context is set correctly:\n\n```bash\nibmcloud ks cluster-config --cluster <cluster-name>\n```\n\nThen, verify the context:\n\n```bash\nkubectl config current-context\n```\n"
+      },
+      {
+        "title": "HPA Not Scaling",
+        "description": "If the Horizontal Pod Autoscaler is not scaling as expected, ensure that metrics-server is running:\n\n```bash\nkubectl get pods -n kube-system\n```\n\nCheck the logs of the metrics-server pod for errors:\n\n```bash\nkubectl logs <metrics-server-pod-name> -n kube-system\n```\n"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "1.30",
+        "changes": "Introduced support for new node types and improved security features.",
+        "deprecations": "Deprecated support for Kubernetes 1.26."
+      },
+      {
+        "version": "1.29",
+        "changes": "Enhanced monitoring capabilities and improved autoscaling features.",
+        "deprecations": "No major deprecations."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of IBM Cloud Kubernetes Service includes a running cluster with all nodes in 'Ready' status, kubectl configured correctly, and post-install configurations such as autoscaling enabled.",
+      "codeSnippets": [
+        "ibmcloud ks cluster-create --name <cluster-name> --zone <region> --num-workers 3 --machine-type b3c.4x16",
+        "ibmcloud ks cluster-config --cluster <cluster-name>",
+        "kubectl cluster-info\nkubectl get nodes",
+        "kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml",
+        "kubectl autoscale deployment <deployment-name> --cpu-percent=50 --min=1 --max=10"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "managed",
+      "managed-k8s",
+      "ibm-cloud"
+    ],
+    "platform": "iks",
+    "platformType": "managed",
+    "platformProvider": "IBM Cloud",
+    "platformVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "supportedK8sVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli"
+    ],
+    "containerImages": [
+      "ibmcom/ibm-cloud-kubernetes-service:1.30"
+    ],
+    "sourceUrls": {
+      "docs": "https://cloud.ibm.com/docs/containers",
+      "repo": "https://github.com/IBM-Cloud/kube-samples"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "ibmcloud"
+    ],
+    "cloudCLI": "optional IBM Cloud CLI",
+    "description": "Ensure you have the IBM Cloud CLI installed and configured with your account."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:07:08.911Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-k0s.json
+++ b/solutions/platform-install/platform-k0s.json
@@ -1,0 +1,130 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-k0s",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure k0s (Zero Friction Kubernetes)",
+    "description": "k0s is a lightweight, all-inclusive Kubernetes distribution designed for ease of use and minimal friction in deployment. It is ideal for cloud, bare metal, edge, and IoT environments, allowing users to bootstrap Kubernetes clusters quickly.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Configure kubectl access",
+        "description": "To access the cluster with kubectl, copy the kubeconfig file:\n```bash\nsudo cp /var/lib/k0s/pki/admin.conf ~/.kube/config\n``` \nVerify kubectl access:\n```bash\nkubectl get nodes\n```\nThis should list the nodes in your cluster."
+      },
+      {
+        "title": "Post-install configuration",
+        "description": "Enable the metrics server for monitoring:\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml\n```\nVerify the metrics server is running:\n```bash\nkubectl get pods -n kube-system | grep metrics-server\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove k0s cluster",
+        "description": "Stop and uninstall the k0s controller and clean up resources:\n```bash\nsudo k0s stop\nsudo k0s uninstall\nrm -rf /var/lib/k0s\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade k0s to v1.31",
+        "description": "Before upgrading, back up your cluster configuration:\n```bash\nsudo k0s backup\n```\nTo upgrade to v1.31, run:\n```bash\ncurl -sSL https://get.k0s.sh | sudo sh\n```\nAfter the upgrade, restart the k0s controller:\n```bash\nsudo k0s restart\n```\nVerify the upgrade:\n```bash\nk0s version\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Cluster not starting",
+        "description": "If the cluster fails to start, check the logs:\n```bash\nsudo journalctl -u k0s-controller\n```\nLook for errors related to configuration or resource limits."
+      },
+      {
+        "title": "kubectl access issues",
+        "description": "If kubectl commands fail, ensure the kubeconfig file is correctly set:\n```bash\necho $KUBECONFIG\n```\nIf it’s empty, set it to the correct path:\n```bash\nexport KUBECONFIG=/var/lib/k0s/pki/admin.conf\n```"
+      },
+      {
+        "title": "Metrics server not available",
+        "description": "If the metrics server is not available, check its pod status:\n```bash\nkubectl get pods -n kube-system | grep metrics-server\n```\nIf it's not running, check the logs:\n```bash\nkubectl logs -n kube-system <metrics-server-pod-name>\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.31",
+        "changes": "Improved performance and stability, added support for new Kubernetes features.",
+        "deprecations": "Deprecated support for Kubernetes versions below 1.29."
+      },
+      {
+        "version": "v1.30",
+        "changes": "Introduced enhanced security features and better integration with cloud providers.",
+        "deprecations": "Removed legacy CLI commands."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of k0s will have a running Kubernetes cluster with all nodes in a ready state, and kubectl will be able to communicate with the cluster. You should also have monitoring enabled and be able to view node metrics.",
+      "codeSnippets": [
+        "sudo cp /var/lib/k0s/pki/admin.conf ~/.kube/config",
+        "kubectl get nodes",
+        "kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml",
+        "kubectl get pods -n kube-system | grep metrics-server"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "distribution",
+      "distribution",
+      "mirantis"
+    ],
+    "platform": "k0s",
+    "platformType": "distribution",
+    "platformProvider": "Mirantis",
+    "platformVersions": [
+      "v1.29",
+      "v1.30",
+      "v1.31"
+    ],
+    "supportedK8sVersions": [
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "kubectl"
+    ],
+    "containerImages": [
+      "mirantis/k0s:v1.31.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.k0sproject.io/",
+      "repo": "https://github.com/k0sproject/k0s"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "curl"
+    ],
+    "cloudCLI": "none",
+    "description": "Ensure you have a Linux environment with internet access and necessary permissions."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:08:38.578Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-kubeadm.json
+++ b/solutions/platform-install/platform-kubeadm.json
@@ -1,0 +1,159 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-kubeadm",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure kubeadm (Kubernetes bootstrapper)",
+    "description": "Kubeadm is a tool designed to simplify the process of creating and managing Kubernetes clusters. It provides best-practice paths for bootstrapping a secure and minimal viable cluster, making it ideal for users who want to set up Kubernetes quickly and efficiently.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Kubeadm",
+        "description": "Install kubeadm on your Linux nodes. For Ubuntu 22.04, use the following commands:\n```bash\nsudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl\ncurl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -\nsudo bash -c 'echo \"deb https://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list'\nsudo apt-get update\nsudo apt-get install -y kubelet=1.31.0-00 kubeadm=1.31.0-00 kubectl=1.31.0-00\nsudo apt-mark hold kubelet kubeadm kubectl\n```\nNote: Replace `1.31.0` with the specific version you wish to install."
+      },
+      {
+        "title": "Initialize the Control Plane",
+        "description": "Run the following command to initialize the Kubernetes control plane:\n```bash\nsudo kubeadm init --kubernetes-version=v1.31.0 --pod-network-cidr=10.244.0.0/16\n```\nAfter initialization, set up your kubeconfig:\n```bash\nmkdir -p $HOME/.kube\nsudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config\nsudo chown $(id -u):$(id -g) $HOME/.kube/config\n```"
+      },
+      {
+        "title": "Install a Pod Network",
+        "description": "Install a network add-on for your cluster. For Flannel, run:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel.yml\n```"
+      },
+      {
+        "title": "Join Worker Nodes",
+        "description": "On each worker node, run the join command provided at the end of the `kubeadm init` output. It looks like this:\n```bash\nkubeadm join <control-plane-ip>:6443 --token <token> --discovery-token-ca-cert-hash sha256:<hash>\n```"
+      },
+      {
+        "title": "Verify the Cluster",
+        "description": "Check the status of your cluster:\n```bash\nkubectl cluster-info\nkubectl get nodes\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "To enable the Horizontal Pod Autoscaler, run:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/cloud-provider/aws/examples/cluster-autoscaler-example.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Reset Kubeadm",
+        "description": "To remove Kubernetes and reset the node, run:\n```bash\nsudo kubeadm reset\nsudo rm -rf $HOME/.kube\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Kubernetes Cluster",
+        "description": "Before upgrading, backup your cluster configuration and data. To upgrade from v1.30 to v1.31, run:\n```bash\nsudo kubeadm upgrade plan\nsudo kubeadm upgrade apply v1.31.0\n```\nAfter upgrading, update your kubelet and kubectl:\n```bash\nsudo apt-get update\nsudo apt-get install -y kubelet=1.31.0-00 kubectl=1.31.0-00\nsudo systemctl daemon-reload\nsudo systemctl restart kubelet\n```\nVerify the upgrade:\n```bash\nkubectl get nodes\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Kubelet Not Starting",
+        "description": "If kubelet fails to start, check the logs:\n```bash\njournalctl -u kubelet\n```\nCommon issues include misconfigured CNI or insufficient resources."
+      },
+      {
+        "title": "Control Plane Node Not Ready",
+        "description": "If the control plane node shows as 'NotReady', check the status of the pods in the kube-system namespace:\n```bash\nkubectl get pods -n kube-system\n```\nLook for errors in the etcd or kube-apiserver pods."
+      },
+      {
+        "title": "Network Issues",
+        "description": "If pods cannot communicate, ensure the network add-on is correctly installed and running:\n```bash\nkubectl get pods -n kube-system\n```\nCheck for any errors in the network plugin."
+      },
+      {
+        "title": "Token Expired",
+        "description": "If you receive a token expired error when joining nodes, create a new token:\n```bash\nkubeadm token create --print-join-command\n```"
+      },
+      {
+        "title": "Kubeadm Upgrade Fails",
+        "description": "If the upgrade fails, check the logs for kubeadm:\n```bash\njournalctl -xeu kubelet\n```\nEnsure that your cluster is in a healthy state before attempting to upgrade."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.31",
+        "changes": "Improved performance and stability, new features for managing cluster resources.",
+        "deprecations": "Deprecated support for older CNI plugins."
+      },
+      {
+        "version": "v1.30",
+        "changes": "Enhanced security features and improved upgrade paths.",
+        "deprecations": "Deprecated certain flags in kubeadm init."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Kubeadm results in a fully functional Kubernetes cluster with a control plane and worker nodes ready to deploy applications. You should be able to verify the cluster status and have a network add-on installed.",
+      "codeSnippets": [
+        "sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl\ncurl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -\nsudo bash -c 'echo \"deb https://apt.kubernetes.io/ kubernetes-xenial main\" > /etc/apt/sources.list.d/kubernetes.list'\nsudo apt-get update\nsudo apt-get install -y kubelet=1.31.0-00 kubeadm=1.31.0-00 kubectl=1.31.0-00\nsudo apt-mark hold kubelet kubeadm kubectl",
+        "sudo kubeadm init --kubernetes-version=v1.31.0 --pod-network-cidr=10.244.0.0/16",
+        "mkdir -p $HOME/.kube\nsudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config\nsudo chown $(id -u):$(id -g) $HOME/.kube/config",
+        "kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel.yml",
+        "kubeadm join <control-plane-ip>:6443 --token <token> --discovery-token-ca-cert-hash sha256:<hash>",
+        "kubectl cluster-info\nkubectl get nodes"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "distribution",
+      "distribution",
+      "kubernetes"
+    ],
+    "platform": "kubeadm",
+    "platformType": "distribution",
+    "platformProvider": "Kubernetes",
+    "platformVersions": [
+      "v1.29",
+      "v1.30",
+      "v1.31"
+    ],
+    "supportedK8sVersions": [
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli"
+    ],
+    "containerImages": [
+      "k8s.gcr.io/kube-apiserver:v1.31.0",
+      "k8s.gcr.io/kube-controller-manager:v1.31.0",
+      "k8s.gcr.io/kube-scheduler:v1.31.0",
+      "k8s.gcr.io/kube-proxy:v1.31.0",
+      "k8s.gcr.io/pause:3.6"
+    ],
+    "sourceUrls": {
+      "docs": "https://kubernetes.io/docs/reference/setup-tools/kubeadm/",
+      "repo": "https://github.com/kubernetes/kubeadm"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.29",
+    "tools": [
+      "kubectl",
+      "kubeadm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Linux environment with sufficient resources to run a Kubernetes cluster."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:09:28.865Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-kyverno.json
+++ b/solutions/platform-install/platform-kyverno.json
@@ -1,0 +1,134 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-kyverno",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Kyverno (Policy Engine)",
+    "description": "Kyverno is a Kubernetes-native policy engine that allows teams to manage security, compliance, and governance through policy-as-code. It is particularly useful for organizations looking to enforce policies across their Kubernetes clusters without the need for additional languages.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Kyverno Operator",
+        "description": "To install Kyverno, use Helm to deploy the operator in your Kubernetes cluster. First, add the Kyverno Helm repository and update it:\n```bash\nhelm repo add kyverno https://kyverno.github.io/kyverno\nhelm repo update\n```\nThen, install Kyverno with the following command:\n```bash\nhelm install kyverno kyverno/kyverno --version v1.13.0 --namespace kyverno --create-namespace\n```\nVerify the installation by checking the pods:\n```bash\nkubectl get pods -n kyverno\n```\nYou should see the Kyverno pod running."
+      },
+      {
+        "title": "Configure Kyverno Policies",
+        "description": "After installation, you can create policies. For example, create a simple policy to enforce label presence on all pods:\n```yaml\napiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: require-label\nspec:\n  validationFailureAction: enforce\n  rules:\n    - name: check-label\n      match:\n        resources:\n          kinds:\n            - Pod\n      validate:\n        message: \"Label 'app' is required.\"\n        pattern:\n          metadata:\n            labels:\n              app: ?\n```\nApply the policy:\n```bash\nkubectl apply -f require-label.yaml\n```"
+      },
+      {
+        "title": "Verify Kyverno Installation",
+        "description": "Ensure that Kyverno is correctly installed and running:\n```bash\nkubectl get pods -n kyverno\nkubectl get clusterpolicies\nkubectl cluster-info\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Kyverno Operator",
+        "description": "To uninstall Kyverno, run the following command:\n```bash\nhelm uninstall kyverno --namespace kyverno\n```\nThen, delete the namespace if no longer needed:\n```bash\nkubectl delete namespace kyverno\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Kyverno Operator",
+        "description": "To upgrade Kyverno, first check the current version:\n```bash\nhelm list -n kyverno\n```\nBackup existing policies if necessary:\n```bash\nkubectl get clusterpolicies -o yaml > backup-policies.yaml\n```\nThen, upgrade to the desired version (e.g., v1.13.0):\n```bash\nhelm upgrade kyverno kyverno/kyverno --version v1.13.0 --namespace kyverno\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n kyverno\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Kyverno Pod Not Running",
+        "description": "If the Kyverno pod is not running, check the pod logs for errors:\n```bash\nkubectl logs -n kyverno <kyverno-pod-name>\n```\nCommon issues include insufficient permissions or resource limits."
+      },
+      {
+        "title": "Policy Not Enforcing",
+        "description": "If a policy is not being enforced, ensure it is applied correctly:\n```bash\nkubectl get clusterpolicies\n```\nCheck the policy for syntax errors or misconfigurations."
+      },
+      {
+        "title": "Helm Upgrade Fails",
+        "description": "If the Helm upgrade fails, check for version compatibility issues. Ensure that the current Kubernetes version is supported by the new Kyverno version."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.13",
+        "changes": "Introduced new policy validation features and improved performance.",
+        "deprecations": "Deprecated certain legacy APIs in favor of newer, more efficient ones."
+      },
+      {
+        "version": "v1.12",
+        "changes": "Added support for new Kubernetes versions and enhanced policy management capabilities.",
+        "deprecations": "Removed deprecated features from previous versions."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Kyverno includes a running operator, applied policies, and verification of policy enforcement through testing. You should see the Kyverno pod running and the policies listed in your cluster.",
+      "codeSnippets": [
+        "helm repo add kyverno https://kyverno.github.io/kyverno\nhelm repo update",
+        "helm install kyverno kyverno/kyverno --version v1.13.0 --namespace kyverno --create-namespace",
+        "kubectl get pods -n kyverno",
+        "apiVersion: kyverno.io/v1\nkind: ClusterPolicy\nmetadata:\n  name: require-label\nspec:\n  validationFailureAction: enforce\n  rules:\n    - name: check-label\n      match:\n        resources:\n          kinds:\n            - Pod\n      validate:\n        message: \"Label 'app' is required.\"\n        pattern:\n          metadata:\n            labels:\n              app: ?",
+        "kubectl apply -f require-label.yaml",
+        "kubectl get pods -n kyverno\nkubectl get clusterpolicies\nkubectl cluster-info"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "security-operator",
+      "kyverno"
+    ],
+    "platform": "kyverno",
+    "platformType": "operator",
+    "platformProvider": "Kyverno",
+    "platformVersions": [
+      "v1.11",
+      "v1.12",
+      "v1.13"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "ghcr.io/kyverno/kyverno:v1.13.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://kyverno.io/docs/",
+      "repo": "https://github.com/kyverno/kyverno"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have kubectl and helm installed and configured to interact with your Kubernetes cluster."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:08:49.405Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-metallb.json
+++ b/solutions/platform-install/platform-metallb.json
@@ -1,0 +1,135 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-metallb",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure MetalLB (Bare-metal Load Balancer)",
+    "description": "MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, utilizing standard routing protocols. It is ideal for on-premises Kubernetes setups where cloud load balancers are not available.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install MetalLB using Helm",
+        "description": "First, add the MetalLB Helm repository and install MetalLB. Ensure you are using Helm version 3.5.0 or later. Run the following commands:\n```bash\nhelm repo add metallb https://metallb.github.io/metallb\nhelm repo update\nhelm install metallb metallb/metallb --version v0.15.3\n```"
+      },
+      {
+        "title": "Configure MetalLB with Layer 2 mode",
+        "description": "Create a ConfigMap to configure MetalLB. Replace the IP range with your own available IPs:\n```bash\nkubectl apply -f - <<EOF\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: metallb-system\n  name: config\ndata:\n  config: |\n    layer2:\n      addresses:\n      - 192.168.1.200-192.168.1.250\nEOF\n```"
+      },
+      {
+        "title": "Verify MetalLB installation",
+        "description": "Check that MetalLB pods are running and ready:\n```bash\nkubectl get pods -n metallb-system\nkubectl get svc -n metallb-system\n```"
+      },
+      {
+        "title": "Post-install configuration for LoadBalancer service",
+        "description": "Create a sample LoadBalancer service to test MetalLB:\n```bash\nkubectl expose deployment your-deployment --type=LoadBalancer --name=your-service\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall MetalLB",
+        "description": "To uninstall MetalLB, run the following command:\n```bash\nhelm uninstall metallb\n``` Then, delete the ConfigMap if it was created:\n```bash\nkubectl delete configmap config -n metallb-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade MetalLB to v0.15",
+        "description": "Before upgrading, ensure you backup your current configuration:\n```bash\nkubectl get configmap config -n metallb-system -o yaml > metallb-config-backup.yaml\n```\nTo upgrade to v0.15.3, run:\n```bash\nhelm upgrade metallb metallb/metallb --version v0.15.3\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n metallb-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "MetalLB pods are not starting",
+        "description": "Check the logs of the MetalLB pods for errors:\n```bash\nkubectl logs -n metallb-system -l app=metallb\n```\nCommon issues include misconfiguration in the ConfigMap or insufficient permissions."
+      },
+      {
+        "title": "LoadBalancer service not getting an external IP",
+        "description": "Ensure that the IP range defined in the ConfigMap is within the subnet of your network. Check the service status:\n```bash\nkubectl get svc your-service\n```"
+      },
+      {
+        "title": "MetalLB not responding to ARP requests",
+        "description": "Verify that your network is configured to allow ARP broadcasts. Check the MetalLB logs for ARP-related messages:\n```bash\nkubectl logs -n metallb-system -l app=metallb | grep ARP\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v0.15",
+        "changes": "Introduced support for additional IP address management features and improved stability.",
+        "deprecations": "Deprecated the old configuration format in favor of a new structured format."
+      },
+      {
+        "version": "v0.14",
+        "changes": "Initial support for Layer 2 mode and basic service functionalities.",
+        "deprecations": "No deprecated features."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of MetalLB will have the MetalLB pods running in the 'metallb-system' namespace and LoadBalancer services successfully receiving external IPs from the configured range.",
+      "codeSnippets": [
+        "helm repo add metallb https://metallb.github.io/metallb\nhelm repo update\nhelm install metallb metallb/metallb --version v0.15.3",
+        "kubectl apply -f - <<EOF\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: metallb-system\n  name: config\ndata:\n  config: |\n    layer2:\n      addresses:\n      - 192.168.1.200-192.168.1.250\nEOF",
+        "kubectl get pods -n metallb-system\nkubectl get svc -n metallb-system",
+        "kubectl expose deployment your-deployment --type=LoadBalancer --name=your-service"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "networking-operator",
+      "metallb"
+    ],
+    "platform": "metallb",
+    "platformType": "operator",
+    "platformProvider": "MetalLB",
+    "platformVersions": [
+      "v0.14",
+      "v0.15"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "containerImages": [
+      "metallb/controller:v0.15.3",
+      "metallb/speaker:v0.15.3"
+    ],
+    "sourceUrls": {
+      "docs": "https://metallb.universe.tf/",
+      "repo": "https://github.com/metallb/metallb"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "none",
+    "description": "Ensure you have a running Kubernetes cluster and access to it via kubectl."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:08:05.028Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-microk8s.json
+++ b/solutions/platform-install/platform-microk8s.json
@@ -1,0 +1,151 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-microk8s",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure MicroK8s",
+    "description": "MicroK8s is a lightweight, fully conformant Kubernetes distribution designed for developers, IoT, and edge computing. It is ideal for quick setups and local development environments.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install MicroK8s",
+        "description": "Install MicroK8s using Snap. This command installs the latest stable version of MicroK8s. For specific versions, use the `--channel` flag.\n```bash\nsudo snap install microk8s --classic --channel=1.31/stable\n```"
+      },
+      {
+        "title": "Verify Installation",
+        "description": "Check that MicroK8s is installed and running correctly. Use the following commands to verify the status of the cluster and nodes:\n```bash\nsudo microk8s status --wait-ready\nsudo microk8s kubectl get nodes\n```"
+      },
+      {
+        "title": "Configure kubectl Access",
+        "description": "To use the standard kubectl command, configure your kubeconfig file:\n```bash\nsudo microk8s kubectl config view --raw > $HOME/.kube/config\n```"
+      },
+      {
+        "title": "Enable Add-ons",
+        "description": "Enable essential add-ons such as DNS and the Kubernetes dashboard:\n```bash\nsudo microk8s enable dns\nsudo microk8s enable dashboard\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "For user access without sudo, add your user to the microk8s group:\n```bash\nsudo usermod -a -G microk8s <username>\n```"
+      },
+      {
+        "title": "Verify Cluster Info",
+        "description": "Ensure the cluster is operational by checking cluster information:\n```bash\nsudo microk8s kubectl cluster-info\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove MicroK8s",
+        "description": "To uninstall MicroK8s, use the following command:\n```bash\nsudo snap remove microk8s\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade MicroK8s",
+        "description": "To upgrade MicroK8s to a specific version, use the following command:\n```bash\nsudo snap refresh microk8s --channel=1.31/stable\n```\nBefore upgrading, ensure to backup your configurations and data. You can check the current version with:\n```bash\nsudo microk8s version\n```\nIf issues arise after the upgrade, you can rollback to the previous version using:\n```bash\nsudo snap revert microk8s\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "MicroK8s not starting",
+        "description": "If MicroK8s fails to start, check the logs for errors:\n```bash\nsudo journalctl -u snap.microk8s.daemon-kubelet\n```\nEnsure that your system meets the requirements and that Snap is installed correctly."
+      },
+      {
+        "title": "kubectl command not found",
+        "description": "If you receive a 'command not found' error for kubectl, ensure you have configured your kubeconfig correctly:\n```bash\nsudo microk8s kubectl config view --raw > $HOME/.kube/config\n```"
+      },
+      {
+        "title": "Add-ons not working",
+        "description": "If enabled add-ons are not functioning, check their status:\n```bash\nsudo microk8s status\n```\nRe-enable the add-on if necessary:\n```bash\nsudo microk8s disable <addon>\nsudo microk8s enable <addon>\n```"
+      },
+      {
+        "title": "Insufficient permissions",
+        "description": "If you encounter permission issues, ensure your user is added to the microk8s group:\n```bash\nsudo usermod -a -G microk8s <username>\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "1.31",
+        "changes": "Improved performance and stability, added support for new Kubernetes features.",
+        "deprecations": "Deprecated support for Kubernetes versions below 1.29."
+      },
+      {
+        "version": "1.30",
+        "changes": "Introduced new add-ons and enhanced security features.",
+        "deprecations": "Removed legacy add-ons that were not maintained."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of MicroK8s will have all nodes in a 'Ready' state, with the necessary add-ons enabled and accessible via kubectl. You should be able to deploy applications and manage your cluster seamlessly.",
+      "codeSnippets": [
+        "sudo snap install microk8s --classic --channel=1.31/stable",
+        "sudo microk8s status --wait-ready\nsudo microk8s kubectl get nodes",
+        "sudo microk8s kubectl config view --raw > $HOME/.kube/config",
+        "sudo microk8s enable dns\nsudo microk8s enable dashboard",
+        "sudo usermod -a -G microk8s <username>",
+        "sudo microk8s kubectl cluster-info"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "distribution",
+      "distribution",
+      "canonical"
+    ],
+    "platform": "microk8s",
+    "platformType": "distribution",
+    "platformProvider": "Canonical",
+    "platformVersions": [
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "supportedK8sVersions": [
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "snap"
+    ],
+    "containerImages": [
+      "registry/canonical/microk8s:1.31"
+    ],
+    "sourceUrls": {
+      "docs": "https://microk8s.io/docs",
+      "repo": "https://github.com/canonical/microk8s"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.29",
+    "tools": [
+      "snap"
+    ],
+    "cloudCLI": "none",
+    "description": "Ensure Snap is installed on your Linux system."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:09:01.577Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-minikube.json
+++ b/solutions/platform-install/platform-minikube.json
@@ -1,0 +1,143 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-minikube",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Minikube",
+    "description": "Minikube is a tool that allows you to run Kubernetes locally on your machine. It's ideal for developers who want to test and develop applications in a Kubernetes environment without needing a full cloud setup.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Minikube",
+        "description": "Download and install Minikube v1.34. Use the following command to install it on Linux:\n```bash\ncurl -LO https://storage.googleapis.com/minikube/releases/v1.34.0/minikube-linux-amd64\nsudo install minikube-linux-amd64 /usr/local/bin/minikube\n```\nVerify the installation:\n```bash\nminikube version\n```"
+      },
+      {
+        "title": "Start Minikube Cluster",
+        "description": "Start a Minikube cluster with Kubernetes version 1.30:\n```bash\nminikube start --kubernetes-version=v1.30.0\n```\nThis command initializes a local Kubernetes cluster with the specified version."
+      },
+      {
+        "title": "Configure kubectl",
+        "description": "Set up kubectl to connect to your Minikube cluster:\n```bash\nkubectl config use-context minikube\n```\nVerify the cluster is running:\n```bash\nkubectl cluster-info\nkubectl get nodes\n```"
+      },
+      {
+        "title": "Enable Dashboard",
+        "description": "Enable the Kubernetes dashboard for easier management:\n```bash\nminikube dashboard\n```\nThis command opens the dashboard in your default web browser."
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Enable the metrics-server addon for monitoring:\n```bash\nminikube addons enable metrics-server\n```\nVerify that the metrics-server is running:\n```bash\nkubectl get pods -n kube-system\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Stop and Delete Minikube Cluster",
+        "description": "To stop and delete the Minikube cluster, run:\n```bash\nminikube stop\nminikube delete\n```\nThis will remove the local Kubernetes cluster and free up resources."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Minikube",
+        "description": "To upgrade Minikube to the latest version (v1.34), first back up your configurations and data:\n```bash\nminikube config view > minikube-config-backup.yaml\n```\nThen, upgrade Minikube:\n```bash\nminikube update-check\nminikube stop\nminikube delete\ncurl -LO https://storage.googleapis.com/minikube/releases/v1.34.0/minikube-linux-amd64\nsudo install minikube-linux-amd64 /usr/local/bin/minikube\nminikube start --kubernetes-version=v1.30.0\n```\nVerify the upgrade:\n```bash\nminikube version\nkubectl version\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Minikube fails to start",
+        "description": "If Minikube fails to start, check the logs:\n```bash\nminikube logs\n```\nCommon issues include insufficient memory or CPU allocation. Ensure your system meets the requirements and adjust the resources with:\n```bash\nminikube start --memory=4096 --cpus=2\n```"
+      },
+      {
+        "title": "kubectl not connecting to Minikube",
+        "description": "If kubectl cannot connect, ensure you are using the correct context:\n```bash\nkubectl config current-context\n```\nIf it’s not set to 'minikube', switch contexts:\n```bash\nkubectl config use-context minikube\n```"
+      },
+      {
+        "title": "Dashboard not accessible",
+        "description": "If the dashboard does not open, check if it is enabled:\n```bash\nminikube addons list\n```\nIf it is not enabled, run:\n```bash\nminikube addons enable dashboard\n```"
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.34",
+        "changes": "Improved performance and stability, added support for new Kubernetes features.",
+        "deprecations": "Deprecated certain flags related to VM drivers."
+      },
+      {
+        "version": "v1.33",
+        "changes": "Introduced new addons and improved compatibility with Kubernetes 1.30.",
+        "deprecations": "Removed support for older Kubernetes versions."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running Minikube cluster with kubectl configured to connect to it, the Kubernetes dashboard accessible, and the metrics-server enabled for monitoring.",
+      "codeSnippets": [
+        "curl -LO https://storage.googleapis.com/minikube/releases/v1.34.0/minikube-linux-amd64\nsudo install minikube-linux-amd64 /usr/local/bin/minikube",
+        "minikube version",
+        "minikube start --kubernetes-version=v1.30.0",
+        "kubectl config use-context minikube",
+        "kubectl cluster-info\nkubectl get nodes",
+        "minikube dashboard"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "local",
+      "local-dev",
+      "kubernetes"
+    ],
+    "platform": "minikube",
+    "platformType": "local",
+    "platformProvider": "Kubernetes",
+    "platformVersions": [
+      "v1.33",
+      "v1.34"
+    ],
+    "supportedK8sVersions": [
+      "1.28",
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli"
+    ],
+    "containerImages": [
+      "k8s.gcr.io/pause:3.5"
+    ],
+    "sourceUrls": {
+      "docs": "https://minikube.sigs.k8s.io/docs/",
+      "repo": "https://github.com/kubernetes/minikube"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "minikube"
+    ],
+    "cloudCLI": "none",
+    "description": "Ensure you have kubectl and minikube installed on your local machine."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:10:09.888Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-mongodb-community-operator.json
+++ b/solutions/platform-install/platform-mongodb-community-operator.json
@@ -1,0 +1,133 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-mongodb-community-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure MongoDB Community Operator",
+    "description": "The MongoDB Community Operator simplifies the deployment and management of MongoDB databases on Kubernetes. It is ideal for users looking to run MongoDB in a Kubernetes environment without the need for enterprise features.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install MongoDB Community Operator",
+        "description": "To install the MongoDB Community Operator, use Helm to add the repository and install the operator. Ensure you have Helm v3.x installed.\n\n```bash\n# Add the MongoDB Helm repository\nhelm repo add mongodb https://mongodb.github.io/mongodb-kubernetes-operator\nhelm repo update\n\n# Install the MongoDB Community Operator\nhelm install mongodb-community-operator mongodb/mongodb-kubernetes-operator --version 0.11.0\n```\n\nVerify the installation:\n```bash\nkubectl get pods -n default\n```\nYou should see the operator pod running."
+      },
+      {
+        "title": "Create MongoDB Custom Resource",
+        "description": "Create a MongoDB resource to deploy a MongoDB instance. Save the following YAML as `mongodb.yaml`:\n\n```yaml\napiVersion: mongodb.com/v1\nkind: MongoDB\nmetadata:\n  name: my-mongo\nspec:\n  members: 3\n  type: ReplicaSet\n  version: 4.4.0\n  podSpec:\n    resources:\n      requests:\n        cpu: 100m\n        memory: 512Mi\n      limits:\n        cpu: 1000m\n        memory: 2Gi\n```\n\nDeploy it using:\n```bash\nkubectl apply -f mongodb.yaml\n```\n\nVerify the MongoDB instance:\n```bash\nkubectl get mongodb\n```\n"
+      },
+      {
+        "title": "Post-install Configuration",
+        "description": "After deploying MongoDB, configure RBAC to manage access. Create a role and bind it to a user:\n\n```bash\n# Create a role\nkubectl create role mongo-admin --verb=* --resource=pods --namespace=default\n\n# Bind the role to a user\nkubectl create rolebinding mongo-admin-binding --role=mongo-admin --user=<username> --namespace=default\n```\n"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall MongoDB Community Operator",
+        "description": "To uninstall the MongoDB Community Operator and clean up resources:\n```bash\n# Uninstall the operator\nhelm uninstall mongodb-community-operator\n\n# Delete MongoDB resources\nkubectl delete mongodb my-mongo\n```\nEnsure all resources are cleaned up:\n```bash\nkubectl get all\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade MongoDB Community Operator",
+        "description": "To upgrade the MongoDB Community Operator from v0.10 to v0.11:\n1. Backup your MongoDB data using the built-in backup features or by exporting data.\n2. Upgrade the Helm release:\n```bash\nhelm upgrade mongodb-community-operator mongodb/mongodb-kubernetes-operator --version 0.11.0\n```\n3. Verify the upgrade:\n```bash\nkubectl get pods -n default\n```\n4. If issues arise, rollback to the previous version:\n```bash\nhelm rollback mongodb-community-operator 0\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator Pod CrashLoopBackOff",
+        "description": "If the MongoDB Operator pod is in a CrashLoopBackOff state, check the logs:\n```bash\nkubectl logs <operator-pod-name>\n```\nCommon issues include misconfigured permissions or missing CRDs. Ensure all CRDs are installed:\n```bash\nkubectl get crd | grep mongodb\n```"
+      },
+      {
+        "title": "MongoDB Instance Not Starting",
+        "description": "If the MongoDB instance is not starting, check the status:\n```bash\nkubectl get mongodb my-mongo -o yaml\n```\nLook for events indicating resource issues or misconfigurations. Adjust resources in the `mongodb.yaml` file if necessary."
+      },
+      {
+        "title": "Insufficient Resources Error",
+        "description": "If you encounter an 'Insufficient CPU' or 'Insufficient Memory' error, check the resource requests and limits in your MongoDB spec. You may need to adjust them based on your cluster's available resources."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "0.11",
+        "changes": "Improved stability and performance enhancements.",
+        "deprecations": "No deprecated features in this version."
+      },
+      {
+        "version": "0.10",
+        "changes": "Initial release with basic MongoDB deployment capabilities.",
+        "deprecations": "N/A"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running MongoDB Community Operator and a deployed MongoDB instance, with proper RBAC configured for user access. You can verify the deployment by checking the status of the pods and MongoDB resources.",
+      "codeSnippets": [
+        "# Add the MongoDB Helm repository\nhelm repo add mongodb https://mongodb.github.io/mongodb-kubernetes-operator\nhelm repo update\n\n# Install the MongoDB Community Operator\nhelm install mongodb-community-operator mongodb/mongodb-kubernetes-operator --version 0.11.0",
+        "kubectl get pods -n default",
+        "apiVersion: mongodb.com/v1\nkind: MongoDB\nmetadata:\n  name: my-mongo\nspec:\n  members: 3\n  type: ReplicaSet\n  version: 4.4.0\n  podSpec:\n    resources:\n      requests:\n        cpu: 100m\n        memory: 512Mi\n      limits:\n        cpu: 1000m\n        memory: 2Gi",
+        "kubectl apply -f mongodb.yaml",
+        "kubectl get mongodb",
+        "# Create a role\nkubectl create role mongo-admin --verb=* --resource=pods --namespace=default\n\n# Bind the role to a user\nkubectl create rolebinding mongo-admin-binding --role=mongo-admin --user=<username> --namespace=default"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "mongodb"
+    ],
+    "platform": "mongodb-community-operator",
+    "platformType": "operator",
+    "platformProvider": "MongoDB",
+    "platformVersions": [
+      "0.10",
+      "0.11"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "mongodb/mongodb-kubernetes-operator:v0.11.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://www.mongodb.com/docs/kubernetes-operator/",
+      "repo": "https://github.com/mongodb/mongodb-kubernetes-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running and kubectl configured."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:06:52.786Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-mysql-operator.json
+++ b/solutions/platform-install/platform-mysql-operator.json
@@ -1,0 +1,146 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-mysql-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure MySQL Operator for Kubernetes (Oracle)",
+    "description": "The MySQL Operator for Kubernetes simplifies the management of MySQL InnoDB Cluster setups within Kubernetes, automating tasks such as deployment, upgrades, and backups. It is ideal for users looking to leverage MySQL in a cloud-native environment.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Deploy Custom Resource Definitions (CRDs)",
+        "description": "First, apply the Custom Resource Definitions necessary for the MySQL Operator. Use the following command:\n```sh\nkubectl apply -f https://raw.githubusercontent.com/mysql/mysql-operator/9.0/deploy/deploy-crds.yaml\n```"
+      },
+      {
+        "title": "Deploy MySQL Operator",
+        "description": "Next, deploy the MySQL Operator using the manifest file:\n```sh\nkubectl apply -f https://raw.githubusercontent.com/mysql/mysql-operator/9.0/deploy/deploy-operator.yaml\n```\nVerify that the operator is running:\n```sh\nkubectl get deployment -n mysql-operator mysql-operator\n```"
+      },
+      {
+        "title": "Create MySQL Root User Secret",
+        "description": "Create a secret for the MySQL root user credentials:\n```sh\nkubectl create secret generic mypwds \\\n        --from-literal=rootUser=root \\\n        --from-literal=rootHost=% \\\n        --from-literal=rootPassword=\"sakila\"\n```"
+      },
+      {
+        "title": "Define MySQL InnoDB Cluster",
+        "description": "Create a YAML file (e.g., `mycluster.yaml`) to define your MySQL InnoDB Cluster:\n```yaml\napiVersion: mysql.oracle.com/v2\nkind: InnoDBCluster\nmetadata:\n  name: mycluster\nspec:\n  secretName: mypwds\n  version: \"8.4\"\n```\nThen apply it:\n```sh\nkubectl apply -f mycluster.yaml\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Set up monitoring for your MySQL cluster using Prometheus. Create a ServiceMonitor:\n```yaml\napiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: mysql-monitor\n  labels:\n    app: mysql\nspec:\n  selector:\n    matchLabels:\n      app: mysql\n  endpoints:\n  - port: mysql\n    interval: 30s\n```"
+      },
+      {
+        "title": "Verify Installation",
+        "description": "Check the cluster information and node status:\n```sh\nkubectl cluster-info\nkubectl get nodes\nkubectl get innodbclusters\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove MySQL Operator",
+        "description": "To uninstall the MySQL Operator, first delete the InnoDB Cluster and then the operator and CRDs:\n```sh\nkubectl delete -f mycluster.yaml\nkubectl delete -f https://raw.githubusercontent.com/mysql/mysql-operator/9.0/deploy/deploy-operator.yaml\nkubectl delete -f https://raw.githubusercontent.com/mysql/mysql-operator/9.0/deploy/deploy-crds.yaml\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade MySQL Operator",
+        "description": "To upgrade from version 8.4 to 9.0, first back up your data and configurations. Check the operator's current version:\n```sh\nkubectl get deployment -n mysql-operator mysql-operator -o=jsonpath='{.spec.template.spec.containers[:1].image}'\n```\nThen apply the new operator version:\n```sh\nkubectl apply -f https://raw.githubusercontent.com/mysql/mysql-operator/9.0/deploy/deploy-operator.yaml\n```\nVerify the new version is running:\n```sh\nkubectl get deployment -n mysql-operator mysql-operator\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator Not Running",
+        "description": "If the MySQL Operator is not running, check the logs:\n```sh\nkubectl logs -n mysql-operator deployment/mysql-operator\n```\nEnsure that your Kubernetes version is compatible and that all required CRDs are applied."
+      },
+      {
+        "title": "InnoDB Cluster Not Starting",
+        "description": "If the InnoDB Cluster fails to start, check the secret for correct credentials:\n```sh\nkubectl get secret mypwds -o yaml\n```\nEnsure the root password is correct and that the secret is correctly referenced in your cluster definition."
+      },
+      {
+        "title": "Resource Quotas Exceeded",
+        "description": "If you encounter resource quota issues, check the current resource usage:\n```sh\nkubectl describe quota -n mysql-operator\n```\nAdjust your resource requests/limits in the InnoDB Cluster spec accordingly."
+      },
+      {
+        "title": "Version Mismatch",
+        "description": "If you see errors related to version mismatches, ensure that the MySQL version specified in your InnoDB Cluster matches the operator's capabilities. Update the version in your cluster definition if necessary."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "9.0",
+        "changes": "Introduced support for new MySQL features and improved backup mechanisms.",
+        "deprecations": "Deprecated support for MySQL versions below 8.0."
+      },
+      {
+        "version": "8.4",
+        "changes": "Initial release with basic functionalities for managing MySQL clusters.",
+        "deprecations": "No deprecations in this version."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running MySQL Operator, a configured InnoDB Cluster, and verification of the cluster's health and accessibility. You should be able to manage MySQL instances through Kubernetes seamlessly.",
+      "codeSnippets": [
+        "Verify that the operator is running:",
+        "apiVersion: mysql.oracle.com/v2\nkind: InnoDBCluster\nmetadata:\n  name: mycluster\nspec:\n  secretName: mypwds\n  version: \"8.4\"",
+        "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: mysql-monitor\n  labels:\n    app: mysql\nspec:\n  selector:\n    matchLabels:\n      app: mysql\n  endpoints:\n  - port: mysql\n    interval: 30s"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "oracle/mysql"
+    ],
+    "platform": "mysql-operator",
+    "platformType": "operator",
+    "platformProvider": "Oracle/MySQL",
+    "platformVersions": [
+      "8.4",
+      "9.0"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "kubectl",
+      "helm"
+    ],
+    "containerImages": [
+      "mysql/mysql-operator:9.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://dev.mysql.com/doc/mysql-operator/en/",
+      "repo": "https://github.com/mysql/mysql-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running and kubectl configured to interact with it."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:06:07.894Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-oke.json
+++ b/solutions/platform-install/platform-oke.json
@@ -1,0 +1,141 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-oke",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Oracle Container Engine for Kubernetes (OKE)",
+    "description": "Oracle Container Engine for Kubernetes (OKE) is a managed Kubernetes service that simplifies the deployment and management of Kubernetes clusters on Oracle Cloud Infrastructure. It is ideal for organizations looking to leverage Kubernetes without the overhead of managing the underlying infrastructure.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Create a Kubernetes Cluster",
+        "description": "Use the Oracle Cloud CLI to create a Kubernetes cluster. Replace placeholders with your actual values.\n\n```bash\noci ce cluster create --compartment-id <your_compartment_id> --name <your_cluster_name> --vcn-id <your_vcn_id> --kubernetes-version 1.30.1 --node-pool-configuration '[{\"name\":\"nodepool1\",\"nodeShape\":\"VM.Standard2.1\",\"nodeShapeConfig\":{\"ocpus\":1,\"memoryInGBs\":1},\"initialNodeCount\":3}]'\n```\n\nEnsure that you have the necessary IAM policies in place for your compartment."
+      },
+      {
+        "title": "Configure kubectl",
+        "description": "After creating the cluster, configure kubectl to connect to it:\n\n```bash\noci ce cluster create-kubeconfig --cluster-id <your_cluster_id> --file $HOME/.kube/config --region <your_region> --token-version 2.0.0\n```\n\nVerify the connection:\n```bash\nkubectl cluster-info\n```"
+      },
+      {
+        "title": "Install OCI Cloud Controller Manager",
+        "description": "Deploy the OCI Cloud Controller Manager using Helm. First, add the Oracle Helm repository:\n\n```bash\nhelm repo add oracle https://oracle.github.io/oci-cloud-controller-manager\nhelm repo update\n```\n\nThen install the controller manager:\n```bash\nhelm install oci-cloud-controller-manager oracle/oci-cloud-controller-manager --namespace kube-system --set provider-config=provider-config-example.yaml\n```\n\nEnsure the controller is running:\n```bash\nkubectl get pods -n kube-system\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Configure autoscaling for your node pool:\n\n```bash\noci ce node-pool update --node-pool-id <your_node_pool_id> --management-config '{\"autoScale\":true,\"minNodes\":1,\"maxNodes\":5}'\n```\n\nYou can also set up monitoring using Oracle Cloud Monitoring services."
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Delete the Kubernetes Cluster",
+        "description": "To uninstall the OKE cluster, use the following command:\n\n```bash\noci ce cluster delete --cluster-id <your_cluster_id> --force\n```\n\nThis will remove the cluster and associated resources. Ensure to clean up any remaining resources in your compartment."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Kubernetes Version",
+        "description": "To upgrade your OKE cluster to a newer version, first check the current version:\n\n```bash\noci ce cluster get --cluster-id <your_cluster_id>\n```\n\nThen, initiate the upgrade:\n```bash\noci ce cluster update --cluster-id <your_cluster_id> --kubernetes-version 1.30.1\n```\n\nBefore upgrading, ensure you have backed up any critical data. After the upgrade, verify the cluster status:\n```bash\nkubectl get nodes\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "kubectl not connecting to the cluster",
+        "description": "If kubectl cannot connect, ensure your kubeconfig is correctly set up. Check the context:\n```bash\nkubectl config current-context\n```\nIf necessary, regenerate the kubeconfig using:\n```bash\noci ce cluster create-kubeconfig --cluster-id <your_cluster_id> --file $HOME/.kube/config --region <your_region> --token-version 2.0.0\n```"
+      },
+      {
+        "title": "OCI Cloud Controller Manager not running",
+        "description": "If the OCI Cloud Controller Manager pod is not running, check the logs:\n```bash\nkubectl logs -n kube-system <pod_name>\n```\nEnsure that the provider configuration file is correctly set up and that the necessary IAM policies are in place."
+      },
+      {
+        "title": "Node pool scaling issues",
+        "description": "If nodes are not scaling as expected, check the node pool configuration:\n```bash\noci ce node-pool get --node-pool-id <your_node_pool_id>\n```\nEnsure that the min and max nodes are set correctly and that there are no resource constraints in your compartment."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.30.1",
+        "changes": "Introduced support for new node shapes and improved performance metrics.",
+        "deprecations": "Deprecated the use of older Kubernetes versions below 1.28."
+      },
+      {
+        "version": "v1.29.2",
+        "changes": "Enhanced security features and added support for additional OCI regions.",
+        "deprecations": "Removed support for legacy authentication methods."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of OKE includes a running Kubernetes cluster, configured kubectl access, and the OCI Cloud Controller Manager deployed and operational. You should be able to manage your workloads seamlessly on Oracle Cloud Infrastructure.",
+      "codeSnippets": [
+        "oci ce cluster create --compartment-id <your_compartment_id> --name <your_cluster_name> --vcn-id <your_vcn_id> --kubernetes-version 1.30.1 --node-pool-configuration '[{\"name\":\"nodepool1\",\"nodeShape\":\"VM.Standard2.1\",\"nodeShapeConfig\":{\"ocpus\":1,\"memoryInGBs\":1},\"initialNodeCount\":3}]'",
+        "oci ce cluster create-kubeconfig --cluster-id <your_cluster_id> --file $HOME/.kube/config --region <your_region> --token-version 2.0.0",
+        "kubectl cluster-info",
+        "helm repo add oracle https://oracle.github.io/oci-cloud-controller-manager\nhelm repo update",
+        "helm install oci-cloud-controller-manager oracle/oci-cloud-controller-manager --namespace kube-system --set provider-config=provider-config-example.yaml",
+        "kubectl get pods -n kube-system"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "managed",
+      "managed-k8s",
+      "oracle-cloud"
+    ],
+    "platform": "oke",
+    "platformType": "managed",
+    "platformProvider": "Oracle Cloud",
+    "platformVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "supportedK8sVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "helm"
+    ],
+    "containerImages": [
+      "oracle/oci-cloud-controller-manager:v1.33.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.oracle.com/en-us/iaas/Content/ContEng/home.htm",
+      "repo": "https://github.com/oracle/oci-cloud-controller-manager"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.28",
+    "tools": [
+      "oci-cli",
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "oci",
+    "description": "Ensure you have the OCI CLI installed and configured with the necessary permissions."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:05:17.897Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-postgres-operator.json
+++ b/solutions/platform-install/platform-postgres-operator.json
@@ -1,0 +1,134 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-postgres-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure CloudNativePG (PostgreSQL Operator)",
+    "description": "CloudNativePG is an open-source PostgreSQL operator designed to manage PostgreSQL databases within Kubernetes environments, covering the entire operational lifecycle from deployment to maintenance. It is ideal for organizations looking to integrate PostgreSQL management into their Kubernetes workflows.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install CloudNativePG Operator",
+        "description": "To install the CloudNativePG operator, use Helm to add the repository and install the operator. Ensure you have Helm v3.5.0 or later installed.\n\n```bash\nhelm repo add cloudnative-pg https://cloudnative-pg.io/charts\nhelm repo update\nhelm install cloudnative-pg cloudnative-pg/cloudnative-pg --version 1.25.0\n```\n\nVerify the installation:\n```bash\nkubectl get pods -n default\n```"
+      },
+      {
+        "title": "Create a PostgreSQL Cluster",
+        "description": "Create a PostgreSQL cluster by applying a YAML configuration file. Save the following configuration as `postgresql-cluster.yaml`:\n\n```yaml\napiVersion: postgresql.cnpg.io/v1\nkind: Cluster\nmetadata:\n  name: my-postgres\nspec:\n  instances: 3\n  storage:\n    size: 1Gi\n  image: 'docker.io/cloudnativepg/cloudnative-pg:1.25.0'\n```\n\nApply the configuration:\n```bash\nkubectl apply -f postgresql-cluster.yaml\n```\n\nCheck the status of the cluster:\n```bash\nkubectl get clusters\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Configure autoscaling for the PostgreSQL cluster. Edit the `Cluster` resource to include autoscaling:\n\n```yaml\nspec:\n  autoscaling:\n    enabled: true\n    minReplicas: 3\n    maxReplicas: 5\n```\n\nApply the changes:\n```bash\nkubectl apply -f postgresql-cluster.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall CloudNativePG Operator",
+        "description": "To uninstall the CloudNativePG operator, first delete the PostgreSQL cluster:\n```bash\nkubectl delete cluster my-postgres\n```\nThen uninstall the Helm release:\n```bash\nhelm uninstall cloudnative-pg\n```\nFinally, clean up any remaining resources:\n```bash\nkubectl delete namespace cloudnative-pg\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade CloudNativePG Operator",
+        "description": "To upgrade the CloudNativePG operator, first backup your PostgreSQL data. Use the following command to create a backup:\n```bash\nkubectl exec -it <pod-name> -- pg_dumpall -U <username> > backup.sql\n```\nCheck the current version:\n```bash\nhelm list\n```\nUpgrade the operator using Helm:\n```bash\nhelm upgrade cloudnative-pg cloudnative-pg/cloudnative-pg --version 1.25.0\n```\nVerify the upgrade:\n```bash\nkubectl get pods\n```\nIf issues arise, rollback using:\n```bash\nhelm rollback cloudnative-pg\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pod CrashLoopBackOff",
+        "description": "If you encounter a CrashLoopBackOff error, check the logs of the pod:\n```bash\nkubectl logs <pod-name>\n```\nCommon causes include insufficient resources or misconfiguration in the `Cluster` spec. Ensure your resource requests and limits are set appropriately."
+      },
+      {
+        "title": "Cluster Not Starting",
+        "description": "If the PostgreSQL cluster is not starting, check the status of the cluster:\n```bash\nkubectl describe cluster my-postgres\n```\nLook for events indicating issues with pod scheduling or resource allocation."
+      },
+      {
+        "title": "Database Connection Issues",
+        "description": "If you cannot connect to the PostgreSQL database, verify the service is running:\n```bash\nkubectl get svc\n```\nEnsure you are using the correct credentials and connection string."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "1.25.0",
+        "changes": "Improved performance for large clusters and added support for automatic backups.",
+        "deprecations": "The previous backup method using `pg_basebackup` is deprecated in favor of the new automated backup feature."
+      },
+      {
+        "version": "1.24.0",
+        "changes": "Introduced enhanced monitoring capabilities and better integration with Kubernetes events.",
+        "deprecations": "Support for Kubernetes versions below 1.26 has been deprecated."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running CloudNativePG operator and a PostgreSQL cluster that is accessible and properly configured. You should be able to scale the cluster and perform backups without issues.",
+      "codeSnippets": [
+        "helm repo add cloudnative-pg https://cloudnative-pg.io/charts\nhelm repo update\nhelm install cloudnative-pg cloudnative-pg/cloudnative-pg --version 1.25.0",
+        "kubectl get pods -n default",
+        "apiVersion: postgresql.cnpg.io/v1\nkind: Cluster\nmetadata:\n  name: my-postgres\nspec:\n  instances: 3\n  storage:\n    size: 1Gi\n  image: 'docker.io/cloudnativepg/cloudnative-pg:1.25.0'",
+        "kubectl apply -f postgresql-cluster.yaml",
+        "kubectl get clusters",
+        "spec:\n  autoscaling:\n    enabled: true\n    minReplicas: 3\n    maxReplicas: 5"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "cloudnativepg"
+    ],
+    "platform": "postgres-operator",
+    "platformType": "operator",
+    "platformProvider": "CloudNativePG",
+    "platformVersions": [
+      "1.23",
+      "1.24",
+      "1.25"
+    ],
+    "supportedK8sVersions": [
+      "1.26+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "docker.io/cloudnativepg/cloudnative-pg:1.25.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://cloudnative-pg.io/documentation/",
+      "repo": "https://github.com/cloudnative-pg/cloudnative-pg"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.26",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running version 1.26 or later and have kubectl and Helm installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:06:31.412Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-rabbitmq-cluster-operator.json
+++ b/solutions/platform-install/platform-rabbitmq-cluster-operator.json
@@ -1,0 +1,132 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-rabbitmq-cluster-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure RabbitMQ Cluster Operator",
+    "description": "The RabbitMQ Cluster Operator is a Kubernetes operator designed to deploy and manage RabbitMQ clusters efficiently. It automates the lifecycle management of RabbitMQ, making it ideal for applications requiring reliable messaging services.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install RabbitMQ Cluster Operator",
+        "description": "To install the RabbitMQ Cluster Operator, run the following command to apply the operator manifest. This example uses version v2.10.0:\n```bash\nkubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/v2.10.0/cluster-operator.yml\n```\nVerify the operator is running:\n```bash\nkubectl get pods -n rabbitmq-system\n```\nYou should see the operator pod in a Running state."
+      },
+      {
+        "title": "Deploy a RabbitMQ Cluster",
+        "description": "Next, deploy a RabbitMQ cluster using the provided example manifest. Run:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/rabbitmq/cluster-operator/main/docs/examples/hello-world/rabbitmq.yaml\n```\nVerify the RabbitMQ cluster is running:\n```bash\nkubectl get rabbitmqclusters\n```\nYou should see your RabbitMQ cluster listed with a status of 'Running'."
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "To enable monitoring for your RabbitMQ cluster, you can configure Prometheus scraping. Update your RabbitMQ cluster manifest to include:\n```yaml\nspec:\n  metrics:\n    enabled: true\n```\nThen apply the changes:\n```bash\nkubectl apply -f <your-rabbitmq-cluster-manifest>.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove RabbitMQ Cluster Operator",
+        "description": "To uninstall the RabbitMQ Cluster Operator, first delete the RabbitMQ cluster:\n```bash\nkubectl delete rabbitmqcluster <your-cluster-name>\n```\nThen remove the operator:\n```bash\nkubectl delete -f https://github.com/rabbitmq/cluster-operator/releases/download/v2.10.0/cluster-operator.yml\n```\nFinally, clean up the namespace if it was created specifically for the operator:\n```bash\nkubectl delete namespace rabbitmq-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade RabbitMQ Cluster Operator",
+        "description": "To upgrade the RabbitMQ Cluster Operator from v2.9 to v2.10, first back up your RabbitMQ data and configurations. Then, apply the new operator version:\n```bash\nkubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/v2.10.0/cluster-operator.yml\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n rabbitmq-system\n```\nEnsure the operator is running with the new version. If issues arise, you can roll back by reapplying the previous version's manifest."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator Pod Not Starting",
+        "description": "If the operator pod is not starting, check the logs:\n```bash\nkubectl logs <operator-pod-name> -n rabbitmq-system\n```\nCommon issues include insufficient permissions or resource limits. Ensure the service account has the necessary roles."
+      },
+      {
+        "title": "RabbitMQ Cluster Not Ready",
+        "description": "If the RabbitMQ cluster status is not 'Running', check the events:\n```bash\nkubectl describe rabbitmqcluster <your-cluster-name>\n```\nLook for any errors related to configuration or resource allocation."
+      },
+      {
+        "title": "Metrics Not Available",
+        "description": "If metrics are not being scraped, ensure that the metrics section is correctly configured in your RabbitMQ cluster manifest. Check Prometheus logs for any scraping errors."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v2.10.0",
+        "changes": "Improved resource management and added support for RabbitMQ 4.1.3.",
+        "deprecations": "Deprecated the old metrics endpoint; use the new metrics configuration."
+      },
+      {
+        "version": "v2.9.0",
+        "changes": "Added support for custom RabbitMQ configurations and enhanced error handling.",
+        "deprecations": "Deprecated the use of legacy RabbitMQ versions."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running RabbitMQ Cluster Operator and a RabbitMQ cluster with all pods in the Running state. Monitoring should be enabled and functioning correctly.",
+      "codeSnippets": [
+        "kubectl apply -f https://github.com/rabbitmq/cluster-operator/releases/download/v2.10.0/cluster-operator.yml",
+        "kubectl get pods -n rabbitmq-system",
+        "kubectl apply -f https://raw.githubusercontent.com/rabbitmq/cluster-operator/main/docs/examples/hello-world/rabbitmq.yaml",
+        "kubectl get rabbitmqclusters",
+        "spec:\n  metrics:\n    enabled: true",
+        "kubectl apply -f <your-rabbitmq-cluster-manifest>.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "rabbitmq-/-broadcom"
+    ],
+    "platform": "rabbitmq-cluster-operator",
+    "platformType": "operator",
+    "platformProvider": "RabbitMQ / Broadcom",
+    "platformVersions": [
+      "v2.8",
+      "v2.9",
+      "v2.10"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "kubectl"
+    ],
+    "containerImages": [
+      "rabbitmq/cluster-operator:v2.10.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://www.rabbitmq.com/kubernetes/operator/operator-overview",
+      "repo": "https://github.com/rabbitmq/cluster-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a running Kubernetes cluster and kubectl configured to access it."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:10:23.856Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-rancher.json
+++ b/solutions/platform-install/platform-rancher.json
@@ -1,0 +1,135 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-rancher",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Rancher / RKE2",
+    "description": "Rancher is a complete container management platform that simplifies deploying and managing Kubernetes clusters across various environments. It's particularly useful for organizations looking to streamline their container orchestration and management processes.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Rancher Server",
+        "description": "Run the Rancher server using Docker. Ensure Docker is installed on your Linux node. Execute the following command:\n```bash\nsudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged rancher/rancher:v2.10.0\n```\nAfter the command completes, access Rancher by visiting `https://localhost` in your web browser."
+      },
+      {
+        "title": "Connect kubectl to Rancher",
+        "description": "Once Rancher is running, you can configure `kubectl` to connect to your Rancher-managed clusters. First, get the kubeconfig file from Rancher:\n1. Log in to the Rancher UI.\n2. Navigate to the cluster you want to manage.\n3. Click on 'Kubeconfig File' to download it.\n4. Set the KUBECONFIG environment variable:\n```bash\nexport KUBECONFIG=path/to/downloaded/kubeconfig.yaml\n```\nVerify the connection:\n```bash\nkubectl cluster-info\n```"
+      },
+      {
+        "title": "Post-install Configuration",
+        "description": "Configure monitoring and autoscaling for your clusters. For example, to enable the Horizontal Pod Autoscaler, you can use the following command:\n```bash\nkubectl autoscale deployment your-deployment-name --cpu-percent=50 --min=1 --max=10\n```\nEnsure that metrics-server is installed in your cluster for HPA to function correctly."
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove Rancher Server",
+        "description": "To uninstall Rancher, stop and remove the Docker container:\n```bash\nsudo docker ps -a # to find the container ID\nsudo docker stop <container_id>\nsudo docker rm <container_id>\n```\nAdditionally, clean up any persistent storage if configured."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Rancher Server",
+        "description": "To upgrade Rancher, first back up your data. You can create a backup by exporting the database. Then, pull the new version and run it:\n```bash\nsudo docker pull rancher/rancher:v2.10.0\nsudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged rancher/rancher:v2.10.0\n```\nVerify the upgrade by checking the Rancher UI and running:\n```bash\nkubectl get pods -n cattle-system\n```\nIf issues arise, you can roll back to the previous version by running the older image."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Rancher UI not accessible",
+        "description": "If the Rancher UI is not accessible, check if the Docker container is running:\n```bash\nsudo docker ps\n```\nIf it's not running, check the logs for errors:\n```bash\nsudo docker logs <container_id>\n```\nCommon issues include port conflicts or insufficient resources."
+      },
+      {
+        "title": "kubectl not connecting to Rancher",
+        "description": "Ensure that the KUBECONFIG is set correctly. Run:\n```bash\necho $KUBECONFIG\n```\nIf it points to the wrong file, reset it. Also, verify that the kubeconfig file is valid and contains the correct cluster information."
+      },
+      {
+        "title": "Pods in CrashLoopBackOff",
+        "description": "If you see pods in a CrashLoopBackOff state, check the pod logs:\n```bash\nkubectl logs <pod_name>\n```\nCommon causes include misconfigurations in deployments or insufficient resources allocated to the pods."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "2.10",
+        "changes": "Introduced support for Kubernetes 1.30, improved UI performance, and enhanced security features.",
+        "deprecations": "Deprecated support for Kubernetes versions below 1.27."
+      },
+      {
+        "version": "2.9",
+        "changes": "Added new monitoring capabilities and improved cluster management features.",
+        "deprecations": "Deprecated certain legacy APIs."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Rancher should allow you to access the Rancher UI at `https://localhost`, manage Kubernetes clusters, and utilize features like monitoring and autoscaling. Ensure that all components are running smoothly and that `kubectl` is configured correctly.",
+      "codeSnippets": [
+        "sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged rancher/rancher:v2.10.0",
+        "export KUBECONFIG=path/to/downloaded/kubeconfig.yaml",
+        "kubectl cluster-info",
+        "kubectl autoscale deployment your-deployment-name --cpu-percent=50 --min=1 --max=10"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "distribution",
+      "distribution",
+      "suse"
+    ],
+    "platform": "rancher",
+    "platformType": "distribution",
+    "platformProvider": "SUSE",
+    "platformVersions": [
+      "2.8",
+      "2.9",
+      "2.10"
+    ],
+    "supportedK8sVersions": [
+      "1.27",
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "docker"
+    ],
+    "containerImages": [
+      "rancher/rancher:v2.10.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://ranchermanager.docs.rancher.com/",
+      "repo": "https://github.com/rancher/rancher"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.27",
+    "tools": [
+      "kubectl",
+      "docker"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure Docker is installed and running on your Linux node."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:07:54.322Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-redis-operator.json
+++ b/solutions/platform-install/platform-redis-operator.json
@@ -1,0 +1,136 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-redis-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Redis Operator (Spotahome / OT-CONTAINER-KIT)",
+    "description": "The Redis Operator by OT-CONTAINER-KIT simplifies the deployment and management of Redis on Kubernetes, supporting standalone, cluster, and sentinel modes. It is ideal for organizations looking to leverage Redis in a Kubernetes environment with built-in monitoring and best practices.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Redis Operator",
+        "description": "Use Helm to install the Redis Operator. Ensure you have Helm v3.x installed. Run the following commands:\n\n```bash\n# Add the Helm repository\nhelm repo add opstree https://opstree.github.io/redis-operator\n\n# Update the Helm repository\nhelm repo update\n\n# Install the Redis Operator\nhelm install redis-operator opstree/redis-operator --version v0.19.0\n```"
+      },
+      {
+        "title": "Verify Installation",
+        "description": "Check if the Redis Operator is running correctly:\n\n```bash\nkubectl get pods -n default -l app=redis-operator\n```"
+      },
+      {
+        "title": "Create a Redis Cluster",
+        "description": "Create a Redis cluster by applying a custom resource definition (CRD). Save the following YAML to `redis-cluster.yaml`:\n\n```yaml\napiVersion: redis.opstree.dev/v1\nkind: Redis\nmetadata:\n  name: my-redis-cluster\nspec:\n  mode: cluster\n  replicas: 3\n  redis:\n    image: redis:7.0.0\n    password: \"yourpassword\"\n```\n\nThen apply the configuration:\n\n```bash\nkubectl apply -f redis-cluster.yaml\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Set up monitoring for your Redis cluster using the built-in redis-exporter. Ensure you have the necessary RBAC permissions set up:\n\n```bash\nkubectl apply -f https://raw.githubusercontent.com/OT-CONTAINER-KIT/redis-operator/main/deploy/rbac.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Redis Operator",
+        "description": "To uninstall the Redis Operator and clean up resources, run:\n\n```bash\nhelm uninstall redis-operator\nkubectl delete crd redis.opstree.dev\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Redis Operator",
+        "description": "To upgrade from v0.18 to v0.19, first backup your Redis data. Then run:\n\n```bash\nhelm repo update\nhelm upgrade redis-operator opstree/redis-operator --version v0.19.0\n```\n\nVerify the upgrade:\n\n```bash\nkubectl get pods -n default -l app=redis-operator\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Redis Operator Pod CrashLoopBackOff",
+        "description": "If the Redis Operator pod is in a CrashLoopBackOff state, check the logs:\n\n```bash\nkubectl logs <pod-name> -n default\n```\n\nCommon issues include misconfigured CRDs or insufficient permissions."
+      },
+      {
+        "title": "Redis Cluster Not Starting",
+        "description": "If your Redis cluster is not starting, check the status of the Redis CR:\n\n```bash\nkubectl describe redis my-redis-cluster\n```\n\nEnsure that the Redis image version is compatible and the password is correctly set."
+      },
+      {
+        "title": "Monitoring Not Working",
+        "description": "If monitoring is not functioning, verify that the redis-exporter is running:\n\n```bash\nkubectl get pods -n default -l app=redis-exporter\n```\n\nCheck the RBAC permissions if the exporter is not starting."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v0.19",
+        "changes": "Improved monitoring capabilities and support for Redis 7.x.",
+        "deprecations": "Support for Redis 5.x has been deprecated."
+      },
+      {
+        "version": "v0.18",
+        "changes": "Initial support for Redis cluster mode and enhanced RBAC configurations.",
+        "deprecations": "None."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup includes a running Redis Operator pod, a deployed Redis cluster, and operational monitoring. You can verify the installation by checking the status of the pods and ensuring that the Redis cluster is accessible.",
+      "codeSnippets": [
+        "# Add the Helm repository\nhelm repo add opstree https://opstree.github.io/redis-operator\n\n# Update the Helm repository\nhelm repo update\n\n# Install the Redis Operator\nhelm install redis-operator opstree/redis-operator --version v0.19.0",
+        "kubectl get pods -n default -l app=redis-operator",
+        "apiVersion: redis.opstree.dev/v1\nkind: Redis\nmetadata:\n  name: my-redis-cluster\nspec:\n  mode: cluster\n  replicas: 3\n  redis:\n    image: redis:7.0.0\n    password: \"yourpassword\"",
+        "kubectl apply -f redis-cluster.yaml",
+        "kubectl apply -f https://raw.githubusercontent.com/OT-CONTAINER-KIT/redis-operator/main/deploy/rbac.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "ot-container-kit"
+    ],
+    "platform": "redis-operator",
+    "platformType": "operator",
+    "platformProvider": "OT-CONTAINER-KIT",
+    "platformVersions": [
+      "v0.18",
+      "v0.19"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "quay.io/opstree/redis-operator:v0.19.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://ot-redis-operator.netlify.app/",
+      "repo": "https://github.com/OT-CONTAINER-KIT/redis-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running and kubectl configured to access it."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:05:43.791Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-rook-ceph-operator.json
+++ b/solutions/platform-install/platform-rook-ceph-operator.json
@@ -1,0 +1,138 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-rook-ceph-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Rook Ceph Operator",
+    "description": "Rook is a cloud-native storage orchestrator for Kubernetes that automates the deployment and management of Ceph storage. It provides a framework for integrating storage services into Kubernetes, making it ideal for applications requiring scalable and resilient storage solutions.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Rook Ceph Operator",
+        "description": "1. Clone the Rook repository:\n```bash\ngit clone --single-branch --branch v1.16.0 https://github.com/rook/rook.git\ncd rook/deploy/examples\n```\n2. Create the Rook operator namespace:\n```bash\nkubectl create namespace rook-ceph\n```\n3. Apply the Rook CRDs:\n```bash\nkubectl apply -f crds.yaml\n```\n4. Deploy the Rook operator:\n```bash\nkubectl apply -f operator.yaml -n rook-ceph\n```\n5. Verify the operator is running:\n```bash\nkubectl -n rook-ceph get pods\n```"
+      },
+      {
+        "title": "Create a Ceph Cluster",
+        "description": "1. Apply the Ceph cluster configuration:\n```bash\nkubectl apply -f cluster.yaml -n rook-ceph\n```\n2. Verify the Ceph cluster status:\n```bash\nkubectl -n rook-ceph get cephclusters.ceph.rook.io\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "1. Enable monitoring for the Ceph cluster:\n```bash\nkubectl apply -f toolbox.yaml -n rook-ceph\n```\n2. Set up RBAC for accessing Ceph:\n```bash\nkubectl apply -f rbac.yaml -n rook-ceph\n```"
+      },
+      {
+        "title": "Verify Installation",
+        "description": "Check the overall status of the Rook and Ceph components:\n```bash\nkubectl -n rook-ceph get pods\nkubectl -n rook-ceph get cephclusters.ceph.rook.io\nkubectl -n rook-ceph get cephblockpools.ceph.rook.io\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove Rook Ceph Operator",
+        "description": "1. Delete the Ceph cluster:\n```bash\nkubectl delete cephcluster <cluster-name> -n rook-ceph\n```\n2. Remove the Rook operator:\n```bash\nkubectl delete -f operator.yaml -n rook-ceph\n```\n3. Delete the CRDs:\n```bash\nkubectl delete -f crds.yaml\n```\n4. Delete the Rook namespace:\n```bash\nkubectl delete namespace rook-ceph\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Rook Ceph Operator",
+        "description": "1. Backup your Ceph cluster data:\n```bash\nkubectl -n rook-ceph exec -it <toolbox-pod> -- ceph osd pool export <pool-name> > backup.pool\n```\n2. Update the Rook operator version in the operator.yaml file to the desired version (e.g., v1.16.0).\n3. Apply the updated operator:\n```bash\nkubectl apply -f operator.yaml -n rook-ceph\n```\n4. Verify the upgrade:\n```bash\nkubectl -n rook-ceph get pods\nkubectl -n rook-ceph get cephclusters.ceph.rook.io\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator Pod Not Starting",
+        "description": "If the Rook operator pod is not starting, check the logs:\n```bash\nkubectl -n rook-ceph logs <operator-pod>\n```\nCommon issues include missing CRDs or incorrect RBAC permissions. Ensure all necessary resources are applied correctly."
+      },
+      {
+        "title": "Ceph Cluster Not Healthy",
+        "description": "To check the health of the Ceph cluster, run:\n```bash\nkubectl -n rook-ceph exec -it <toolbox-pod> -- ceph health\n```\nIf the cluster is unhealthy, check for OSDs that are down or misconfigured pools."
+      },
+      {
+        "title": "Insufficient Resources for Ceph OSDs",
+        "description": "If you encounter issues with OSDs not starting due to insufficient resources, check the resource requests in your cluster.yaml file. Adjust the requests and limits as necessary."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v1.16.0",
+        "changes": "Improved stability and performance enhancements for Ceph integration.",
+        "deprecations": "Deprecated the use of certain legacy configuration options in cluster.yaml."
+      },
+      {
+        "version": "v1.15.0",
+        "changes": "Added support for new storage classes and enhanced monitoring capabilities.",
+        "deprecations": "Removed support for Kubernetes versions below 1.25."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of Rook Ceph Operator includes a running operator, a healthy Ceph cluster, and properly configured storage classes. Verify that all components are operational and accessible.",
+      "codeSnippets": [
+        "git clone --single-branch --branch v1.16.0 https://github.com/rook/rook.git\ncd rook/deploy/examples",
+        "kubectl create namespace rook-ceph",
+        "kubectl apply -f crds.yaml",
+        "kubectl apply -f operator.yaml -n rook-ceph",
+        "kubectl -n rook-ceph get pods",
+        "kubectl apply -f cluster.yaml -n rook-ceph"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "storage-operator",
+      "rook"
+    ],
+    "platform": "rook-ceph-operator",
+    "platformType": "operator",
+    "platformProvider": "Rook",
+    "platformVersions": [
+      "v1.14",
+      "v1.15",
+      "v1.16"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "kubectl",
+      "helm"
+    ],
+    "containerImages": [
+      "rook/ceph:v1.16.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://rook.io/docs/rook/latest/",
+      "repo": "https://github.com/rook/rook"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running version 1.25 or higher and have kubectl and helm installed."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:07:18.448Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-strimzi-kafka-operator.json
+++ b/solutions/platform-install/platform-strimzi-kafka-operator.json
@@ -1,0 +1,134 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-strimzi-kafka-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Strimzi Kafka Operator",
+    "description": "Strimzi Kafka Operator allows you to run Apache Kafka clusters on Kubernetes or OpenShift, providing a simple way to manage Kafka instances and their configurations. It's ideal for organizations looking to leverage Kafka's messaging capabilities in a cloud-native environment.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Strimzi Kafka Operator",
+        "description": "Use Helm to install the Strimzi Kafka Operator. Make sure you have Helm installed and configured. Run the following commands:\n\n```bash\n# Add the Strimzi Helm repository\nhelm repo add strimzi https://strimzi.io/charts\nhelm repo update\n\n# Install the Strimzi Kafka Operator (version 0.44)\nhelm install strimzi-kafka-operator strimzi/strimzi-kafka-operator --version 0.44.0 --namespace kafka --create-namespace\n```\n\nVerify the installation:\n```bash\nkubectl get pods -n kafka\n```"
+      },
+      {
+        "title": "Create a Kafka Cluster",
+        "description": "Create a Kafka cluster by applying a custom resource definition (CRD). Create a file named `kafka-cluster.yaml` with the following content:\n\n```yaml\napiVersion: kafka.strimzi.io/v1beta2\nkind: Kafka\nmetadata:\n  name: my-cluster\n  namespace: kafka\nspec:\n  kafka:\n    version: \"3.4.0\"\n    replicas: 3\n    listeners:\n      plain:\n        authentication:\n          type: tls\n      tls:\n        authentication:\n          type: tls\n    storage:\n      type: persistent-claim\n      size: 10Gi\n      class: standard\n  zookeeper:\n    replicas: 3\n    storage:\n      type: persistent-claim\n      size: 10Gi\n      class: standard\n```\n\nApply the configuration:\n```bash\nkubectl apply -f kafka-cluster.yaml\n```\n\nVerify the Kafka cluster:\n```bash\nkubectl get kafka -n kafka\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Configure Kafka to enable monitoring and autoscaling. For monitoring, you can integrate with Prometheus and Grafana. To enable autoscaling, modify the Kafka CR:\n\n```yaml\nspec:\n  kafka:\n    ...\n    metrics:\n      enabled: true\n    autoscaling:\n      enabled: true\n      minReplicas: 3\n      maxReplicas: 10\n```\n\nApply the updated configuration:\n```bash\nkubectl apply -f kafka-cluster.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Strimzi Kafka Operator",
+        "description": "To uninstall the Strimzi Kafka Operator and clean up resources, run the following commands:\n\n```bash\n# Delete the Kafka cluster\nkubectl delete kafka my-cluster -n kafka\n\n# Uninstall the Helm release\nhelm uninstall strimzi-kafka-operator -n kafka\n\n# Optionally, delete the namespace\nkubectl delete namespace kafka\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Strimzi Kafka Operator",
+        "description": "To upgrade the Strimzi Kafka Operator from version 0.43 to 0.44, follow these steps:\n\n1. Backup your current Kafka cluster configuration:\n   ```bash\n   kubectl get kafka my-cluster -n kafka -o yaml > kafka-backup.yaml\n   ```\n2. Upgrade the Helm release:\n   ```bash\n   helm upgrade strimzi-kafka-operator strimzi/strimzi-kafka-operator --version 0.44.0 -n kafka\n   ```\n3. Verify the upgrade:\n   ```bash\n   kubectl get pods -n kafka\n   ```\n4. If issues arise, rollback to the previous version:\n   ```bash\n   helm rollback strimzi-kafka-operator -n kafka\n   ```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Kafka Pod CrashLoopBackOff",
+        "description": "If you encounter a CrashLoopBackOff error with Kafka pods, check the logs for errors:\n```bash\nkubectl logs <pod-name> -n kafka\n```\nCommon issues include misconfiguration in the Kafka CR or insufficient resources. Ensure your storage class is correctly set up."
+      },
+      {
+        "title": "Zookeeper Not Ready",
+        "description": "If Zookeeper pods are not in a ready state, check the pod status:\n```bash\nkubectl get pods -n kafka\n```\nEnsure that the storage class allows for persistent volumes and that the Zookeeper configuration in the Kafka CR is correct."
+      },
+      {
+        "title": "Helm Upgrade Fails",
+        "description": "If the Helm upgrade fails, check for existing resources that may conflict with the new version. Use:\n```bash\nhelm history strimzi-kafka-operator -n kafka\n```\nYou may need to manually delete conflicting resources before retrying the upgrade."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "0.44",
+        "changes": "Improved metrics support and enhanced autoscaling features.",
+        "deprecations": "Deprecated support for Kafka versions below 2.8."
+      },
+      {
+        "version": "0.43",
+        "changes": "Introduced support for Kafka 3.3 and improved Helm chart configurations.",
+        "deprecations": "Deprecated the old metrics API."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of the Strimzi Kafka Operator includes a running Kafka cluster with all pods in the 'Running' state and the ability to produce and consume messages. Monitoring and autoscaling should also be configured correctly.",
+      "codeSnippets": [
+        "# Add the Strimzi Helm repository\nhelm repo add strimzi https://strimzi.io/charts\nhelm repo update\n\n# Install the Strimzi Kafka Operator (version 0.44)\nhelm install strimzi-kafka-operator strimzi/strimzi-kafka-operator --version 0.44.0 --namespace kafka --create-namespace",
+        "kubectl get pods -n kafka",
+        "apiVersion: kafka.strimzi.io/v1beta2\nkind: Kafka\nmetadata:\n  name: my-cluster\n  namespace: kafka\nspec:\n  kafka:\n    version: \"3.4.0\"\n    replicas: 3\n    listeners:\n      plain:\n        authentication:\n          type: tls\n      tls:\n        authentication:\n          type: tls\n    storage:\n      type: persistent-claim\n      size: 10Gi\n      class: standard\n  zookeeper:\n    replicas: 3\n    storage:\n      type: persistent-claim\n      size: 10Gi\n      class: standard",
+        "kubectl apply -f kafka-cluster.yaml",
+        "kubectl get kafka -n kafka",
+        "spec:\n  kafka:\n    ...\n    metrics:\n      enabled: true\n    autoscaling:\n      enabled: true\n      minReplicas: 3\n      maxReplicas: 10"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "data-operator",
+      "strimzi"
+    ],
+    "platform": "strimzi-kafka-operator",
+    "platformType": "operator",
+    "platformProvider": "Strimzi",
+    "platformVersions": [
+      "0.42",
+      "0.43",
+      "0.44"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "registry/strimzi/strimzi-kafka-operator:0.44.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://strimzi.io/documentation/",
+      "repo": "https://github.com/strimzi/strimzi-kafka-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running and kubectl configured to interact with it."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:05:20.918Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-tanzu.json
+++ b/solutions/platform-install/platform-tanzu.json
@@ -1,0 +1,151 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-tanzu",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure VMware Tanzu Kubernetes Grid",
+    "description": "VMware Tanzu Kubernetes Grid is a Kubernetes distribution that provides a robust platform for deploying and managing Kubernetes clusters in enterprise environments. It is ideal for organizations looking to leverage Kubernetes with integrated tools and services for enhanced operational efficiency.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Tanzu CLI",
+        "description": "Download and install the Tanzu CLI for version 2.5. Use the following commands to install on Linux:\n```bash\nwget https://github.com/vmware-tanzu/tanzu-framework/releases/download/v0.29.0/tanzu-framework-linux-amd64.tar.gz\nsudo tar -C /usr/local/bin -xzf tanzu-framework-linux-amd64.tar.gz\ntanzu version\n```"
+      },
+      {
+        "title": "Bootstrap Management Cluster",
+        "description": "Create a management cluster using the Tanzu CLI. Replace `<your-cluster-name>` and `<your-region>` with your desired values:\n```bash\ntanzu bootstrap management-cluster create --name <your-cluster-name> --plan dev --region <your-region>\n```"
+      },
+      {
+        "title": "Create Workload Cluster",
+        "description": "Create a workload cluster using the management cluster. Replace `<your-cluster-name>` and `<your-region>`:\n```bash\ntanzu cluster create <your-cluster-name> --plan dev --region <your-region>\n```"
+      },
+      {
+        "title": "Connect kubectl to the Workload Cluster",
+        "description": "Set the context for kubectl to connect to the newly created workload cluster:\n```bash\nkubectl config use-context <your-cluster-name>\n```"
+      },
+      {
+        "title": "Verify Cluster Installation",
+        "description": "Check the status of the cluster and nodes:\n```bash\nkubectl cluster-info\nkubectl get nodes\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Enable Horizontal Pod Autoscaler for the workload cluster:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/master/vertical-pod-autoscaler/deploy/vpa-operator.yaml\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Delete Workload Cluster",
+        "description": "To remove the workload cluster, use the following command:\n```bash\ntanzu cluster delete <your-cluster-name>\n```"
+      },
+      {
+        "title": "Delete Management Cluster",
+        "description": "To remove the management cluster, use:\n```bash\ntanzu bootstrap management-cluster delete --name <your-cluster-name>\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Tanzu Kubernetes Grid",
+        "description": "To upgrade from version 2.4 to 2.5, first backup your cluster configuration and data. Use the following command to upgrade:\n```bash\ntanzu cluster upgrade <your-cluster-name> --version 2.5\n```\nEnsure you check the upgrade notes for any breaking changes or migration steps."
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Cluster Not Responding",
+        "description": "If the cluster is not responding, check the status of the nodes:\n```bash\nkubectl get nodes\n```\nIf nodes are NotReady, check the logs for kubelet and other components for errors."
+      },
+      {
+        "title": "kubectl Context Issues",
+        "description": "If you cannot connect to the cluster, ensure the correct context is set:\n```bash\nkubectl config get-contexts\n```\nSwitch context if necessary using `kubectl config use-context <context-name>`."
+      },
+      {
+        "title": "Resource Quotas Exceeded",
+        "description": "If you encounter resource quota issues, check the resource usage:\n```bash\nkubectl describe quota -n <namespace>\n```\nAdjust your resource requests or limits accordingly."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "2.5",
+        "changes": "Enhanced support for Kubernetes 1.29, improved CLI commands for cluster management.",
+        "deprecations": "Deprecated certain legacy commands in favor of new CLI structure."
+      },
+      {
+        "version": "2.4",
+        "changes": "Introduced new features for workload management and improved integration with Tanzu Mission Control.",
+        "deprecations": "Deprecated older versions of Kubernetes support."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of VMware Tanzu Kubernetes Grid will have a management cluster and at least one workload cluster running, with kubectl configured to interact with the workload cluster. All nodes should be in a Ready state.",
+      "codeSnippets": [
+        "wget https://github.com/vmware-tanzu/tanzu-framework/releases/download/v0.29.0/tanzu-framework-linux-amd64.tar.gz\nsudo tar -C /usr/local/bin -xzf tanzu-framework-linux-amd64.tar.gz\ntanzu version",
+        "tanzu bootstrap management-cluster create --name <your-cluster-name> --plan dev --region <your-region>",
+        "tanzu cluster create <your-cluster-name> --plan dev --region <your-region>",
+        "kubectl config use-context <your-cluster-name>",
+        "kubectl cluster-info\nkubectl get nodes",
+        "kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/master/vertical-pod-autoscaler/deploy/vpa-operator.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "distribution",
+      "distribution",
+      "broadcom/vmware"
+    ],
+    "platform": "tanzu",
+    "platformType": "distribution",
+    "platformProvider": "Broadcom/VMware",
+    "platformVersions": [
+      "2.4",
+      "2.5"
+    ],
+    "supportedK8sVersions": [
+      "1.27",
+      "1.28",
+      "1.29"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli",
+      "kubectl"
+    ],
+    "containerImages": [
+      "vmware/tanzu-kubernetes-grid:2.5"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/",
+      "repo": "https://github.com/vmware-tanzu/tanzu-framework"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.27",
+    "tools": [
+      "kubectl",
+      "tanzu"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have the Tanzu CLI and kubectl installed and configured."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:08:17.530Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-trivy-operator.json
+++ b/solutions/platform-install/platform-trivy-operator.json
@@ -1,0 +1,131 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-trivy-operator",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Trivy Operator (Aqua Security)",
+    "description": "The Trivy Operator is a Kubernetes-native security toolkit that continuously scans your Kubernetes cluster for security issues, providing automated vulnerability and compliance reports. It is ideal for organizations looking to enhance their cluster security posture through automated scanning and reporting.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Install Trivy Operator using Helm",
+        "description": "Add the Aqua Security Helm repository and install the Trivy Operator. Ensure you are using Helm version 3.0 or higher.\n\n```bash\nhelm repo add aquasecurity https://aquasecurity.github.io/helm-charts\nhelm repo update\nhelm install trivy-operator aquasecurity/trivy-operator --version 0.23.0 --namespace trivy --create-namespace\n```"
+      },
+      {
+        "title": "Verify Installation",
+        "description": "Check if the Trivy Operator is running successfully in the cluster.\n\n```bash\nkubectl get pods -n trivy\nkubectl get deployment trivy-operator -n trivy\n```"
+      },
+      {
+        "title": "Configure RBAC for Trivy Operator",
+        "description": "Create a Role and RoleBinding to allow the Trivy Operator to access necessary resources.\n\n```yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: trivy\n  name: trivy-operator-role\nrules:\n- apiGroups: [\"*\"]\n  resources: [\"pods\", \"pods/log\", \"secrets\", \"configmaps\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n\n---\n\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: trivy-operator-rolebinding\n  namespace: trivy\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: trivy-operator-role\nsubjects:\n- kind: ServiceAccount\n  name: trivy-operator\n  namespace: trivy\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Trivy Operator",
+        "description": "Remove the Trivy Operator and its associated resources from the cluster.\n\n```bash\nhelm uninstall trivy-operator -n trivy\nkubectl delete namespace trivy\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade Trivy Operator",
+        "description": "To upgrade the Trivy Operator, first backup existing configurations and reports. Then, run the Helm upgrade command.\n\n```bash\nhelm upgrade trivy-operator aquasecurity/trivy-operator --version 0.23.0 -n trivy\n```\n\n**Backup:** Ensure you back up any custom resources and configurations before upgrading. You can export them using:\n\n```bash\nkubectl get trivyreports --all-namespaces -o yaml > trivyreports-backup.yaml\n```\n\n**Rollback:** If issues arise, you can rollback to the previous version using:\n\n```bash\nhelm rollback trivy-operator -n trivy\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Trivy Operator not scanning new Pods",
+        "description": "Ensure that the Trivy Operator has the necessary permissions and that the deployment is running. Check logs for errors:\n\n```bash\nkubectl logs -l app=trivy-operator -n trivy\n```"
+      },
+      {
+        "title": "Failed to generate reports",
+        "description": "Check if the Trivy Operator has access to the required resources. Verify RBAC settings and ensure the necessary permissions are granted."
+      },
+      {
+        "title": "Helm installation fails",
+        "description": "Ensure you are using a compatible version of Helm (3.0+). Check for network issues or repository access problems."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v0.23",
+        "changes": "Introduced enhanced compliance reporting features and improved performance.",
+        "deprecations": "Deprecated support for Kubernetes versions below 1.25."
+      },
+      {
+        "version": "v0.22",
+        "changes": "Added support for new vulnerability scanning capabilities and improved RBAC configurations.",
+        "deprecations": "Deprecated some legacy API endpoints."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup of the Trivy Operator will have the operator running in the specified namespace, with the ability to scan Kubernetes resources and generate security reports. You can verify the installation by checking the status of the operator pods and ensuring reports are being generated.",
+      "codeSnippets": [
+        "helm repo add aquasecurity https://aquasecurity.github.io/helm-charts\nhelm repo update\nhelm install trivy-operator aquasecurity/trivy-operator --version 0.23.0 --namespace trivy --create-namespace",
+        "kubectl get pods -n trivy\nkubectl get deployment trivy-operator -n trivy",
+        "apiVersion: rbac.authorization.k8s.io/v1\nkind: Role\nmetadata:\n  namespace: trivy\n  name: trivy-operator-role\nrules:\n- apiGroups: [\"*\"]\n  resources: [\"pods\", \"pods/log\", \"secrets\", \"configmaps\"]\n  verbs: [\"get\", \"list\", \"watch\"]\n\n---\n\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: trivy-operator-rolebinding\n  namespace: trivy\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: Role\n  name: trivy-operator-role\nsubjects:\n- kind: ServiceAccount\n  name: trivy-operator\n  namespace: trivy"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "operator",
+      "security-operator",
+      "aqua-security"
+    ],
+    "platform": "trivy-operator",
+    "platformType": "operator",
+    "platformProvider": "Aqua Security",
+    "platformVersions": [
+      "v0.21",
+      "v0.22",
+      "v0.23"
+    ],
+    "supportedK8sVersions": [
+      "1.25+"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm",
+      "kubectl"
+    ],
+    "containerImages": [
+      "aquasec/trivy-operator:v0.23.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://aquasecurity.github.io/trivy-operator/",
+      "repo": "https://github.com/aquasecurity/trivy-operator"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.25",
+    "tools": [
+      "kubectl",
+      "helm"
+    ],
+    "cloudCLI": "optional cloud CLI tool (gcloud, aws, az, oci)",
+    "description": "Ensure you have a Kubernetes cluster running and kubectl configured to access it."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:09:11.595Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/platform-install/platform-vke.json
+++ b/solutions/platform-install/platform-vke.json
@@ -1,0 +1,141 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-vke",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Vultr Kubernetes Engine (VKE)",
+    "description": "Vultr Kubernetes Engine (VKE) is a managed Kubernetes service that simplifies the deployment and management of Kubernetes clusters on Vultr's infrastructure. It is ideal for users looking for a hassle-free Kubernetes experience with integrated Vultr features.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Create a Kubernetes Cluster",
+        "description": "Use the Vultr CLI to create a new Kubernetes cluster. Replace `<region>` and `<plan>` with your desired values.\n```bash\nvultr-cli k8s create --region <region> --plan <plan> --k8s-version 1.30\n```"
+      },
+      {
+        "title": "Configure kubectl",
+        "description": "After the cluster is created, configure kubectl to connect to your new cluster. Replace `<cluster-id>` with your actual cluster ID.\n```bash\nvultr-cli k8s config <cluster-id> --output kubeconfig.yaml\nexport KUBECONFIG=$(pwd)/kubeconfig.yaml\nkubectl cluster-info\n```"
+      },
+      {
+        "title": "Install Vultr Cloud Controller Manager",
+        "description": "Download and apply the necessary YAML files for the Vultr Cloud Controller Manager. Ensure you replace `<region-id>` and `<api-key>` with your actual Vultr region ID and API key.\n```bash\nkubectl apply -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/secret.yml\nkubectl apply -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/v0.16.0.yml\n```"
+      },
+      {
+        "title": "Verify Installation",
+        "description": "Check the status of the Vultr Cloud Controller Manager pods to ensure they are running.\n```bash\nkubectl get pods -n kube-system | grep vultr-cloud-controller-manager\n```"
+      },
+      {
+        "title": "Post-Install Configuration",
+        "description": "Set up autoscaling for your cluster. Ensure the metrics server is installed and then configure the Horizontal Pod Autoscaler (HPA).\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml\nkubectl autoscale deployment <deployment-name> --cpu-percent=50 --min=1 --max=10\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Kubernetes Cluster",
+        "description": "Use the Vultr CLI to delete the Kubernetes cluster. Replace `<cluster-id>` with your actual cluster ID.\n```bash\nvultr-cli k8s delete <cluster-id>\n```"
+      },
+      {
+        "title": "Clean Up Resources",
+        "description": "Ensure all resources related to the Vultr Cloud Controller Manager are removed.\n```bash\nkubectl delete -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/v0.16.0.yml\nkubectl delete -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/secret.yml\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade the Vultr Cloud Controller Manager",
+        "description": "Before upgrading, back up your current configuration. Then, apply the new version YAML. Replace `v0.16.0` with the new version if necessary.\n```bash\nkubectl apply -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/v0.16.0.yml\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods Not Starting",
+        "description": "If the Vultr Cloud Controller Manager pods are not starting, check the logs for errors.\n```bash\nkubectl logs <pod-name> -n kube-system\n``` Ensure that your API key and region ID are correctly set in the secret."
+      },
+      {
+        "title": "kubectl Not Connecting",
+        "description": "If kubectl cannot connect to the cluster, verify your kubeconfig file.\n```bash\ncat $KUBECONFIG\n``` Make sure it points to the correct cluster and that the credentials are valid."
+      },
+      {
+        "title": "LoadBalancer Not Provisioned",
+        "description": "If a LoadBalancer service is not being provisioned, ensure that the Vultr Cloud Controller Manager is running and check the service configuration.\n```bash\nkubectl describe service <service-name>\n``` Look for events indicating provisioning issues."
+      }
+    ],
+    "versionNotes": [
+      {
+        "version": "v0.16.0",
+        "changes": "Improved integration with Vultr features and enhanced stability.",
+        "deprecations": "No deprecated features in this version."
+      }
+    ],
+    "resolution": {
+      "summary": "A successful setup will have a running Kubernetes cluster on Vultr with the Vultr Cloud Controller Manager installed and configured. You should be able to deploy applications and utilize Vultr's cloud features seamlessly.",
+      "codeSnippets": [
+        "vultr-cli k8s create --region <region> --plan <plan> --k8s-version 1.30",
+        "vultr-cli k8s config <cluster-id> --output kubeconfig.yaml\nexport KUBECONFIG=$(pwd)/kubeconfig.yaml\nkubectl cluster-info",
+        "kubectl apply -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/secret.yml\nkubectl apply -f https://raw.githubusercontent.com/vultr/vultr-cloud-controller-manager/master/docs/releases/v0.16.0.yml",
+        "kubectl get pods -n kube-system | grep vultr-cloud-controller-manager",
+        "kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml\nkubectl autoscale deployment <deployment-name> --cpu-percent=50 --min=1 --max=10"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "managed",
+      "managed-k8s",
+      "vultr"
+    ],
+    "platform": "vke",
+    "platformType": "managed",
+    "platformProvider": "Vultr",
+    "platformVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "supportedK8sVersions": [
+      "1.28",
+      "1.29",
+      "1.30"
+    ],
+    "cncfProjects": [],
+    "targetResourceKinds": [
+      "Namespace",
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "cli"
+    ],
+    "containerImages": [
+      "vultr/vultr-cloud-controller-manager:v0.16.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://www.vultr.com/docs/vultr-kubernetes-engine/",
+      "repo": "https://github.com/vultr/vultr-cloud-controller-manager"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.28",
+    "tools": [
+      "kubectl",
+      "vultr-cli"
+    ],
+    "cloudCLI": "optional Vultr CLI tool",
+    "description": "Ensure you have the Vultr CLI installed and configured with your API key."
+  },
+  "security": {
+    "scannedAt": "2026-03-03T12:07:32.827Z",
+    "scannerVersion": "platform-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
Merges all 26 remaining platform missions from overnight scheduled runs + fixes the workflow label bug.

## New Missions (26)
**Managed K8s:** DOKS, IKS, OKE, VKE
**Distributions:** Charmed K8s, k0s, kubeadm, MicroK8s, Minikube, Rancher, Tanzu, Docker Desktop
**Operators:** Cluster API, ECK, ExternalDNS, Grafana, Kyverno, MetalLB, MongoDB, MySQL, PostgreSQL, RabbitMQ, Redis, Rook-Ceph, Strimzi Kafka, Trivy

## Workflow Fix
Removed `--label` flag from `gh pr create` — the label didn't exist and caused all 3 runs to fail at the PR creation step (missions generated fine).

## Totals
- 36/37 platforms covered (only LKE missing — generation failed)
- 386 missions in index (186 CNCF + 36 platform + existing)