### PR TITLE
✨ Include versioning metadata in mission index

### DIFF
--- a/scripts/__tests__/build-index.test.mjs
+++ b/scripts/__tests__/build-index.test.mjs
@@ -35,6 +35,9 @@ metadata:
         targetResourceKinds: ['ClusterRole', 'RoleBinding'],
         cncfProjects: [],
         difficulty: 'advanced',
+        maturity: 'graduated',
+        qualityScore: 85,
+        projectVersion: '2.1.0',
       }
     }));
 
@@ -87,5 +90,23 @@ metadata:
   it('should include count in index', async () => {
     const index = await buildIndex();
     expect(index.count).toBe(index.missions.length);
+  });
+
+  it('should include versioning metadata when present', async () => {
+    const index = await buildIndex();
+    const rbac = index.missions.find(m => m.title === 'Fix RBAC Denied Errors');
+    expect(rbac).toBeDefined();
+    expect(rbac.maturity).toBe('graduated');
+    expect(rbac.qualityScore).toBe(85);
+    expect(rbac.projectVersion).toBe('2.1.0');
+  });
+
+  it('should omit versioning metadata when absent', async () => {
+    const index = await buildIndex();
+    const crash = index.missions.find(m => m.title === 'Fix CrashLoopBackOff');
+    expect(crash).toBeDefined();
+    expect(crash.maturity).toBeUndefined();
+    expect(crash.qualityScore).toBeUndefined();
+    expect(crash.projectVersion).toBeUndefined();
   });
 });

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -41,7 +41,7 @@ function extractMetadata(content, filePath) {
     const author = data.author || 'KubeStellar Bot';
     const authorGithub = data.authorGithub || 'kubestellar';
     
-    return {
+    const entry = {
       path: relPath,
       title: data.title || data.mission?.title || '',
       description: (data.description || data.mission?.description || '').slice(0, 200),
@@ -58,6 +58,13 @@ function extractMetadata(content, filePath) {
       type: data.type || data.mission?.type || 'troubleshoot',
       installMethods: data.metadata?.installMethods || [],
     };
+
+    // Include versioning metadata when present in the mission file
+    if (data.metadata?.projectVersion) entry.projectVersion = data.metadata.projectVersion;
+    if (data.metadata?.maturity) entry.maturity = data.metadata.maturity;
+    if (data.metadata?.qualityScore != null) entry.qualityScore = data.metadata.qualityScore;
+
+    return entry;
   } catch (e) {
     console.warn(`Skipping ${relPath}: ${e.message}`);
     return null;


### PR DESCRIPTION
## Summary
- Add `projectVersion`, `maturity`, and `qualityScore` fields to index entries in `build-index.mjs`
- Fields are only included when present in the mission file (no bloat for missions without them)
- Enables console UI to show version info on browse cards without fetching full mission JSON

## Stats from rebuilt index (397 missions)
- **187** missions now include `projectVersion` (e.g., "1.4.1" for Aeraki Mesh)
- **360** missions include `maturity` (graduated/incubating/sandbox)
- **388** missions include `qualityScore`

## Test plan
- [x] All 8 build-index tests pass (including 2 new tests for versioning fields)
- [x] Verified rebuilt index.json contains correct fields
- [ ] Console UI PR (kubestellar/console) will consume these fields