### PR TITLE
🐛 Fix 8 CNCF outreach install missions against official docs

### DIFF
--- a/solutions/cncf-install/install-drasi.json
+++ b/solutions/cncf-install/install-drasi.json
@@ -6,130 +6,91 @@
   "authorGithub": "kubestellar",
   "mission": {
     "title": "Install and Configure Drasi on Kubernetes",
-    "description": "Drasi is a data processing platform that simplifies detecting changes in data and taking immediate action. It provides real-time actionable insights without the overhead of traditional data processing methods, making it ideal for applications that require immediate responses to data changes.",
+    "description": "Drasi is a data processing platform that simplifies detecting changes in data and taking immediate action. It uses a dedicated CLI tool to deploy its control plane (including Dapr) onto a Kubernetes cluster, then you define Sources, Continuous Queries, and Reactions to process data changes in real time.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Clone the Drasi repository",
-        "description": "Clone the Drasi repository to your local machine to access the necessary Kubernetes manifests.\n```bash\ngit clone https://github.com/drasi-project/drasi-platform.git\ncd drasi-platform\n```"
+        "title": "Install the Drasi CLI",
+        "description": "Download and install the Drasi CLI for your platform:\n```bash\n# macOS\ncurl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash\n\n# Linux\nwget -q https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh -O - | /bin/bash\n```\nVerify the CLI is installed:\n```bash\ndrasi version\n```"
       },
       {
-        "title": "Apply the Kubernetes manifests",
-        "description": "Deploy Drasi to your Kubernetes cluster using the provided manifests.\n```bash\nkubectl apply -f k8s/deployment.yaml --namespace drasi --create-namespace\n```"
+        "title": "Configure the Drasi environment",
+        "description": "Point the Drasi CLI at your Kubernetes cluster:\n```bash\ndrasi env kube\n```\nThis configures Drasi to use your current kubeconfig context."
       },
       {
-        "title": "Verify the deployment",
-        "description": "Check if the Drasi pods are running successfully.\n```bash\nkubectl get pods --namespace drasi\n```"
+        "title": "Initialize Drasi on the cluster",
+        "description": "Deploy the Drasi control plane to your cluster. This installs all Drasi components (including Dapr) into the drasi-system namespace:\n```bash\ndrasi init\n```\nOptional flags:\n- `-n <namespace>` to use a different namespace\n- `--version <tag>` to specify a Drasi version\n- `--registry <registry>` to use a custom container registry"
       },
       {
-        "title": "Post-install configuration",
-        "description": "Configure resource limits for the Drasi deployment to ensure optimal performance.\n```bash\nkubectl set resources deployment/drasi --namespace drasi --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi\n```"
+        "title": "Set up ingress for local clusters",
+        "description": "If running on a local cluster (kind, k3s, minikube), configure the ingress controller:\n```bash\ndrasi ingress init --local-cluster\n```"
       },
       {
-        "title": "Set up RBAC for Drasi",
-        "description": "Create a Role and RoleBinding to allow Drasi to access necessary resources.\n```bash\nkubectl apply -f k8s/rbac.yaml --namespace drasi\n```"
+        "title": "Verify the installation",
+        "description": "Check that all Drasi pods are running in the drasi-system namespace:\n```bash\nkubectl get pods -n drasi-system\n```\nYou should see the Drasi control plane pods in Running state."
       }
     ],
+    "resolution": {
+      "summary": "A successful installation will have all Drasi control plane pods running in the drasi-system namespace. You can now define Sources, Continuous Queries, and Reactions using `drasi apply -f <file.yaml>` and list them with `drasi list source`, `drasi list query`, `drasi list reaction`.",
+      "codeSnippets": [
+        "curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash",
+        "drasi env kube",
+        "drasi init",
+        "kubectl get pods -n drasi-system"
+      ]
+    },
     "uninstall": [
       {
-        "title": "Remove the Drasi deployment",
-        "description": "Delete the Drasi deployment from your Kubernetes cluster.\n```bash\nkubectl delete deployment drasi --namespace drasi\n```"
-      },
-      {
-        "title": "Clean up associated resources",
-        "description": "Remove any associated resources such as services and config maps.\n```bash\nkubectl delete service drasi --namespace drasi\nkubectl delete configmap drasi-config --namespace drasi\n```"
-      },
-      {
-        "title": "Delete the namespace",
-        "description": "Finally, delete the namespace to clean up all resources.\n```bash\nkubectl delete namespace drasi\n```"
+        "title": "Uninstall Drasi",
+        "description": "Remove the Drasi environment from your cluster:\n```bash\ndrasi uninstall -y\n```\nThis removes all Drasi components and the drasi-system namespace."
       }
     ],
     "upgrade": [
       {
-        "title": "Backup current state",
-        "description": "Export the current configuration and state of Drasi before upgrading.\n```bash\nkubectl get all --namespace drasi -o yaml > drasi-backup.yaml\n```"
-      },
-      {
-        "title": "Update the manifests",
-        "description": "Pull the latest changes from the Drasi repository to get the updated manifests.\n```bash\ngit pull origin main\n```"
-      },
-      {
-        "title": "Upgrade the deployment",
-        "description": "Apply the updated manifests to upgrade Drasi.\n```bash\nkubectl apply -f k8s/deployment.yaml --namespace drasi\n```"
-      },
-      {
-        "title": "Verify the upgrade",
-        "description": "Check the status of the pods to ensure the upgrade was successful.\n```bash\nkubectl get pods --namespace drasi\n```"
+        "title": "Upgrade Drasi",
+        "description": "Install the latest CLI version and re-initialize:\n```bash\ncurl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash\ndrasi init --version <new-version>\n```"
       }
     ],
     "troubleshooting": [
       {
+        "title": "drasi init fails",
+        "description": "Check that your kubeconfig context is correct and you have cluster-admin permissions:\n```bash\nkubectl config current-context\nkubectl auth can-i create namespaces\n```"
+      },
+      {
         "title": "Pods not starting",
-        "description": "If the Drasi pods are not starting, check the logs for errors:\n```bash\nkubectl logs <pod-name> --namespace drasi\n``` \nLook for any error messages that indicate what might be wrong, such as configuration issues or missing dependencies."
+        "description": "Check pod logs and events in the drasi-system namespace:\n```bash\nkubectl logs -n drasi-system -l app.kubernetes.io/part-of=drasi\nkubectl get events -n drasi-system --sort-by=.lastTimestamp\n```"
       },
       {
-        "title": "Resource limits causing OOMKilled",
-        "description": "If pods are being terminated due to OOMKilled, check the resource usage:\n```bash\nkubectl top pods --namespace drasi\n``` \nConsider increasing the memory limits in your deployment."
-      },
-      {
-        "title": "RBAC permission errors",
-        "description": "If you encounter permission errors, verify the RBAC configuration:\n```bash\nkubectl get rolebindings --namespace drasi\nkubectl describe rolebinding <rolebinding-name> --namespace drasi\n``` \nEnsure that the correct permissions are granted."
+        "title": "Drasi CLI not found after install",
+        "description": "Ensure the CLI binary is on your PATH. The installer places it in `~/.drasi/bin`. Add to your shell profile:\n```bash\nexport PATH=$PATH:~/.drasi/bin\n```"
       }
-    ],
-    "resolution": {
-      "summary": "A successful installation of Drasi will have all pods running without errors, and you will be able to access the service as intended. You can verify this by checking the pod status and ensuring that the application is responding to data changes.",
-      "codeSnippets": [
-        "git clone https://github.com/drasi-project/drasi-platform.git\ncd drasi-platform",
-        "kubectl apply -f k8s/deployment.yaml --namespace drasi --create-namespace",
-        "kubectl get pods --namespace drasi",
-        "kubectl set resources deployment/drasi --namespace drasi --limits=cpu=500m,memory=512Mi --requests=cpu=250m,memory=256Mi",
-        "kubectl apply -f k8s/rbac.yaml --namespace drasi"
-      ]
-    }
+    ]
   },
   "metadata": {
-    "tags": [
-      "installation",
-      "configuration",
-      "cncf",
-      "app-definition",
-      "sandbox"
-    ],
-    "cncfProjects": [
-      "drasi"
-    ],
-    "targetResourceKinds": [
-      "Deployment",
-      "Namespace"
-    ],
+    "tags": ["installation", "configuration", "cncf", "app-definition", "sandbox"],
+    "cncfProjects": ["drasi"],
+    "targetResourceKinds": ["Namespace"],
     "difficulty": "intermediate",
-    "issueTypes": [
-      "installation",
-      "configuration"
-    ],
-    "installMethods": [
-      "kubectl"
-    ],
+    "issueTypes": ["installation", "configuration"],
+    "installMethods": ["cli"],
     "maturity": "sandbox",
     "projectVersion": "latest",
     "containerImages": [],
     "sourceUrls": {
-      "docs": "https://drasi.io/",
+      "docs": "https://drasi.io/drasi-kubernetes/getting-started/",
       "repo": "https://github.com/drasi-project/drasi-platform"
     },
     "qualityScore": 100
   },
   "prerequisites": {
     "kubernetes": ">=1.24",
-    "tools": [
-      "kubectl"
-    ],
-    "description": "Ensure you have a Kubernetes cluster running and kubectl configured to interact with it."
+    "tools": ["kubectl"],
+    "description": "A running Kubernetes cluster with kubectl configured. The Drasi CLI is installed as part of the mission. Docker is required for local cluster setups."
   },
   "security": {
-    "scannedAt": "2026-03-05T22:34:09.741Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-keylime.json
+++ b/solutions/cncf-install/install-keylime.json
@@ -5,56 +5,65 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Keylime on Kubernetes",
-    "description": "Keylime is an open-source scalable trust system that leverages TPM technology to bootstrap and maintain trust on edge, cloud, and IoT devices. Installing Keylime allows you to ensure the integrity of remote machines and securely manage cryptographic trust.",
+    "title": "Install Keylime Attestation Operator on Kubernetes",
+    "description": "Keylime is a TPM-based remote boot attestation and runtime integrity measurement system. The Keylime Attestation Operator deploys Keylime components (registrar, verifier, and agent) on Kubernetes to provide hardware-rooted trust and continuous node integrity monitoring using TPM 2.0 devices.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Create a Namespace for Keylime",
-        "description": "First, create a dedicated namespace for Keylime to keep its resources organized."
+        "title": "Clone the attestation-operator repository",
+        "description": "Clone the Keylime attestation-operator repository which contains the Helm charts and manifests for deploying Keylime on Kubernetes:\n```bash\ngit clone https://github.com/keylime/attestation-operator.git\ncd attestation-operator\n```"
       },
       {
-        "title": "Apply Keylime Manifests",
-        "description": "Next, apply the Keylime manifests from the GitHub repository. Ensure you are using a specific version."
+        "title": "Install cert-manager (prerequisite)",
+        "description": "The attestation operator requires cert-manager for TLS certificate management:\n```bash\nkubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml\nkubectl wait --for=condition=Available --timeout=120s deployment/cert-manager -n cert-manager\nkubectl wait --for=condition=Available --timeout=120s deployment/cert-manager-webhook -n cert-manager\n```"
       },
       {
-        "title": "Verify Keylime Installation",
-        "description": "Check that all Keylime pods are running correctly in the keylime namespace."
+        "title": "Deploy the Keylime Attestation Operator",
+        "description": "Use the Makefile target to deploy the operator and Keylime components via Helm:\n```bash\nmake helm-keylime-deploy\n```\nThis installs the operator CRDs, the operator itself, and creates a default Keylime CR that deploys the registrar, verifier, and agent components.\n\nAlternatively, install step by step:\n```bash\nmake install           # Install CRDs\nmake deploy            # Deploy the operator\nkubectl apply -f config/samples/  # Create Keylime CR\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that all Keylime components are running:\n```bash\nkubectl get pods -n keylime\n```\nYou should see pods for:\n- `keylime-registrar` — tracks enrolled agents\n- `keylime-verifier` — performs attestation checks\n- `keylime-agent` (DaemonSet) — runs on each node with a TPM device\n- The attestation operator controller"
       }
     ],
     "resolution": {
-      "summary": "A successful installation of Keylime will show all Keylime pods running in the 'keylime' namespace. You will also have configured resource limits and RBAC for secure operation.",
-      "codeSnippets": []
+      "summary": "A successful installation will show the Keylime operator, registrar, verifier, and agent pods running in the keylime namespace. Agent pods run as a DaemonSet on nodes with TPM 2.0 devices. Use `kubectl get keylime -n keylime` to check the custom resource status.",
+      "codeSnippets": [
+        "git clone https://github.com/keylime/attestation-operator.git",
+        "make helm-keylime-deploy",
+        "kubectl get pods -n keylime",
+        "kubectl get keylime -n keylime"
+      ]
     },
     "uninstall": [
       {
-        "title": "Remove Keylime Resources",
-        "description": "To uninstall Keylime, delete the resources applied in the keylime namespace."
+        "title": "Remove Keylime components",
+        "description": "Undeploy Keylime using the Makefile:\n```bash\nmake helm-keylime-undeploy\n```\nOr manually:\n```bash\nkubectl delete -f config/samples/\nmake undeploy\nmake uninstall\n```"
       },
       {
-        "title": "Delete the Keylime Namespace",
-        "description": "Finally, delete the namespace to clean up all resources."
+        "title": "Clean up namespace",
+        "description": "If the namespace still exists after undeployment:\n```bash\nkubectl delete namespace keylime\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Upgrade Keylime",
-        "description": "To upgrade Keylime, apply the new version of the manifests. Ensure to specify the new version in the URLs."
+        "title": "Pull latest and redeploy",
+        "description": "Update the attestation-operator repository and redeploy:\n```bash\ncd attestation-operator\ngit pull origin main\nmake helm-keylime-deploy\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pod Not Starting",
-        "description": "If a pod is not starting, check the pod logs for errors using the command: `kubectl logs <pod-name> -n keylime`."
+        "title": "Agent pods not starting",
+        "description": "Keylime agents require TPM 2.0 hardware on worker nodes. If agent pods fail to start:\n1. Verify TPM device exists: `ls /dev/tpm*` on the node\n2. Check agent logs: `kubectl logs -n keylime -l app=keylime-agent`\n3. On Kubernetes 1.26+, unprivileged TPM access may be available; on older versions, the agent may need privileged access"
       },
       {
-        "title": "Resource Quotas",
-        "description": "Ensure that your cluster has enough resources (CPU, memory) to run Keylime pods. Check resource usage with `kubectl top pods -n keylime`."
+        "title": "cert-manager not ready",
+        "description": "If the operator fails to start with certificate errors, ensure cert-manager is fully ready:\n```bash\nkubectl get pods -n cert-manager\nkubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s\n```"
       },
       {
-        "title": "Network Issues",
-        "description": "If the Keylime components cannot communicate, check your network policies and ensure that the necessary ports are open."
+        "title": "CRD not found errors",
+        "description": "If you see CRD-related errors, ensure the CRDs were installed:\n```bash\nkubectl get crd | grep keylime\n```\nIf missing, run `make install` to install them."
       }
     ]
   },
