### PR TITLE
🐛 Fix inaccurate Kubewarden and Ratify install missions

### DIFF
--- a/solutions/cncf-install/install-kubewarden.json
+++ b/solutions/cncf-install/install-kubewarden.json
@@ -6,85 +6,81 @@
   "authorGithub": "kubestellar",
   "mission": {
     "title": "Install and Configure Kubewarden on Kubernetes",
-    "description": "Kubewarden is a Kubernetes Dynamic Admission Controller that allows you to manage admission policies in your cluster using WebAssembly. Installing Kubewarden enables you to enforce security and compliance policies dynamically as resources are created or modified.",
+    "description": "Kubewarden is a Kubernetes Dynamic Admission Controller that uses WebAssembly policies to validate, mutate, or reject admission requests. Installing Kubewarden requires three Helm charts deployed in sequence: CRDs, the controller, and default policy server.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
         "title": "Add the Kubewarden Helm repository",
-        "description": "Add the official Kubewarden Helm chart repository to your Helm configuration with the following command:\n```bash\nhelm repo add kubewarden https://charts.kubewarden.io\nhelm repo update\n```"
+        "description": "Add the official Kubewarden Helm chart repository and update your local cache:\n```bash\nhelm repo add kubewarden https://charts.kubewarden.io\nhelm repo update kubewarden\n```"
+      },
+      {
+        "title": "Install the Kubewarden CRDs",
+        "description": "Install the CRDs chart first — this registers ClusterAdmissionPolicy, AdmissionPolicy, PolicyServer, and audit report Custom Resource Definitions:\n```bash\nhelm install --wait -n kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds\n```\nThe `--wait` flag ensures all CRDs are registered before proceeding."
       },
       {
         "title": "Install the Kubewarden Controller",
-        "description": "Install the Kubewarden Controller using Helm with the following command:\n```bash\nhelm install kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --create-namespace --version v1.32.1\n```"
+        "description": "Install the controller and audit scanner. This chart must be installed after the CRDs chart:\n```bash\nhelm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller\n```"
+      },
+      {
+        "title": "Install the Kubewarden Defaults",
+        "description": "Install the defaults chart, which creates a PolicyServer resource named `default` and optionally deploys recommended security policies:\n```bash\nhelm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults\n```"
       },
       {
         "title": "Verify the installation",
-        "description": "Check that the Kubewarden Controller pod is running:\n```bash\nkubectl get pods --namespace kubewarden\n```"
-      },
-      {
-        "title": "Configure resource limits",
-        "description": "To ensure the Kubewarden Controller has appropriate resource limits, edit the Helm release:\n```bash\nhelm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --version v1.32.1\n```"
-      },
-      {
-        "title": "Set up admission policies",
-        "description": "After installation, you can start defining admission policies. Refer to the official documentation for creating policies:\n```bash\n# Example command to create a policy (customize as needed)\nkubectl apply -f your-admission-policy.yaml --namespace kubewarden\n```"
+        "description": "Check that all Kubewarden pods are running and the default PolicyServer is ready:\n```bash\nkubectl get pods -n kubewarden\nkubectl get policyservers -n kubewarden\n```\nYou should see the controller, audit-scanner, and default policy-server pods in `Running` state."
       }
     ],
     "resolution": {
-      "summary": "A successful installation will have the Kubewarden Controller running in the 'kubewarden' namespace, and you will see the pod status as 'Running'. You can then proceed to define and apply your admission policies.",
+      "summary": "A successful installation will have three Helm releases (kubewarden-crds, kubewarden-controller, kubewarden-defaults) in the kubewarden namespace. The controller, audit-scanner, and default policy-server pods should all be Running. You can then define ClusterAdmissionPolicy or AdmissionPolicy resources to enforce policies.",
       "codeSnippets": [
-        "helm repo add kubewarden https://charts.kubewarden.io\nhelm repo update",
-        "helm install kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --create-namespace --version v1.32.1",
-        "kubectl get pods --namespace kubewarden",
-        "helm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --version v1.32.1",
-        "# Example command to create a policy (customize as needed)\nkubectl apply -f your-admission-policy.yaml --namespace kubewarden"
+        "helm repo add kubewarden https://charts.kubewarden.io\nhelm repo update kubewarden",
+        "helm install --wait -n kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds",
+        "helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller",
+        "helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults",
+        "kubectl get pods -n kubewarden\nkubectl get policyservers -n kubewarden"
       ]
     },
     "uninstall": [
       {
-        "title": "Remove the Helm release",
-        "description": "Uninstall the Kubewarden Controller release using Helm to remove the deployment from your cluster. Run the following command:\n```bash\nhelm uninstall kubewarden-controller --namespace kubewarden\n```"
-      },
-      {
-        "title": "Clean up CRDs and persistent resources",
-        "description": "Remove any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) associated with Kubewarden. Execute the following commands:\n```bash\nkubectl delete crd policies.kubewarden.io\nkubectl delete pvc --all --namespace kubewarden\n```"
+        "title": "Remove Helm releases in reverse order",
+        "description": "Uninstall all three Kubewarden Helm releases in reverse order (defaults first, then controller, then CRDs):\n```bash\nhelm uninstall kubewarden-defaults -n kubewarden\nhelm uninstall kubewarden-controller -n kubewarden\nhelm uninstall kubewarden-crds -n kubewarden\n```"
       },
       {
         "title": "Remove namespace and verify",
-        "description": "Delete the Kubewarden namespace and verify that it has been removed. Use the following commands:\n```bash\nkubectl delete namespace kubewarden\nkubectl get namespaces\n```"
+        "description": "Delete the kubewarden namespace and verify removal:\n```bash\nkubectl delete namespace kubewarden\nkubectl get namespaces | grep kubewarden\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Backup current state",
-        "description": "Before upgrading, back up the current configuration and state of the Kubewarden Controller. You can export the current Helm release values with:\n```bash\nhelm get values kubewarden-controller --namespace kubewarden > backup-values.yaml\n```"
+        "title": "Update the Helm repository",
+        "description": "Fetch the latest chart versions:\n```bash\nhelm repo update kubewarden\n```"
       },
       {
-        "title": "Update repo and run upgrade command",
-        "description": "Update the Helm repository and upgrade the Kubewarden Controller to the latest version. Run the following commands:\n```bash\nhelm repo update\nhelm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --version v1.33.0\n```"
+        "title": "Upgrade all three charts in order",
+        "description": "Upgrade the CRDs first, then the controller, then defaults — the same order as the initial install:\n```bash\nhelm upgrade --wait -n kubewarden kubewarden-crds kubewarden/kubewarden-crds\nhelm upgrade --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller\nhelm upgrade --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults\n```"
       },
       {
         "title": "Verify the upgrade",
-        "description": "After upgrading, check that the Kubewarden Controller pod is running with the new version. Use this command:\n```bash\nkubectl get pods --namespace kubewarden\n```"
+        "description": "Confirm all pods restarted with the new version:\n```bash\nkubectl get pods -n kubewarden\nhelm list -n kubewarden\n```"
       }
     ],
     "troubleshooting": [
       {
+        "title": "CRDs not registered",
+        "description": "If the controller install fails with missing CRDs, ensure the CRDs chart was installed first and completed successfully:\n```bash\nhelm list -n kubewarden\nkubectl get crd | grep kubewarden\n```\nIf CRDs are missing, re-run: `helm install --wait -n kubewarden kubewarden-crds kubewarden/kubewarden-crds`"
+      },
+      {
         "title": "Pods stuck in CrashLoopBackOff",
-        "description": "If the Kubewarden Controller pods are in a CrashLoopBackOff state, check the logs for errors. Use the following command to view logs:\n```bash\nkubectl logs <pod-name> --namespace kubewarden\n```"
+        "description": "Check the controller logs for errors:\n```bash\nkubectl logs -n kubewarden -l app=kubewarden-controller\nkubectl describe pod -n kubewarden -l app=kubewarden-controller\n```\nCommon causes: missing CRDs (install order wrong), insufficient RBAC permissions, or resource constraints."
       },
       {
-        "title": "Admission policies not being enforced",
-        "description": "If admission policies are not being enforced, ensure that the policies are correctly defined and applied. Verify with:\n```bash\nkubectl get policies --namespace kubewarden\n```"
+        "title": "PolicyServer not creating pods",
+        "description": "If the default PolicyServer exists but no policy-server pod appears, check events:\n```bash\nkubectl get policyservers -n kubewarden\nkubectl describe policyserver default -n kubewarden\nkubectl get events -n kubewarden --sort-by=.lastTimestamp\n```"
       },
       {
-        "title": "Helm release not found",
-        "description": "If you encounter an error stating that the Helm release is not found, confirm that you are using the correct namespace and release name. List all releases with:\n```bash\nhelm list --namespace kubewarden\n```"
-      },
-      {
-        "title": "Insufficient resources allocated",
-        "description": "If the Kubewarden Controller is failing due to insufficient resources, check the resource limits and requests. Adjust them if necessary using:\n```bash\nhelm upgrade kubewarden-controller kubewarden/kubewarden-controller --namespace kubewarden --set resources.limits.cpu=500m --set resources.limits.memory=512Mi --version v1.32.1\n```"
+        "title": "Admission policies not enforced",
+        "description": "Verify the policy is bound to the default PolicyServer and its status is active:\n```bash\nkubectl get clusteradmissionpolicies\nkubectl get admissionpolicies -A\nkubectl get validatingwebhookconfigurations | grep kubewarden\n```"
       }
     ]
   },