@@ -63,46 +72,49 @@
       "installation",
       "configuration",
       "cncf",
-      "app-definition",
+      "security",
       "sandbox"
     ],
     "cncfProjects": [
       "keylime"
     ],
     "targetResourceKinds": [
+      "Deployment",
+      "DaemonSet",
       "Service",
-      "Namespace",
-      "Serviceaccount"
+      "Namespace"
     ],
-    "difficulty": "intermediate",
+    "difficulty": "advanced",
     "issueTypes": [
       "installation",
       "configuration"
     ],
     "installMethods": [
-      "kubectl"
+      "make",
+      "helm"
     ],
     "maturity": "sandbox",
-    "projectVersion": "v7.14.1",
-    "containerImages": [
-      "keylime/keylime:v7.14.1"
-    ],
+    "projectVersion": "latest",
+    "containerImages": [],
     "sourceUrls": {
       "docs": "https://keylime.dev",
-      "repo": "https://github.com/keylime/keylime"
+      "repo": "https://github.com/keylime/attestation-operator"
     },
     "qualityScore": 100
   },
   "prerequisites": {
     "kubernetes": ">=1.24",
     "tools": [
-      "kubectl"
+      "kubectl",
+      "git",
+      "make",
+      "helm"
     ],
-    "description": "Ensure you have a running Kubernetes cluster and kubectl installed and configured to interact with your cluster."
+    "description": "Kubernetes 1.24+ cluster with worker nodes that have TPM 2.0 hardware. cert-manager must be installed. git, make, helm, and kubectl must be available on your workstation."
   },
   "security": {
-    "scannedAt": "2026-03-01T16:37:46.416Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-konveyor.json
+++ b/solutions/cncf-install/install-konveyor.json
@@ -5,86 +5,73 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Konveyor on Kubernetes",
-    "description": "Konveyor is an open-source project that provides tools for developers and platform teams to analyze and transform legacy applications for Kubernetes and cloud-native technologies. Installing the Konveyor Operator allows you to manage the deployment and lifecycle of Konveyor on your Kubernetes cluster.",
+    "title": "Install Konveyor (Tackle) on Kubernetes",
+    "description": "Konveyor is an open-source application modernization platform that helps developers and platform teams analyze, assess, and transform legacy applications for Kubernetes. The Tackle toolkit is deployed via the tackle2-operator, which manages the lifecycle of Konveyor components including the Hub API, UI, and analysis engines.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Add the Konveyor Helm repository",
-        "description": "Add the Konveyor Helm repository to your local Helm configuration to access the Konveyor charts.\n```bash\nhelm repo add konveyor https://move2kube.konveyor.io\nhelm repo update\n```"
+        "title": "Install OLM (prerequisite)",
+        "description": "Konveyor's operator is distributed via OLM (Operator Lifecycle Manager). If OLM is not already installed on your cluster (it is pre-installed on OpenShift):\n```bash\ncurl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/install.sh | bash -s v0.28.0\n```\nVerify OLM is running:\n```bash\nkubectl get pods -n olm\n```"
       },
       {
         "title": "Install the Konveyor Operator",
-        "description": "Install the Konveyor Operator using Helm. This command will create a new namespace called `konveyor` and deploy the operator within it.\n```bash\nhelm install konveyor konveyor/konveyor --namespace konveyor --create-namespace --version v99.0.0\n```"
+        "description": "Apply the Konveyor operator manifest which creates the namespace, operator group, catalog source, and subscription:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml\n```\nThis creates the `konveyor-tackle` namespace and installs the operator via OLM."
+      },
+      {
+        "title": "Wait for the operator to be ready",
+        "description": "Wait for the operator pod to be running in the `konveyor-tackle` namespace:\n```bash\nkubectl wait --for=condition=Available --timeout=300s deployment/tackle-operator -n konveyor-tackle\n```\nOr check manually:\n```bash\nkubectl get pods -n konveyor-tackle\n```"
+      },
+      {
+        "title": "Create the Tackle custom resource",
+        "description": "Create a Tackle CR to trigger the deployment of all Konveyor components (Hub, UI, Pathfinder, Keycloak, PostgreSQL):\n```yaml\napiVersion: tackle.konveyor.io/v1alpha1\nkind: Tackle\nmetadata:\n  name: tackle\n  namespace: konveyor-tackle\nspec: {}\n```\nApply it:\n```bash\nkubectl apply -f - <<EOF\napiVersion: tackle.konveyor.io/v1alpha1\nkind: Tackle\nmetadata:\n  name: tackle\n  namespace: konveyor-tackle\nspec: {}\nEOF\n```"
       },
       {
         "title": "Verify the installation",
-        "description": "Check that the Konveyor Operator pod is running successfully in the `konveyor` namespace.\n```bash\nkubectl get pods --namespace konveyor\n```"
-      },
-      {
-        "title": "Post-install configuration",
-        "description": "Configure resource limits for the Konveyor Operator to ensure it has adequate resources. Edit the Helm release to set resource limits.\n```bash\nhelm upgrade konveyor konveyor/konveyor --namespace konveyor --set resources.limits.cpu=500m --set resources.limits.memory=512Mi\n```"
-      },
-      {
-        "title": "Set up Ingress (optional)",
-        "description": "If you want to expose the Konveyor UI, set up Ingress by creating an Ingress resource. Replace `<your-domain>` with your actual domain.\n```yaml\napiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: konveyor-ingress\n  namespace: konveyor\nspec:\n  rules:\n  - host: <your-domain>\n    http:\n      paths:\n      - path: /\n        pathType: Prefix\n        backend:\n          service:\n            name: konveyor-ui\n            port:\n              number: 80\n```\nApply the Ingress resource:\n```bash\nkubectl apply -f konveyor-ingress.yaml\n```"
+        "description": "Wait for all Konveyor components to be running (this may take several minutes as images are pulled):\n```bash\nkubectl get pods -n konveyor-tackle\n```\nYou should see pods for: tackle-hub, tackle-ui, tackle-keycloak, tackle-postgresql, and the operator.\n\nAccess the UI via port-forward:\n```bash\nkubectl port-forward svc/tackle-ui -n konveyor-tackle 8080:8080\n```\nThen open http://localhost:8080 in your browser."
       }
     ],
     "resolution": {
-      "summary": "A successful installation will show the Konveyor Operator pod running in the `konveyor` namespace. You can access the Konveyor UI through the configured Ingress if set up.",
+      "summary": "A successful installation will show all Konveyor (Tackle) pods running in the konveyor-tackle namespace. The UI is accessible via port-forward on port 8080. Default credentials are admin/password (from Keycloak).",
       "codeSnippets": [
-        "helm repo add konveyor https://move2kube.konveyor.io\nhelm repo update",
-        "helm install konveyor konveyor/konveyor --namespace konveyor --create-namespace --version v99.0.0",
-        "kubectl get pods --namespace konveyor",
-        "helm upgrade konveyor konveyor/konveyor --namespace konveyor --set resources.limits.cpu=500m --set resources.limits.memory=512Mi",
-        "apiVersion: networking.k8s.io/v1\nkind: Ingress\nmetadata:\n  name: konveyor-ingress\n  namespace: konveyor\nspec:\n  rules:\n  - host: <your-domain>\n    http:\n      paths:\n      - path: /\n        pathType: Prefix\n        backend:\n          service:\n            name: konveyor-ui\n            port:\n              number: 80"
+        "kubectl apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml",
+        "kubectl apply -f - <<EOF\napiVersion: tackle.konveyor.io/v1alpha1\nkind: Tackle\nmetadata:\n  name: tackle\n  namespace: konveyor-tackle\nspec: {}\nEOF",
+        "kubectl get pods -n konveyor-tackle",
+        "kubectl port-forward svc/tackle-ui -n konveyor-tackle 8080:8080"
       ]
     },
     "uninstall": [
       {
-        "title": "Remove the Helm release",
-        "description": "Uninstall the Konveyor Operator release from your Kubernetes cluster using Helm. This will remove the deployment and associated resources from the `konveyor` namespace.\n```bash\nhelm uninstall konveyor --namespace konveyor\n```"
+        "title": "Delete the Tackle CR",
+        "description": "Remove the Tackle custom resource which will clean up all managed components:\n```bash\nkubectl delete tackle tackle -n konveyor-tackle\n```"
       },
       {
-        "title": "Clean up CRDs and persistent resources",
-        "description": "Delete any Custom Resource Definitions (CRDs) and persistent volume claims (PVCs) that were created during the installation. This ensures that all resources are cleaned up.\n```bash\nkubectl delete crd $(kubectl get crd | grep konveyor | awk '{print $1}')\nkubectl delete pvc --all --namespace konveyor\n```"
-      },
-      {
-        "title": "Remove namespace and verify",
-        "description": "Delete the `konveyor` namespace to remove any remaining resources and verify that it has been successfully deleted.\n```bash\nkubectl delete namespace konveyor\nkubectl get namespaces\n```"
+        "title": "Remove the operator and namespace",
+        "description": "Delete the operator subscription and namespace:\n```bash\nkubectl delete -f https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml\n```\nClean up any remaining CRDs:\n```bash\nkubectl delete crd $(kubectl get crd | grep konveyor | awk '{print $1}')\nkubectl delete crd $(kubectl get crd | grep tackle | awk '{print $1}')\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Backup current state",
-        "description": "Before upgrading, back up the current state of your Konveyor installation. This can be done by exporting the current configuration and resources.\n```bash\nkubectl get all --namespace konveyor -o yaml > konveyor-backup.yaml\n```"
-      },
-      {
-        "title": "Update repo and run upgrade command",
-        "description": "Update the Helm repository and upgrade the Konveyor Operator to the latest version. Ensure you specify the correct version.\n```bash\nhelm repo update\nhelm upgrade konveyor konveyor/konveyor --namespace konveyor --version v99.1.0\n```"
-      },
-      {
-        "title": "Verify the upgrade",
-        "description": "Check that the Konveyor Operator pod is running successfully after the upgrade. Ensure that the version is updated.\n```bash\nkubectl get pods --namespace konveyor\nkubectl describe deployment konveyor --namespace konveyor | grep Image\n```"
+        "title": "Upgrade via OLM",
+        "description": "OLM handles operator upgrades automatically via the subscription. To check the current version:\n```bash\nkubectl get csv -n konveyor-tackle\n```\nTo trigger a manual upgrade, update the subscription channel or approve a pending install plan:\n```bash\nkubectl get installplan -n konveyor-tackle\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods stuck in CrashLoopBackOff",
-        "description": "If the Konveyor Operator pods are in a CrashLoopBackOff state, check the logs for errors. This may indicate a misconfiguration or resource issue.\n```bash\nkubectl logs <pod-name> --namespace konveyor\n```"
+        "title": "OLM not installed",
+        "description": "If you see errors about missing CatalogSource or Subscription resources, OLM is not installed. Install it first:\n```bash\ncurl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/install.sh | bash -s v0.28.0\n```"
       },
       {
-        "title": "Ingress not reachable",
-        "description": "If the Ingress resource is not reachable, verify the Ingress configuration and check the service endpoints. Ensure that the Ingress controller is running.\n```bash\nkubectl describe ingress konveyor-ingress --namespace konveyor\nkubectl get svc --namespace konveyor\n```"
+        "title": "Pods stuck in Pending",
+        "description": "Konveyor requires significant resources. If pods are stuck in Pending:\n```bash\nkubectl describe pod <pod-name> -n konveyor-tackle\n```\nCheck for insufficient CPU/memory or missing PVCs. Ensure your cluster has a default StorageClass for PostgreSQL."
       },
       {
-        "title": "Resource limits causing OOMKilled",
-        "description": "If pods are being killed due to out-of-memory (OOM) errors, check the resource limits set for the Konveyor Operator and adjust them accordingly.\n```bash\nkubectl describe pod <pod-name> --namespace konveyor | grep -i oom\n```"
+        "title": "Tackle CR not reconciling",
+        "description": "If creating the Tackle CR doesn't spawn any pods, check the operator logs:\n```bash\nkubectl logs -n konveyor-tackle deployment/tackle-operator\n```\nEnsure the operator pod is running and the Tackle CRD exists:\n```bash\nkubectl get crd | grep tackle\n```"
       },
       {
-        "title": "Helm upgrade fails with version conflict",
-        "description": "If the Helm upgrade fails due to a version conflict, ensure that the specified version is available in the Helm repository and that there are no pending changes.\n```bash\nhelm search repo konveyor/konveyor --versions\n```"
+        "title": "UI not accessible",
+        "description": "If the UI is not loading after port-forward:\n1. Verify the tackle-ui pod is running\n2. Check the service exists: `kubectl get svc tackle-ui -n konveyor-tackle`\n3. Check UI pod logs: `kubectl logs -n konveyor-tackle -l app.kubernetes.io/name=tackle-ui`"
       }
     ]
   },
@@ -100,9 +87,10 @@
       "konveyor"
     ],
     "targetResourceKinds": [
+      "Deployment",
       "Service",
       "Namespace",
-      "Ingress"
+      "Subscription"
     ],
     "difficulty": "intermediate",
     "issueTypes": [
@@ -110,34 +98,28 @@
       "configuration"
     ],
     "installMethods": [
-      "helm"
+      "olm",
+      "kubectl"
     ],
     "maturity": "sandbox",
-    "projectVersion": "v0.9.0",
-    "containerImages": [
-      "quay.io/konveyor/tackle2-operator:v99.0.0",
-      "quay.io/openshift/origin-oauth-proxy:latest",
-      "quay.io/sclorg/postgresql-15-c9s:latest",
-      "quay.io/keycloak/keycloak:26.1"
-    ],
+    "projectVersion": "latest",
+    "containerImages": [],
     "sourceUrls": {
       "docs": "https://konveyor.io",
-      "repo": "https://github.com/konveyor/operator",
-      "helm": "https://move2kube.konveyor.io"
+      "repo": "https://github.com/konveyor/tackle2-operator"
     },
     "qualityScore": 100
   },
   "prerequisites": {
     "kubernetes": ">=1.22",
     "tools": [
-      "helm",
       "kubectl"
     ],
-    "description": "Ensure you have a Kubernetes cluster running with OLM and Ingress support."
+    "description": "Kubernetes 1.22+ cluster with OLM installed (pre-installed on OpenShift). A default StorageClass is required for PostgreSQL persistence. kubectl must be configured to access your cluster with cluster-admin permissions."
   },
   "security": {
-    "scannedAt": "2026-03-01T17:22:43.695Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-kuadrant.json
+++ b/solutions/cncf-install/install-kuadrant.json
@@ -5,82 +5,86 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Kuadrant on Kubernetes",
-    "description": "Kuadrant is an operator that manages the lifecycle of Kuadrant components, enhancing gateway providers with features like TLS, DNS, application authentication, and rate limiting. Installing Kuadrant allows you to leverage these capabilities in your Kubernetes environment.",
+    "title": "Install Kuadrant on Kubernetes",
+    "description": "Kuadrant is a Kubernetes operator that enhances Gateway API providers (Istio or Envoy Gateway) with policy capabilities including TLS management, DNS routing, application authentication (AuthPolicy), and rate limiting (RateLimitPolicy). The Kuadrant operator is installed via Helm and requires Gateway API CRDs, cert-manager, and a gateway provider as prerequisites.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Add the Kuadrant Helm repository",
-        "description": "Add the Kuadrant Helm chart repository to your Helm configuration with the following command:\n```bash\nhelm repo add kuadrant https://kuadrant.io/helm-charts/\nhelm repo update\n```"
+        "title": "Install Gateway API CRDs (prerequisite)",
+        "description": "Kuadrant requires Gateway API CRDs to be installed on your cluster:\n```bash\nkubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml\n```"
       },
       {
-        "title": "Install the Kuadrant Operator",
-        "description": "Install the Kuadrant Operator in a new namespace called 'kuadrant' using the following command:\n```bash\nhelm install kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant --create-namespace --version v1.4.1\n```"
+        "title": "Install cert-manager (prerequisite)",
+        "description": "Kuadrant requires cert-manager for TLS certificate management:\n```bash\nkubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml\nkubectl wait --for=condition=Available --timeout=120s deployment/cert-manager -n cert-manager\nkubectl wait --for=condition=Available --timeout=120s deployment/cert-manager-webhook -n cert-manager\n```"
+      },
+      {
+        "title": "Install a Gateway provider (prerequisite)",
+        "description": "Kuadrant works with either Istio or Envoy Gateway. Install one of them:\n\n**Option A — Istio:**\n```bash\ncurl -L https://istio.io/downloadIstio | sh -\nistioctl install --set profile=minimal -y\n```\n\n**Option B — Envoy Gateway:**\n```bash\nhelm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.2.6 -n envoy-gateway-system --create-namespace\n```"
+      },
+      {
+        "title": "Install the Kuadrant Operator via Helm",
+        "description": "Add the Kuadrant Helm repository and install the operator:\n```bash\nhelm repo add kuadrant https://kuadrant.io/helm-charts/\nhelm repo update\nhelm install kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant-system --create-namespace --version v1.4.1\n```\nWait for the operator to be ready:\n```bash\nkubectl wait --for=condition=Available --timeout=120s deployment/kuadrant-operator-controller-manager -n kuadrant-system\n```"
+      },
+      {
+        "title": "Create the Kuadrant custom resource",
+        "description": "Create a Kuadrant CR to activate the operator's reconciliation of policy resources:\n```bash\nkubectl apply -f - <<EOF\napiVersion: kuadrant.io/v1beta1\nkind: Kuadrant\nmetadata:\n  name: kuadrant\n  namespace: kuadrant-system\nspec: {}\nEOF\n```\nVerify the Kuadrant CR is ready:\n```bash\nkubectl get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions}' | jq .\n```"
       },
       {
         "title": "Verify the installation",
-        "description": "Check that the Kuadrant Operator pod is running with the following command:\n```bash\nkubectl get pods --namespace kuadrant\n```"
-      },
-      {
-        "title": "Post-install configuration",
-        "description": "To configure resource limits for the Kuadrant Operator, you can edit the deployment with the following command:\n```bash\nkubectl edit deployment kuadrant-operator --namespace kuadrant\n```\nAdd the following resource limits under the containers section:\n```yaml\nresources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\"\n```"
+        "description": "Check that all Kuadrant components are running:\n```bash\nkubectl get pods -n kuadrant-system\n```\nYou should see the Kuadrant operator controller manager and Limitador (rate limiting) pods running.\n\nVerify the CRDs were installed:\n```bash\nkubectl get crd | grep kuadrant\n```\nYou should see AuthPolicy, RateLimitPolicy, DNSPolicy, TLSPolicy, and Kuadrant CRDs."
       }
     ],
     "resolution": {
-      "summary": "A successful installation will have the Kuadrant Operator running in the 'kuadrant' namespace, with its pod status showing as 'Running'. You can further configure it as needed.",
+      "summary": "A successful installation will have the Kuadrant operator and Limitador pods running in the kuadrant-system namespace. The Kuadrant CR should show ready status. You can now create AuthPolicy, RateLimitPolicy, DNSPolicy, and TLSPolicy resources targeting your Gateway API HTTPRoutes and Gateways.",
       "codeSnippets": [
         "helm repo add kuadrant https://kuadrant.io/helm-charts/\nhelm repo update",
-        "helm install kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant --create-namespace --version v1.4.1",
-        "kubectl get pods --namespace kuadrant",
-        "kubectl edit deployment kuadrant-operator --namespace kuadrant",
-        "resources:\n  limits:\n    cpu: \"500m\"\n    memory: \"512Mi\"\n  requests:\n    cpu: \"250m\"\n    memory: \"256Mi\""
+        "helm install kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant-system --create-namespace --version v1.4.1",
+        "kubectl apply -f - <<EOF\napiVersion: kuadrant.io/v1beta1\nkind: Kuadrant\nmetadata:\n  name: kuadrant\n  namespace: kuadrant-system\nspec: {}\nEOF",
+        "kubectl get pods -n kuadrant-system",
+        "kubectl get crd | grep kuadrant"
       ]
     },
     "uninstall": [
       {
+        "title": "Delete the Kuadrant CR",
+        "description": "Remove the Kuadrant custom resource first:\n```bash\nkubectl delete kuadrant kuadrant -n kuadrant-system\n```"
+      },
+      {
         "title": "Remove the Helm release",
-        "description": "Uninstall the Kuadrant Operator release using Helm with the following command:\n```bash\nhelm uninstall kuadrant-operator --namespace kuadrant\n```"
+        "description": "Uninstall the Kuadrant operator Helm release:\n```bash\nhelm uninstall kuadrant-operator -n kuadrant-system\n```"
       },
       {
-        "title": "Clean up CRDs and persistent resources",
-        "description": "Remove any Custom Resource Definitions (CRDs) created by the Kuadrant Operator with the following command:\n```bash\nkubectl delete crd kuadrant*.kuadrant.io\n```"
-      },
-      {
-        "title": "Remove namespace and verify",
-        "description": "Delete the 'kuadrant' namespace and verify its removal with the following commands:\n```bash\nkubectl delete namespace kuadrant\nkubectl get namespaces\n```"
+        "title": "Clean up CRDs and namespace",
+        "description": "Remove Kuadrant CRDs and the namespace:\n```bash\nkubectl delete crd $(kubectl get crd | grep kuadrant | awk '{print $1}')\nkubectl delete namespace kuadrant-system\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Backup current state",
-        "description": "Before upgrading, back up the current state of the Kuadrant Operator with the following command:\n```bash\nkubectl get all --namespace kuadrant -o yaml > kuadrant-backup.yaml\n```"
-      },
-      {
-        "title": "Update repo and run upgrade command",
-        "description": "Update the Helm repository and upgrade the Kuadrant Operator to the latest version with the following commands:\n```bash\nhelm repo update\nhelm upgrade kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant --version v1.5.0\n```"
+        "title": "Upgrade via Helm",
+        "description": "Update the Helm repo and upgrade to a new version:\n```bash\nhelm repo update\nhelm upgrade kuadrant-operator kuadrant/kuadrant-operator --namespace kuadrant-system --version <new-version>\n```"
       },
       {
         "title": "Verify the upgrade",
-        "description": "Check that the Kuadrant Operator pod is running the new version with the following command:\n```bash\nkubectl get pods --namespace kuadrant\n```"
+        "description": "Check that the operator pod is running the new version:\n```bash\nkubectl get pods -n kuadrant-system\nkubectl describe deployment kuadrant-operator-controller-manager -n kuadrant-system | grep Image\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods stuck in CrashLoopBackOff",
-        "description": "If the Kuadrant Operator pod is in a CrashLoopBackOff state, check the logs for errors with the following command:\n```bash\nkubectl logs <pod-name> --namespace kuadrant\n```"
+        "title": "Operator pod in CrashLoopBackOff",
+        "description": "Check the operator logs for errors:\n```bash\nkubectl logs -n kuadrant-system deployment/kuadrant-operator-controller-manager\n```\nCommon causes: missing Gateway API CRDs, missing cert-manager, or no gateway provider (Istio/Envoy Gateway) installed."
       },
       {
-        "title": "Helm upgrade fails with version conflict",
-        "description": "If you encounter a version conflict during the Helm upgrade, check the installed version with:\n```bash\nhelm list --namespace kuadrant\n```\nThen ensure the version you are upgrading to is compatible."
+        "title": "Kuadrant CR not becoming ready",
+        "description": "Check the Kuadrant CR status:\n```bash\nkubectl get kuadrant kuadrant -n kuadrant-system -o yaml\n```\nEnsure all prerequisites are installed and the operator pod is running."
       },
       {
-        "title": "CRDs not found after upgrade",
-        "description": "If the CRDs are not found after an upgrade, ensure they are still installed with:\n```bash\nkubectl get crd --namespace kuadrant\n```"
+        "title": "RateLimitPolicy not enforcing",
+        "description": "If rate limiting is not working:\n1. Check Limitador pod is running: `kubectl get pods -n kuadrant-system -l app=limitador`\n2. Verify the RateLimitPolicy targets a valid HTTPRoute: `kubectl get ratelimitpolicy -A`\n3. Check operator logs for reconciliation errors"
       },
       {
-        "title": "Resource limits not applied",
-        "description": "If the resource limits are not applied as expected, check the deployment configuration with:\n```bash\nkubectl get deployment kuadrant-operator --namespace kuadrant -o yaml\n```"
+        "title": "Gateway API CRDs missing",
+        "description": "If the operator shows errors about missing resources:\n```bash\nkubectl get crd | grep gateway\n```\nInstall Gateway API CRDs: `kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml`"
       }
     ]
   },