@@ -100,7 +96,9 @@
       "kubewarden"
     ],
     "targetResourceKinds": [
-      "Namespace"
+      "Namespace",
+      "PolicyServer",
+      "ClusterAdmissionPolicy"
     ],
     "difficulty": "intermediate",
     "issueTypes": [
@@ -111,27 +109,29 @@
       "helm"
     ],
     "maturity": "sandbox",
-    "projectVersion": "v1.32.1",
+    "projectVersion": "latest",
     "containerImages": [
-      "registry/org/image:tag"
+      "ghcr.io/kubewarden/kubewarden-controller",
+      "ghcr.io/kubewarden/policy-server"
     ],
     "sourceUrls": {
-      "docs": "https://kubewarden.io",
-      "repo": "https://github.com/kubewarden/kubewarden-controller"
+      "docs": "https://docs.kubewarden.io/quick-start",
+      "repo": "https://github.com/kubewarden/kubewarden-controller",
+      "helm": "https://charts.kubewarden.io"
     },
     "qualityScore": 100
   },
   "prerequisites": {
-    "kubernetes": ">=1.24",
+    "kubernetes": ">=1.21",
     "tools": [
       "helm",
       "kubectl"
     ],
-    "description": "Ensure you have a Kubernetes cluster running version 1.24 or higher, along with Helm and kubectl installed."
+    "description": "Kubernetes 1.21 or higher (for kubernetes.io/metadata.name label support). Helm 3 and kubectl configured to access your cluster."
   },
   "security": {
-    "scannedAt": "2026-03-01T19:40:11.213Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-ratify.json
+++ b/solutions/cncf-install/install-ratify.json
@@ -6,89 +6,85 @@
   "authorGithub": "kubestellar",
   "mission": {
     "title": "Install and Configure Ratify on Kubernetes",
-    "description": "Ratify is an Artifact Ratification Framework that enables verification of artifact security metadata, ensuring that only compliant artifacts are deployed. Installing Ratify helps organizations enforce security policies and improve their deployment processes.",
+    "description": "Ratify is an Artifact Ratification Framework that verifies artifact security metadata (signatures, SBOMs, vulnerability reports) before allowing deployment. It integrates with OPA Gatekeeper as an external data provider to enforce verification policies at admission time.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Add the Helm repository",
-        "description": "Add the Ratify Helm chart repository to your Helm configuration.\n```bash\nhelm repo add ratify https://notaryproject.github.io/ratify\nhelm repo update\n```"
+        "title": "Prerequisites — install helmfile",
+        "description": "Ratify's quick-start uses helmfile to deploy Gatekeeper, Ratify, and constraint templates together. Install helmfile (v0.14+, < v1.0.0):\n```bash\n# macOS\nbrew install helmfile\n\n# Linux\ncurl -fsSL -o helmfile https://github.com/helmfile/helmfile/releases/latest/download/helmfile_linux_amd64_v1 && chmod +x helmfile && sudo mv helmfile /usr/local/bin/\n```\nVerify: `helmfile version` — must be >= 0.14 and < 1.0.0."
       },
       {
-        "title": "Install Ratify",
-        "description": "Install Ratify using Helm in a new namespace called 'ratify'.\n```bash\nhelm install ratify ratify/ratify --namespace ratify --create-namespace --version v1.4.0\n```"
+        "title": "Deploy Gatekeeper, Ratify, and constraints",
+        "description": "Run the helmfile sync command to deploy all components in one step. This installs OPA Gatekeeper (v3.18) with external data enabled, the Ratify chart, and default constraint templates:\n```bash\nhelmfile sync -f 'git::https://github.com/notaryproject/ratify.git@helmfile.yaml?ref=v1.4.0'\n```\nThis deploys into the `gatekeeper-system` namespace. The Ratify helm chart comes from `https://ratify-project.github.io/ratify`."
       },
       {
         "title": "Verify the installation",
-        "description": "Check if the Ratify pods are running successfully.\n```bash\nkubectl get pods --namespace ratify\n```"
+        "description": "Check that Gatekeeper and Ratify pods are running in gatekeeper-system:\n```bash\nkubectl get pods -n gatekeeper-system\n```\nYou should see gatekeeper-controller, gatekeeper-audit, and ratify pods all in `Running` state. Also verify the constraint template exists:\n```bash\nkubectl get constrainttemplates | grep ratify\n```"
       },
       {
-        "title": "Configure resource limits",
-        "description": "Set resource limits for the Ratify deployment to ensure it operates within defined constraints.\n```bash\nkubectl patch deployment ratify --namespace ratify --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'\n```"
+        "title": "Test with a signed image",
+        "description": "Verify that Ratify allows a properly signed image:\n```bash\nkubectl run demo --image=ghcr.io/deislabs/ratify/notary-image:signed -n default\n```\nThis should succeed — the image has a valid Notary v2 signature."
+      },
+      {
+        "title": "Test with an unsigned image",
+        "description": "Verify that Ratify blocks an unsigned image:\n```bash\nkubectl run demo1 --image=ghcr.io/deislabs/ratify/notary-image:unsigned -n default\n```\nThis should be denied by Gatekeeper with an error message indicating signature verification failed."
       }
     ],