@@ -89,7 +93,7 @@
       "installation",
       "configuration",
       "cncf",
-      "app-definition",
+      "networking",
       "sandbox"
     ],
     "cncfProjects": [
@@ -97,9 +101,12 @@
     ],
     "targetResourceKinds": [
       "Deployment",
-      "Namespace"
+      "Namespace",
+      "Kuadrant",
+      "AuthPolicy",
+      "RateLimitPolicy"
     ],
-    "difficulty": "beginner",
+    "difficulty": "intermediate",
     "issueTypes": [
       "installation",
       "configuration"
@@ -109,13 +116,11 @@
     ],
     "maturity": "sandbox",
     "projectVersion": "v1.4.1",
-    "containerImages": [
-      "registry/org/image:tag"
-    ],
+    "containerImages": [],
     "sourceUrls": {
       "docs": "https://kuadrant.io",
       "repo": "https://github.com/kuadrant/kuadrant-operator",
-      "helm": "https://github.com/kuadrant/kuadrant-operator/tree/main/charts/kuadrant-operator/"
+      "helm": "https://kuadrant.io/helm-charts/"
     },
     "qualityScore": 100
   },
@@ -125,11 +130,11 @@
       "helm",
       "kubectl"
     ],
-    "description": "Ensure you have a Kubernetes cluster running and have installed Helm and kubectl."
+    "description": "Kubernetes 1.24+ cluster with: Gateway API CRDs installed, cert-manager running, and a gateway provider (Istio or Envoy Gateway) deployed. Helm 3 and kubectl must be configured to access your cluster."
   },
   "security": {
-    "scannedAt": "2026-03-01T17:34:58.632Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-kubeclipper.json
+++ b/solutions/cncf-install/install-kubeclipper.json
@@ -5,52 +5,60 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Kubeclipper on Kubernetes",
-    "description": "KubeClipper is a lightweight web service that provides a user-friendly web console, APIs, and CLI tools for managing Kubernetes clusters. Installing KubeClipper allows you to efficiently deploy and manage Kubernetes clusters across various environments.",
+    "title": "Install KubeClipper on Linux Nodes",
+    "description": "KubeClipper is a lightweight web service that provides a friendly web console, APIs, and CLI tools for Kubernetes cluster lifecycle management. It uses the kcctl CLI to deploy components via SSH to your nodes. KubeClipper supports deploying and managing multiple Kubernetes clusters across bare-metal and VM environments.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Create a Namespace for KubeClipper",
-        "description": "First, create a dedicated namespace for KubeClipper to isolate its resources."
+        "title": "Install kcctl CLI",
+        "description": "Download and install the kcctl command-line tool on your management machine:\n```bash\ncurl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | KC_REGION=en bash -\n```\nVerify the installation:\n```bash\nkcctl version\n```"
       },
       {
-        "title": "Deploy KubeClipper Components",
-        "description": "Apply the KubeClipper manifests to deploy the necessary components."
+        "title": "Deploy KubeClipper (All-in-One)",
+        "description": "For a quick single-node deployment, use the AIO (All-in-One) mode. This installs etcd, kc-server, and kc-agent on the same node:\n```bash\nkcctl deploy\n```\nThis command will prompt for your node's SSH credentials and deploy all KubeClipper components. By default, the web console will be available on port 80.\n\nFor a multi-node deployment, specify server and agent nodes explicitly:\n```bash\nkcctl deploy --server <server-ip> --agent <agent-ip1>,<agent-ip2> --pk-file ~/.ssh/id_rsa\n```"
       },
       {
-        "title": "Verify the Installation",
-        "description": "Check if the KubeClipper pods are running successfully."
+        "title": "Access the web console",
+        "description": "After deployment completes, access the KubeClipper web console in your browser:\n```\nhttp://<server-ip>\n```\nDefault credentials:\n- Username: `admin`\n- Password: `Thinkbig1`\n\nChange the default password after your first login."
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that all KubeClipper components are running:\n```bash\nkcctl get node\nkcctl get component\n```\nYou should see your server and agent nodes listed with a 'Running' status."
       }
     ],
     "resolution": {
-      "summary": "A successful installation of KubeClipper will show the KubeClipper pods running in the 'kubeclipper' namespace. You can access the web console by navigating to http://localhost:8080 in your web browser.",
-      "codeSnippets": []
+      "summary": "A successful installation will show all KubeClipper components running via `kcctl get component`. The web console will be accessible at http://<server-ip> with the default admin credentials. You can then use the console or kcctl CLI to create and manage Kubernetes clusters.",
+      "codeSnippets": [
+        "curl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | KC_REGION=en bash -",
+        "kcctl deploy",
+        "kcctl get node\nkcctl get component"
+      ]
     },
     "uninstall": [
       {
-        "title": "Remove KubeClipper",
-        "description": "To uninstall KubeClipper, delete the namespace and all associated resources."
+        "title": "Clean up KubeClipper",
+        "description": "Remove all KubeClipper components from your nodes using kcctl:\n```bash\nkcctl clean --all\n```\nThis removes etcd, kc-server, kc-agent, and all associated data from the deployed nodes."
       }
     ],
     "upgrade": [
       {
         "title": "Upgrade KubeClipper",
-        "description": "To upgrade KubeClipper, apply the new version of the manifests. Make sure to check for breaking changes in the release notes."
+        "description": "Download the latest kcctl CLI and run the upgrade command:\n```bash\ncurl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | KC_REGION=en bash -\nkcctl upgrade\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods Not Starting",
-        "description": "If the KubeClipper pods are not starting, check the events in the namespace for errors."
+        "title": "SSH connection failed during deploy",
+        "description": "If kcctl deploy fails with SSH errors, ensure:\n1. SSH access is configured (key-based or password) between the management machine and target nodes\n2. The target user has sudo privileges\n3. The SSH port (default 22) is open\n```bash\nssh <user>@<node-ip> 'sudo whoami'\n```"
       },
       {
-        "title": "Service Not Accessible",
-        "description": "If you cannot access the KubeClipper web console, ensure that the service is correctly configured and check the service endpoints."
+        "title": "Web console not accessible",
+        "description": "If you cannot access the web console:\n1. Check that kc-server is running: `kcctl get component`\n2. Verify port 80 is not blocked by a firewall\n3. Check kc-server logs for errors"
       },
       {
-        "title": "Insufficient Resources",
-        "description": "If pods are in a pending state, verify that your cluster has sufficient resources (CPU, memory) available."
+        "title": "Node not joining",
+        "description": "If an agent node is not appearing in `kcctl get node`:\n1. Verify the agent is running on the target node\n2. Check network connectivity between agent and server nodes\n3. Ensure the node meets minimum requirements: 2 CPU cores, 2GB RAM"
       }
     ]
   },
@@ -70,20 +78,17 @@
       "Service",
       "Namespace"
     ],
-    "difficulty": "beginner",
+    "difficulty": "intermediate",
     "issueTypes": [
       "installation",
       "configuration"
     ],
     "installMethods": [
-      "kubectl"
+      "cli"
     ],
     "maturity": "sandbox",
     "projectVersion": "v1.4.1",
-    "containerImages": [
-      "kubeclipper/kc-server:v0.0.1",
-      "kubeclipper/kcctl-docs:latest"
-    ],
+    "containerImages": [],
     "sourceUrls": {
       "docs": "https://kubeclipper.io",
       "repo": "https://github.com/kubeclipper/kubeclipper"
@@ -91,15 +96,16 @@
     "qualityScore": 100
   },
   "prerequisites": {
-    "kubernetes": ">=1.24",
+    "kubernetes": "none",
     "tools": [
-      "kubectl"
+      "curl",
+      "ssh"
     ],
-    "description": "Ensure you have a running Kubernetes cluster and kubectl installed and configured to interact with your cluster."
+    "description": "KubeClipper deploys to Linux nodes (not into an existing Kubernetes cluster). You need: Linux nodes with SSH access, sudo privileges, 2+ CPU cores, 2+ GB RAM per node, and curl installed on the management machine."
   },
   "security": {
-    "scannedAt": "2026-03-01T18:25:29.378Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-network-service-mesh.json
+++ b/solutions/cncf-install/install-network-service-mesh.json
@@ -5,54 +5,75 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Network Service Mesh on Kubernetes",
-    "description": "Network Service Mesh provides a way to manage and connect network services in a Kubernetes environment. Installing it allows you to leverage its capabilities for service connectivity and management.",
+    "title": "Install Network Service Mesh on Kubernetes",
+    "description": "Network Service Mesh (NSM) is a hybrid/multi-cloud IP service mesh that provides advanced L2/L3 networking capabilities to Kubernetes pods. NSM uses SPIRE for workload identity and provides secure, zero-trust network connections between workloads. It is deployed via kustomize overlays from the deployments-k8s repository.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Create Namespace",
-        "description": "Create a dedicated namespace for Network Service Mesh."
+        "title": "Install SPIRE (prerequisite)",
+        "description": "NSM requires SPIRE for workload identity. Deploy SPIRE for a single-cluster setup using the NSM-provided kustomize overlay:\n```bash\nkubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire/single_cluster?ref=main\n```\nWait for SPIRE pods to be ready:\n```bash\nkubectl wait --for=condition=ready pod -l app=spire-server -n spire --timeout=120s\nkubectl wait --for=condition=ready pod -l app=spire-agent -n spire --timeout=120s\n```"
       },
       {
-        "title": "Install Network Service Mesh Components",
-        "description": "Apply the necessary manifests to install Network Service Mesh."
+        "title": "Deploy NSM core components",
+        "description": "Install the NSM core infrastructure (nsmgr, registry, forwarder) using the basic example overlay:\n```bash\nkubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=main\n```\nThis deploys the NSM manager (nsmgr) DaemonSet, the registry, and the kernel forwarder into the `nsm-system` namespace."
       },
       {
-        "title": "Verify Installation",
-        "description": "Check if the Network Service Mesh pods are running successfully."
+        "title": "Verify the installation",
+        "description": "Check that all NSM components are running in the nsm-system namespace:\n```bash\nkubectl get pods -n nsm-system\n```\nYou should see:\n- `nsmgr-*` pods (DaemonSet, one per node) — the NSM manager\n- `registry-*` — the NSM registry\n- `forwarder-*` pods — kernel forwarders for dataplane connectivity\n\nAlso verify SPIRE is running:\n```bash\nkubectl get pods -n spire\n```"
+      },
+      {
+        "title": "Test with a sample application (optional)",
+        "description": "Deploy a simple NSM client-server example to verify end-to-end connectivity:\n```bash\nkubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/use-cases/Kernel2Kernel?ref=main\n```\nVerify the client got a network service connection:\n```bash\nkubectl wait --for=condition=ready pod -l app=nsc-kernel --timeout=120s\nkubectl exec $(kubectl get pod -l app=nsc-kernel -o name) -- ping -c 3 172.16.1.100\n```"
       }
     ],