+    "resolution": {
+      "summary": "A successful installation will have Gatekeeper and Ratify pods running in gatekeeper-system. Signed images are allowed while unsigned images are blocked at admission time. You can customize verification policies by modifying the Ratify Store and Verifier custom resources.",
+      "codeSnippets": [
+        "helmfile sync -f 'git::https://github.com/notaryproject/ratify.git@helmfile.yaml?ref=v1.4.0'",
+        "kubectl get pods -n gatekeeper-system",
+        "kubectl run demo --image=ghcr.io/deislabs/ratify/notary-image:signed -n default",
+        "kubectl run demo1 --image=ghcr.io/deislabs/ratify/notary-image:unsigned -n default"
+      ]
+    },
     "uninstall": [
       {
-        "title": "Remove the Helm release",
-        "description": "Uninstall the Ratify Helm release from the cluster.\n```bash\nhelm uninstall ratify --namespace ratify\n```"
+        "title": "Remove all components with helmfile",
+        "description": "Destroy the entire helmfile release to remove Gatekeeper, Ratify, and constraint templates:\n```bash\nhelmfile destroy --skip-charts -f 'git::https://github.com/notaryproject/ratify.git@helmfile.yaml?ref=v1.4.0'\n```"
       },
       {
-        "title": "Clean up CRDs",
-        "description": "Remove any Custom Resource Definitions (CRDs) that were installed with Ratify.\n```bash\nkubectl delete crd ratifyconfigs.ratify.dev\nkubectl delete crd ratifypolicies.ratify.dev\n```"
-      },
-      {
-        "title": "Delete the namespace",
-        "description": "Delete the 'ratify' namespace to clean up all resources associated with Ratify.\n```bash\nkubectl delete namespace ratify\n```"
+        "title": "Clean up test pods",
+        "description": "Remove any test pods created during validation:\n```bash\nkubectl delete pod demo demo1 -n default --ignore-not-found\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Backup current state",
-        "description": "Before upgrading, back up the current configuration and state of Ratify.\n```bash\nkubectl get all --namespace ratify -o yaml > ratify-backup.yaml\n```"
-      },
-      {
-        "title": "Update the Helm repository",
-        "description": "Update the Helm repository to ensure you have the latest charts.\n```bash\nhelm repo update\n```"
-      },
-      {
-        "title": "Upgrade Ratify",
-        "description": "Upgrade the Ratify installation to the latest version.\n```bash\nhelm upgrade ratify ratify/ratify --namespace ratify --version v1.4.0\n```"
+        "title": "Update to a new Ratify version",
+        "description": "Change the ref tag in the helmfile URL to the new version and re-run sync:\n```bash\nhelmfile sync -f 'git::https://github.com/notaryproject/ratify.git@helmfile.yaml?ref=<new-version>'\n```\nFor example, to upgrade to v1.5.0: `ref=v1.5.0`"
       },
       {
         "title": "Verify the upgrade",
-        "description": "Check the status of the Ratify pods to ensure they are running the new version.\n```bash\nkubectl get pods --namespace ratify\n```"
+        "description": "Check that pods are restarted with the new version:\n```bash\nkubectl get pods -n gatekeeper-system\nkubectl describe pod -n gatekeeper-system -l app=ratify | grep Image:\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods stuck in CrashLoopBackOff",
-        "description": "If the Ratify pods are in a CrashLoopBackOff state, check the logs for errors.\n```bash\nkubectl logs <pod-name> --namespace ratify\n``` \nLook for configuration issues or missing dependencies in the logs."
+        "title": "helmfile command not found",
+        "description": "Ensure helmfile is installed and on your PATH:\n```bash\nhelmfile version\n```\nRatify requires helmfile >= v0.14 and < v1.0.0. Install via `brew install helmfile` (macOS) or download from the helmfile GitHub releases page."
       },
       {
-        "title": "Helm release not found",
-        "description": "If you encounter an error stating the Helm release is not found, ensure you are using the correct namespace.\n```bash\nhelm list --namespace ratify\n``` \nIf the release is not listed, it may not have been installed correctly."
+        "title": "Gatekeeper pods not starting",
+        "description": "Check Gatekeeper logs and events:\n```bash\nkubectl logs -n gatekeeper-system -l control-plane=controller-manager\nkubectl get events -n gatekeeper-system --sort-by=.lastTimestamp\n```\nCommon issues: insufficient RBAC, webhook port conflicts, or resource constraints."
       },
       {
-        "title": "Resource limits causing OOMKilled",
-        "description": "If the pods are being killed due to Out Of Memory (OOM), consider increasing the memory limits set during configuration.\n```bash\nkubectl describe pod <pod-name> --namespace ratify\n``` \nAdjust the resource limits accordingly."
+        "title": "Ratify pods in CrashLoopBackOff",
+        "description": "Check Ratify logs for configuration errors:\n```bash\nkubectl logs -n gatekeeper-system -l app=ratify\nkubectl describe pod -n gatekeeper-system -l app=ratify\n```\nEnsure Gatekeeper is running with `enableExternalData=true` — Ratify depends on Gatekeeper's external data provider feature."
+      },
+      {
+        "title": "Signed images being blocked",
+        "description": "If valid signed images are rejected, check the Ratify verifier configuration and logs:\n```bash\nkubectl get verifiers -n gatekeeper-system\nkubectl logs -n gatekeeper-system -l app=ratify | tail -50\n```\nVerify the constraint template and constraint are applied: `kubectl get constraints`"
       }
-    ],
-    "resolution": {
-      "summary": "A successful installation of Ratify will result in the Ratify pods running in the 'ratify' namespace without errors. You can verify this by checking the pod status and ensuring they are in the 'Running' state.",
-      "codeSnippets": [
-        "helm repo add ratify https://notaryproject.github.io/ratify\nhelm repo update",
-        "helm install ratify ratify/ratify --namespace ratify --create-namespace --version v1.4.0",
-        "kubectl get pods --namespace ratify",
-        "kubectl patch deployment ratify --namespace ratify --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/resources\", \"value\": {\"limits\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"requests\": {\"cpu\": \"250m\", \"memory\": \"256Mi\"}}}]'"
-      ]
-    }
+    ]
   },
   "metadata": {
     "tags": [
       "installation",
       "configuration",
       "cncf",
-      "app-definition",
+      "security",
       "sandbox"
     ],
     "cncfProjects": [
@@ -96,7 +92,8 @@
     ],
     "targetResourceKinds": [
       "Deployment",
-      "Namespace"
+      "Namespace",
+      "ConstraintTemplate"
     ],
     "difficulty": "intermediate",
     "issueTypes": [
@@ -104,31 +101,32 @@
       "configuration"
     ],
     "installMethods": [
-      "helm"
+      "helmfile"
     ],
     "maturity": "sandbox",
     "projectVersion": "v1.4.0",
     "containerImages": [
-      "gcr.io/ratify-project/ratify:v1.4.0"
+      "ghcr.io/ratify-project/ratify:v1.4.0"
     ],
     "sourceUrls": {
-      "docs": "https://ratify.dev",
+      "docs": "https://ratify.dev/docs/quick-start",
       "repo": "https://github.com/ratify-project/ratify",
-      "helm": "https://notaryproject.github.io/ratify"
+      "helm": "https://ratify-project.github.io/ratify"
     },
     "qualityScore": 100
   },
   "prerequisites": {
-    "kubernetes": ">=1.24",
+    "kubernetes": ">=1.30",
     "tools": [
+      "helmfile",
       "helm",
       "kubectl"
     ],
-    "description": "Ensure you have Helm and kubectl installed and configured to interact with your Kubernetes cluster."
+    "description": "Kubernetes v1.30 or higher. helmfile >= v0.14 and < v1.0.0. Helm 3 and kubectl configured to access your cluster. OPA Gatekeeper v3.18+ is deployed automatically by the helmfile."
   },
   "security": {
-    "scannedAt": "2026-03-02T22:40:49.069Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }


### PR DESCRIPTION
## Summary

- **Kubewarden**: Rewrote to install all 3 required Helm charts (`kubewarden-crds` → `kubewarden-controller` → `kubewarden-defaults`) in correct order with `--wait` flags, per [official docs](https://docs.kubewarden.io/quick-start). Previous version only installed the controller chart and had fabricated resource-limits and placeholder policy steps.

- **Ratify**: Rewrote to use `helmfile sync` per [official quick-start](https://ratify.dev/docs/quick-start). Previous version used a wrong helm repo URL (`notaryproject.github.io/ratify`), wrong namespace (`ratify` instead of `gatekeeper-system`), and was missing prerequisites (helmfile, OPA Gatekeeper). Added signed/unsigned image validation tests and correct uninstall via `helmfile destroy`.

## Changes verified against
- https://docs.kubewarden.io/quick-start
- https://ratify.dev/docs/quick-start
- https://github.com/notaryproject/ratify/blob/v1.4.0/helmfile.yaml

## Test plan
- [ ] Verify JSON is valid (done locally)
- [ ] Verify missions render correctly in console Mission Explorer