+    "resolution": {
+      "summary": "A successful installation will show nsmgr, registry, and forwarder pods running in the nsm-system namespace, and SPIRE pods running in the spire namespace. You can verify connectivity by deploying a Kernel2Kernel example and confirming ping works between NSM-connected pods.",
+      "codeSnippets": [
+        "kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/spire/single_cluster?ref=main",
+        "kubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=main",
+        "kubectl get pods -n nsm-system",
+        "kubectl get pods -n spire"
+      ]
+    },
     "uninstall": [
       {
-        "title": "Remove Network Service Mesh",
-        "description": "Delete the Network Service Mesh components and namespace."
+        "title": "Remove NSM components",
+        "description": "Delete the NSM mutating webhook and namespace:\n```bash\nkubectl delete mutatingwebhookconfiguration nsm-mutating-webhook\nkubectl delete ns nsm-system\n```"
+      },
+      {
+        "title": "Remove SPIRE",
+        "description": "Delete the SPIRE components:\n```bash\nkubectl delete ns spire\n```"
+      },
+      {
+        "title": "Clean up CRDs",
+        "description": "Remove any NSM CRDs if present:\n```bash\nkubectl delete crd $(kubectl get crd | grep networkservicemesh | awk '{print $1}')\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Upgrade Network Service Mesh",
-        "description": "To upgrade Network Service Mesh, apply the new version manifests."
+        "title": "Upgrade NSM",
+        "description": "Update the kustomize ref to the desired version tag and re-apply:\n```bash\nkubectl apply -k https://github.com/networkservicemesh/deployments-k8s/examples/basic?ref=<new-version>\n```\nNote: Check the NSM releases page for available versions."
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pod Not Running",
-        "description": "If any pods are not in 'Running' state, check the logs for errors."
+        "title": "SPIRE agent not ready",
+        "description": "NSM components depend on SPIRE for identity. If nsmgr pods are crashing, check SPIRE first:\n```bash\nkubectl get pods -n spire\nkubectl logs -n spire -l app=spire-agent\n```\nEnsure the SPIRE server and agent are both running before deploying NSM."
       },
       {
-        "title": "Resource Quotas",
-        "description": "Ensure that your cluster has enough resources (CPU, Memory) to run the pods."
+        "title": "nsmgr pods in CrashLoopBackOff",
+        "description": "Check the nsmgr logs for connection errors:\n```bash\nkubectl logs -n nsm-system -l app=nsmgr\n```\nCommon causes: SPIRE not running, insufficient RBAC permissions, or node resource constraints."
       },
       {
-        "title": "Network Policies",
-        "description": "Check if any network policies are blocking communication between the services."
+        "title": "Webhook blocking pod creation",
+        "description": "If pods are failing to create with webhook errors:\n```bash\nkubectl get mutatingwebhookconfiguration nsm-mutating-webhook -o yaml\n```\nThe NSM webhook injects sidecars. If NSM is not running properly, the webhook may block pod creation. As a workaround, delete the webhook: `kubectl delete mutatingwebhookconfiguration nsm-mutating-webhook`"
+      },
+      {
+        "title": "Network connectivity issues between NSM pods",
+        "description": "If the Kernel2Kernel example ping fails:\n1. Check forwarder pods are running: `kubectl get pods -n nsm-system -l app=forwarder`\n2. Check nsmgr logs for connection errors\n3. Verify no network policies are blocking traffic between nsm-system and application namespaces"
       }
-    ],
-    "resolution": {
-      "summary": "A successful installation of Network Service Mesh will have all pods running in the nsm-system namespace, and you will be able to manage network services effectively. You should also see no errors in the logs of the Network Service Mesh components.",
-      "codeSnippets": []
-    }
+    ]
   },
   "metadata": {
     "tags": [
@@ -66,24 +87,26 @@
       "network-service-mesh"
     ],
     "targetResourceKinds": [
+      "DaemonSet",
       "Deployment",
       "Service",
-      "Namespace"
+      "Namespace",
+      "MutatingWebhookConfiguration"
     ],
-    "difficulty": "intermediate",
+    "difficulty": "advanced",
     "issueTypes": [
       "installation",
       "configuration"
     ],
     "installMethods": [
-      "kubectl"
+      "kustomize"
     ],
     "maturity": "sandbox",
-    "projectVersion": "v1.16.0",
+    "projectVersion": "latest",
     "containerImages": [],
     "sourceUrls": {
-      "docs": "https://github.com/networkservicemesh/api",
-      "repo": "https://github.com/networkservicemesh/api"
+      "docs": "https://networkservicemesh.io",
+      "repo": "https://github.com/networkservicemesh/deployments-k8s"
     },
     "qualityScore": 100
   },
@@ -92,11 +115,11 @@
     "tools": [
       "kubectl"
     ],
-    "description": "Ensure you have a Kubernetes cluster running and kubectl configured to interact with it."
+    "description": "Kubernetes 1.24+ cluster with kubectl configured. SPIRE will be installed as part of this guide. Nodes need to support kernel-level networking for the forwarder. kubectl must support kustomize (built-in since kubectl 1.14)."
   },
   "security": {
-    "scannedAt": "2026-03-02T22:02:06.938Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-open-policy-agent-opa.json
+++ b/solutions/cncf-install/install-open-policy-agent-opa.json
@@ -1,105 +1,92 @@
 {
   "version": "kc-mission-v1",
-  "name": "install-open-policy-agent-opa-",
+  "name": "install-open-policy-agent-opa",
   "missionClass": "install",
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Open Policy Agent Opa- on Kubernetes",
-    "description": "Open Policy Agent (OPA) is an open-source, general-purpose policy engine that enables unified, context-aware policy enforcement across your stack. Installing OPA allows you to manage and enforce policies consistently in your Kubernetes environment.",
+    "title": "Install OPA Gatekeeper on Kubernetes",
+    "description": "OPA Gatekeeper is the recommended way to run Open Policy Agent on Kubernetes. It acts as a customizable admission webhook that enforces policies executed by OPA. Gatekeeper uses constraint templates and constraints to define and enforce policies at admission time.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Create a Namespace for OPA",
-        "description": "First, create a dedicated namespace for OPA to keep your resources organized. Run the following command:"
+        "title": "Install Gatekeeper via Helm",
+        "description": "Add the Gatekeeper Helm chart repository and install Gatekeeper into the gatekeeper-system namespace:\n```bash\nhelm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts\nhelm install gatekeeper/gatekeeper --name-template=gatekeeper --namespace gatekeeper-system --create-namespace\n```\nAlternatively, install via kubectl apply:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.21.1/deploy/gatekeeper.yaml\n```"
       },
       {
-        "title": "Deploy OPA",
-        "description": "Next, apply the OPA deployment manifest from the GitHub repository. Use the following command to deploy OPA version 0.41.0:"
+        "title": "Verify the installation",
+        "description": "Check that the Gatekeeper controller and audit pods are running:\n```bash\nkubectl get pods -n gatekeeper-system\n```\nYou should see gatekeeper-controller-manager and gatekeeper-audit pods in Running state."
       },
       {
-        "title": "Verify the Installation",
-        "description": "After deploying OPA, verify that the OPA pod is running by executing the following command:"
+        "title": "Create a constraint template",
+        "description": "Define a constraint template that specifies the policy logic in Rego. For example, to require all namespaces to have a specific label:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper-library/master/library/general/requiredlabels/template.yaml\n```\nVerify the template was created:\n```bash\nkubectl get constrainttemplates\n```"
+      },
+      {
+        "title": "Create a constraint",
+        "description": "Apply a constraint that uses the template to enforce the policy. For example, require all namespaces to have an 'owner' label:\n```yaml\napiVersion: constraints.gatekeeper.sh/v1beta1\nkind: K8sRequiredLabels\nmetadata:\n  name: ns-must-have-owner\nspec:\n  match:\n    kinds:\n      - apiGroups: [\"\"]\n        kinds: [\"Namespace\"]\n  parameters:\n    labels:\n      - key: owner\n```\nApply with `kubectl apply -f constraint.yaml` and verify:\n```bash\nkubectl get constraints\n```"
       }
     ],
     "resolution": {
-      "summary": "A successful installation of OPA will show the OPA pod running in your specified namespace. You can verify the configuration by checking the resource limits and RBAC settings applied to the OPA deployment.",
-      "codeSnippets": []
+      "summary": "A successful installation will have Gatekeeper pods running in the gatekeeper-system namespace. Constraint templates and constraints define your policies, which are enforced at admission time. Test by creating a resource that violates a constraint — it should be rejected.",
+      "codeSnippets": [
+        "helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts\nhelm install gatekeeper/gatekeeper --name-template=gatekeeper --namespace gatekeeper-system --create-namespace",
+        "kubectl get pods -n gatekeeper-system",
+        "kubectl get constrainttemplates\nkubectl get constraints"
+      ]
     },
     "uninstall": [
       {
-        "title": "Remove OPA",
-        "description": "To uninstall OPA, delete the deployment and the namespace with the following commands:"
+        "title": "Remove Gatekeeper via Helm",
+        "description": "Uninstall the Gatekeeper Helm release. Note: Helm v3 does not clean up CRDs automatically.\n```bash\nhelm uninstall gatekeeper -n gatekeeper-system\nkubectl delete crd -l gatekeeper.sh/system=yes\nkubectl delete ns gatekeeper-system\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Upgrade OPA",
-        "description": "To upgrade OPA to a newer version, first delete the existing deployment and then apply the new manifest. For example, to upgrade to version 0.42.0:"
+        "title": "Upgrade Gatekeeper",
+        "description": "Update the Helm repo and upgrade:\n```bash\nhelm repo update\nhelm upgrade gatekeeper gatekeeper/gatekeeper -n gatekeeper-system\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pod is Not Running",
-        "description": "If the OPA pod is not running, check the pod status with the following command and look for any errors:"
+        "title": "Webhook not enforcing policies",
+        "description": "Check that the validating webhook is registered:\n```bash\nkubectl get validatingwebhookconfigurations | grep gatekeeper\n```\nIf missing, the Gatekeeper controller may not be running."
       },
       {
-        "title": "Check Logs for Errors",
-        "description": "To view the logs of the OPA pod and diagnose issues, use the command below. Replace <pod-name> with the actual pod name:"
+        "title": "Constraint violations not blocking",
+        "description": "Verify the constraint is in enforcement mode (not dry-run):\n```bash\nkubectl get constraints -o yaml | grep enforcementAction\n```\nDefault is 'deny'. If set to 'dryrun' or 'warn', violations are logged but not blocked."
       },
       {
-        "title": "Resource Quotas and Limits",
-        "description": "Ensure that your cluster has enough resources (CPU and memory) allocated for the OPA pod. You can check resource availability with:"
+        "title": "Pods in CrashLoopBackOff",
+        "description": "Check Gatekeeper controller logs:\n```bash\nkubectl logs -n gatekeeper-system -l control-plane=controller-manager\n```"
       }
     ]
   },
   "metadata": {
-    "tags": [
-      "installation",
-      "configuration",
-      "cncf",
-      "security",
-      "graduated"
-    ],
-    "cncfProjects": [
-      "open-policy-agent-opa-"
-    ],
-    "targetResourceKinds": [
-      "Deployment",
-      "Service",
-      "Namespace",
-      "Serviceaccount"
-    ],
+    "tags": ["installation", "configuration", "cncf", "security", "graduated"],
+    "cncfProjects": ["open-policy-agent-opa"],
+    "targetResourceKinds": ["Namespace", "ConstraintTemplate"],
     "difficulty": "intermediate",
-    "issueTypes": [
-      "installation",
-      "configuration"
-    ],
-    "installMethods": [
-      "kubectl"
-    ],
+    "issueTypes": ["installation", "configuration"],
+    "installMethods": ["helm", "kubectl"],
     "maturity": "graduated",
-    "projectVersion": "v1.14.0",
-    "containerImages": [
-      "openpolicyagent/opa:v1.14.0"
-    ],
+    "projectVersion": "v3.21.1",
+    "containerImages": ["openpolicyagent/gatekeeper:v3.21.1"],
     "sourceUrls": {
-      "docs": "https://www.openpolicyagent.org",
-      "repo": "https://github.com/open-policy-agent/opa"
+      "docs": "https://open-policy-agent.github.io/gatekeeper/website/docs/install/",
+      "repo": "https://github.com/open-policy-agent/gatekeeper",
+      "helm": "https://open-policy-agent.github.io/gatekeeper/charts"
     },
     "qualityScore": 100
   },
   "prerequisites": {
-    "kubernetes": ">=1.24",
-    "tools": [
-      "kubectl"
-    ],
-    "description": "Ensure you have a running Kubernetes cluster and kubectl installed and configured to interact with it."
+    "kubernetes": ">=1.16",
+    "tools": ["helm", "kubectl"],
+    "description": "Kubernetes 1.16+ with cluster-admin permissions. Helm 3 and kubectl configured to access your cluster."
   },
   "security": {
-    "scannedAt": "2026-02-28T23:16:06.395Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }

--- a/solutions/cncf-install/install-tokenetes.json
+++ b/solutions/cncf-install/install-tokenetes.json
@@ -12,15 +12,19 @@
     "steps": [
       {
         "title": "Install tconfigd (prerequisite)",
-        "description": "Tokenetes requires tconfigd to be installed first. tconfigd manages Transaction Token (TraT) configurations as Kubernetes custom resources. Follow the tconfigd installation instructions from the Tokenetes documentation:\n```bash\n# Clone the tokenetes repository\ngit clone https://github.com/tokenetes/tokenetes.git\ncd tokenetes\n```\nRefer to the [tconfigd documentation](https://tokenetes.io/docs) for detailed setup instructions, as tconfigd must be running in the `tokenetes-system` namespace before deploying the Tokenetes service."
+        "description": "Tokenetes requires tconfigd to be installed first. tconfigd manages Transaction Token (TraT) configurations as Kubernetes custom resources. Clone and install from the separate tconfigd repository:\n```bash\ngit clone https://github.com/tokenetes/tconfigd.git\ncd tconfigd\n```\nFollow the tconfigd README for installation. tconfigd must be running in the `tokenetes-system` namespace before deploying the Tokenetes service."
+      },
+      {
+        "title": "Clone the Tokenetes repository",
+        "description": "Clone the Tokenetes repository which contains the Kubernetes manifests:\n```bash\ngit clone https://github.com/tokenetes/tokenetes.git\ncd tokenetes\n```"
       },
       {
         "title": "Configure the Tokenetes manifests",
-        "description": "Before deploying, update the Kubernetes manifest files in the `kubernetes/` directory with your environment-specific values:\n\n1. Replace `[your-namespace]` with your target namespace in all YAML files\n2. Replace `[your-trust-domain]` with your SPIRE trust domain\n3. Update the SPIRE agent socket path in `tokenetes-deployment.yaml` if your SPIRE agent socket is not at the default location (`/run/spire/sockets`)\n\n```bash\n# Create the target namespace\nkubectl create namespace <your-namespace>\n```"
+        "description": "Before deploying, update the Kubernetes manifest files in the `kubernetes/` directory with your environment-specific values:\n\n1. Replace `[your-namespace]` with your target namespace in all YAML files\n2. Replace `[your-trust-domain]` with your SPIRE trust domain\n3. Update the SPIRE agent socket path in `deployment.yaml` if your SPIRE agent socket is not at the default location (`/run/spire/sockets`)\n\n```bash\n# Create the target namespace\nkubectl create namespace <your-namespace>\n```"
       },
       {
         "title": "Deploy the Tokenetes service",
-        "description": "Apply the Kubernetes manifests from the `kubernetes/` directory in order:\n```bash\nkubectl apply -f kubernetes/tokenetes-service-account.yaml\nkubectl apply -f kubernetes/tokenetes-deployment.yaml\nkubectl apply -f kubernetes/tokenetes-service.yaml\n```"
+        "description": "Apply the Kubernetes manifests from the `kubernetes/` directory in order:\n```bash\nkubectl apply -f kubernetes/service-account.yaml\nkubectl apply -f kubernetes/deployment.yaml\nkubectl apply -f kubernetes/service.yaml\n```"
       },
       {
         "title": "Verify the installation",
@@ -35,7 +39,7 @@
       "summary": "A successful installation will show tconfigd running in the tokenetes-system namespace and Tokenetes service pods running in your application namespace. You can verify TraT configurations with `kubectl get trats -n <your-namespace>`.",
       "codeSnippets": [
         "git clone https://github.com/tokenetes/tokenetes.git",
-        "kubectl apply -f kubernetes/tokenetes-service-account.yaml\nkubectl apply -f kubernetes/tokenetes-deployment.yaml\nkubectl apply -f kubernetes/tokenetes-service.yaml",
+        "kubectl apply -f kubernetes/service-account.yaml\nkubectl apply -f kubernetes/deployment.yaml\nkubectl apply -f kubernetes/service.yaml",
         "kubectl get pod -n tokenetes-system\nkubectl get pod -n <your-namespace> | grep tokenetes",
         "kubectl get trats -n <your-namespace>"
       ]
@@ -43,7 +47,7 @@
     "uninstall": [
       {
         "title": "Delete Tokenetes resources",
-        "description": "Remove the Tokenetes deployment, service, and service account from your namespace:\n```bash\nkubectl delete -f kubernetes/tokenetes-service.yaml\nkubectl delete -f kubernetes/tokenetes-deployment.yaml\nkubectl delete -f kubernetes/tokenetes-service-account.yaml\n```"
+        "description": "Remove the Tokenetes deployment, service, and service account from your namespace:\n```bash\nkubectl delete -f kubernetes/service.yaml\nkubectl delete -f kubernetes/deployment.yaml\nkubectl delete -f kubernetes/service-account.yaml\n```"
       },
       {
         "title": "Clean up CRDs and TraT resources",
@@ -61,7 +65,7 @@
       },
       {
         "title": "Re-apply the manifests",
-        "description": "After updating the manifests with your environment-specific values, re-apply them:\n```bash\nkubectl apply -f kubernetes/tokenetes-service-account.yaml\nkubectl apply -f kubernetes/tokenetes-deployment.yaml\nkubectl apply -f kubernetes/tokenetes-service.yaml\n```"
+        "description": "After updating the manifests with your environment-specific values, re-apply them:\n```bash\nkubectl apply -f kubernetes/service-account.yaml\nkubectl apply -f kubernetes/deployment.yaml\nkubectl apply -f kubernetes/service.yaml\n```"
       },
       {
         "title": "Verify the upgrade",
@@ -71,7 +75,7 @@
     "troubleshooting": [
       {
         "title": "tconfigd not running",
-        "description": "Tokenetes requires tconfigd to be installed and running. Verify it is in the tokenetes-system namespace:\n```bash\nkubectl get pod -n tokenetes-system\nkubectl logs <tconfigd-pod-name> -n tokenetes-system\n```\nIf tconfigd is not running, follow the tconfigd installation instructions from the Tokenetes documentation before deploying the Tokenetes service."
+        "description": "Tokenetes requires tconfigd to be installed and running. Verify it is in the tokenetes-system namespace:\n```bash\nkubectl get pod -n tokenetes-system\nkubectl logs <tconfigd-pod-name> -n tokenetes-system\n```\nIf tconfigd is not running, install it from https://github.com/tokenetes/tconfigd before deploying the Tokenetes service."
       },
       {
         "title": "Pods stuck in CrashLoopBackOff",
@@ -79,7 +83,7 @@
       },
       {
         "title": "SPIRE agent socket not found",
-        "description": "If logs show errors about the SPIRE agent socket, verify the hostPath in the deployment matches your SPIRE agent socket location:\n```bash\nkubectl describe deployment tokenetes -n <your-namespace>\n```\nThe default path is `/run/spire/sockets`. Update the `spire-agent-socket` volume's `hostPath.path` in `tokenetes-deployment.yaml` if your setup differs."
+        "description": "If logs show errors about the SPIRE agent socket, verify the hostPath in the deployment matches your SPIRE agent socket location:\n```bash\nkubectl describe deployment tokenetes -n <your-namespace>\n```\nThe default path is `/run/spire/sockets`. Update the `spire-agent-socket` volume's `hostPath.path` in `deployment.yaml` if your setup differs."
       },
       {
         "title": "TraT resources not created",
@@ -127,11 +131,11 @@
       "kubectl",
       "git"
     ],
-    "description": "You need a Kubernetes cluster running version 1.24 or higher with SPIRE installed for workload identity. kubectl and git must be installed on your local machine. tconfigd must be deployed before installing the Tokenetes service."
+    "description": "You need a Kubernetes cluster running version 1.24 or higher with SPIRE installed for workload identity. kubectl and git must be installed on your local machine. tconfigd must be deployed (from https://github.com/tokenetes/tconfigd) before installing the Tokenetes service."
   },
   "security": {
-    "scannedAt": "2026-03-05T21:42:00.000Z",
-    "scannerVersion": "cncf-install-gen-1.0.0",
+    "scannedAt": "2026-03-06T00:00:00.000Z",
+    "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []
   }


### PR DESCRIPTION
## Summary

Validated all 8 CNCF outreach install missions against each project's official installation documentation. Every mission had issues ranging from medium to critical — wrong helm repos, fabricated versions, empty placeholder steps, wrong filenames, and missing prerequisites.

### Changes per project

| Project | Severity | What was wrong | Fix |
|---------|----------|---------------|-----|
| OPA | Critical | Used standalone OPA instead of Gatekeeper | Rewrote to use OPA Gatekeeper via Helm |
| Drasi | Critical | Fabricated kubectl manifests that don't exist | Rewrote to use Drasi CLI (`drasi init`) |
| KubeClipper | Critical | Empty placeholder steps, no actual commands | Rewrote to use `kcctl deploy` CLI |
| Keylime | Critical | Empty placeholder steps, wrong install method | Rewrote to use attestation-operator (`make helm-keylime-deploy`) |
| Konveyor | Critical | Fabricated Helm chart (v99.0.0), wrong repo URL | Rewrote to use OLM + `tackle-k8s.yaml` + Tackle CR |
| NSM | Critical | Empty steps, no commands | Rewrote with kustomize overlays from `deployments-k8s` repo + SPIRE prereq |
| Tokenetes | Medium | Wrong manifest filenames (`tokenetes-` prefix), wrong tconfigd repo | Fixed filenames to match repo, fixed tconfigd URL |
| Kuadrant | Medium | Wrong namespace (`kuadrant`→`kuadrant-system`), missing prereqs, no Kuadrant CR step | Fixed namespace, added Gateway API/cert-manager/gateway provider prereqs, added CR creation |

## Test plan

- [ ] Verify all 8 JSON files are valid JSON
- [ ] Spot-check key commands against official docs
- [ ] Verify missions render correctly on console.kubestellar.io after merge