### PR TITLE
🐛 Fix 3 inaccuracies found during doc verification

### DIFF
--- a/solutions/cncf-install/install-keylime.json
+++ b/solutions/cncf-install/install-keylime.json
@@ -15,10 +15,6 @@
         "description": "Clone the Keylime attestation-operator repository which contains the Helm charts and manifests for deploying Keylime on Kubernetes:\n```bash\ngit clone https://github.com/keylime/attestation-operator.git\ncd attestation-operator\n```"
       },
       {
-        "title": "Install cert-manager (prerequisite)",
-        "description": "The attestation operator requires cert-manager for TLS certificate management:\n```bash\nkubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml\nkubectl wait --for=condition=Available --timeout=120s deployment/cert-manager -n cert-manager\nkubectl wait --for=condition=Available --timeout=120s deployment/cert-manager-webhook -n cert-manager\n```"
-      },
-      {
         "title": "Deploy the Keylime Attestation Operator",
         "description": "Use the Makefile target to deploy the operator and Keylime components via Helm:\n```bash\nmake helm-keylime-deploy\n```\nThis installs the operator CRDs, the operator itself, and creates a default Keylime CR that deploys the registrar, verifier, and agent components.\n\nAlternatively, install step by step:\n```bash\nmake install           # Install CRDs\nmake deploy            # Deploy the operator\nkubectl apply -f config/samples/  # Create Keylime CR\n```"
       },
@@ -58,8 +54,8 @@
         "description": "Keylime agents require TPM 2.0 hardware on worker nodes. If agent pods fail to start:\n1. Verify TPM device exists: `ls /dev/tpm*` on the node\n2. Check agent logs: `kubectl logs -n keylime -l app=keylime-agent`\n3. On Kubernetes 1.26+, unprivileged TPM access may be available; on older versions, the agent may need privileged access"
       },
       {
-        "title": "cert-manager not ready",
-        "description": "If the operator fails to start with certificate errors, ensure cert-manager is fully ready:\n```bash\nkubectl get pods -n cert-manager\nkubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s\n```"
+        "title": "Operator pod not starting",
+        "description": "If the operator pod fails to start, check the operator logs for errors:\n```bash\nkubectl logs -n keylime -l control-plane=controller-manager\n```\nEnsure the CRDs were installed with `make install` before deploying the operator."
       },
       {
         "title": "CRD not found errors",
@@ -110,7 +106,7 @@
       "make",
       "helm"
     ],
-    "description": "Kubernetes 1.24+ cluster with worker nodes that have TPM 2.0 hardware. cert-manager must be installed. git, make, helm, and kubectl must be available on your workstation."
+    "description": "Kubernetes 1.24+ cluster with worker nodes that have TPM 2.0 hardware. git, make, helm, and kubectl must be available on your workstation. For unprivileged agent pods, Kubernetes 1.26+ and the k8s-tpm-device-plugin are recommended."
   },
   "security": {
     "scannedAt": "2026-03-06T00:00:00.000Z",

--- a/solutions/cncf-install/install-kubeclipper.json
+++ b/solutions/cncf-install/install-kubeclipper.json
@@ -12,7 +12,7 @@
     "steps": [
       {
         "title": "Install kcctl CLI",
-        "description": "Download and install the kcctl command-line tool on your management machine:\n```bash\ncurl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | KC_REGION=en bash -\n```\nVerify the installation:\n```bash\nkcctl version\n```"
+        "description": "Download and install the kcctl command-line tool on your management machine:\n```bash\ncurl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | bash -\n```\nVerify the installation:\n```bash\nkcctl version\n```"
       },
       {
         "title": "Deploy KubeClipper (All-in-One)",
@@ -30,7 +30,7 @@
     "resolution": {
       "summary": "A successful installation will show all KubeClipper components running via `kcctl get component`. The web console will be accessible at http://<server-ip> with the default admin credentials. You can then use the console or kcctl CLI to create and manage Kubernetes clusters.",
       "codeSnippets": [
-        "curl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | KC_REGION=en bash -",
+        "curl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | bash -",
         "kcctl deploy",
         "kcctl get node\nkcctl get component"
       ]
@@ -44,7 +44,7 @@
     "upgrade": [
       {
         "title": "Upgrade KubeClipper",
-        "description": "Download the latest kcctl CLI and run the upgrade command:\n```bash\ncurl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | KC_REGION=en bash -\nkcctl upgrade\n```"
+        "description": "Download the latest kcctl CLI and run the upgrade command:\n```bash\ncurl -sfL https://oss.kubeclipper.io/get-kubeclipper.sh | bash -\nkcctl upgrade\n```"
       }
     ],
     "troubleshooting": [

--- a/solutions/cncf-install/install-tokenetes.json
+++ b/solutions/cncf-install/install-tokenetes.json
@@ -20,11 +20,11 @@
       },
       {
         "title": "Configure the Tokenetes manifests",
-        "description": "Before deploying, update the Kubernetes manifest files in the `kubernetes/` directory with your environment-specific values:\n\n1. Replace `[your-namespace]` with your target namespace in all YAML files\n2. Replace `[your-trust-domain]` with your SPIRE trust domain\n3. Update the SPIRE agent socket path in `deployment.yaml` if your SPIRE agent socket is not at the default location (`/run/spire/sockets`)\n\n```bash\n# Create the target namespace\nkubectl create namespace <your-namespace>\n```"
+        "description": "Before deploying, update the Kubernetes manifest files in the `kubernetes/` directory with your environment-specific values:\n\n1. Replace `[your-namespace]` with your target namespace in all YAML files\n2. Replace `[your-trust-domain]` with your SPIRE trust domain\n3. Update the SPIRE agent socket path in `tokenetes-deployment.yaml` if your SPIRE agent socket is not at the default location (`/run/spire/sockets`)\n\n```bash\n# Create the target namespace\nkubectl create namespace <your-namespace>\n```"
       },
       {
         "title": "Deploy the Tokenetes service",
-        "description": "Apply the Kubernetes manifests from the `kubernetes/` directory in order:\n```bash\nkubectl apply -f kubernetes/service-account.yaml\nkubectl apply -f kubernetes/deployment.yaml\nkubectl apply -f kubernetes/service.yaml\n```"
+        "description": "Apply the Kubernetes manifests from the `kubernetes/` directory in order:\n```bash\nkubectl apply -f kubernetes/tokenetes-service-account.yaml\nkubectl apply -f kubernetes/tokenetes-deployment.yaml\nkubectl apply -f kubernetes/tokenetes-service.yaml\n```"
       },
       {
         "title": "Verify the installation",
@@ -39,7 +39,7 @@
       "summary": "A successful installation will show tconfigd running in the tokenetes-system namespace and Tokenetes service pods running in your application namespace. You can verify TraT configurations with `kubectl get trats -n <your-namespace>`.",
       "codeSnippets": [
         "git clone https://github.com/tokenetes/tokenetes.git",
-        "kubectl apply -f kubernetes/service-account.yaml\nkubectl apply -f kubernetes/deployment.yaml\nkubectl apply -f kubernetes/service.yaml",
+        "kubectl apply -f kubernetes/tokenetes-service-account.yaml\nkubectl apply -f kubernetes/tokenetes-deployment.yaml\nkubectl apply -f kubernetes/tokenetes-service.yaml",
         "kubectl get pod -n tokenetes-system\nkubectl get pod -n <your-namespace> | grep tokenetes",
         "kubectl get trats -n <your-namespace>"
       ]
@@ -47,7 +47,7 @@
     "uninstall": [
       {
         "title": "Delete Tokenetes resources",
-        "description": "Remove the Tokenetes deployment, service, and service account from your namespace:\n```bash\nkubectl delete -f kubernetes/service.yaml\nkubectl delete -f kubernetes/deployment.yaml\nkubectl delete -f kubernetes/service-account.yaml\n```"
+        "description": "Remove the Tokenetes deployment, service, and service account from your namespace:\n```bash\nkubectl delete -f kubernetes/tokenetes-service.yaml\nkubectl delete -f kubernetes/tokenetes-deployment.yaml\nkubectl delete -f kubernetes/tokenetes-service-account.yaml\n```"
       },
       {
         "title": "Clean up CRDs and TraT resources",
@@ -65,7 +65,7 @@
       },
       {
         "title": "Re-apply the manifests",
-        "description": "After updating the manifests with your environment-specific values, re-apply them:\n```bash\nkubectl apply -f kubernetes/service-account.yaml\nkubectl apply -f kubernetes/deployment.yaml\nkubectl apply -f kubernetes/service.yaml\n```"
+        "description": "After updating the manifests with your environment-specific values, re-apply them:\n```bash\nkubectl apply -f kubernetes/tokenetes-service-account.yaml\nkubectl apply -f kubernetes/tokenetes-deployment.yaml\nkubectl apply -f kubernetes/tokenetes-service.yaml\n```"
       },
       {
         "title": "Verify the upgrade",
@@ -83,7 +83,7 @@
       },
       {
         "title": "SPIRE agent socket not found",
-        "description": "If logs show errors about the SPIRE agent socket, verify the hostPath in the deployment matches your SPIRE agent socket location:\n```bash\nkubectl describe deployment tokenetes -n <your-namespace>\n```\nThe default path is `/run/spire/sockets`. Update the `spire-agent-socket` volume's `hostPath.path` in `deployment.yaml` if your setup differs."
+        "description": "If logs show errors about the SPIRE agent socket, verify the hostPath in the deployment matches your SPIRE agent socket location:\n```bash\nkubectl describe deployment tokenetes -n <your-namespace>\n```\nThe default path is `/run/spire/sockets`. Update the `spire-agent-socket` volume's `hostPath.path` in `tokenetes-deployment.yaml` if your setup differs."
       },
       {
         "title": "TraT resources not created",


### PR DESCRIPTION
## Summary

Follow-up to PR #313. Verified all 8 missions against live official docs and repos. Found 3 inaccuracies:

| Project | Issue | Fix |
|---------|-------|-----|
| KubeClipper | `KC_REGION=en` is not a documented flag | Removed — use plain `bash -` for international users |
| Keylime | cert-manager listed as prerequisite | Removed — attestation-operator Makefile has no cert-manager dependency |
| Tokenetes | Filenames had `tokenetes-` prefix removed | Restored — actual repo files are `tokenetes-deployment.yaml` etc. |

## Verification method

- OPA Gatekeeper: Confirmed helm repo URL, namespace, kubectl alternative against official install docs
- Drasi: Confirmed CLI install curl URL, `drasi env kube`, `drasi init`, namespace `drasi-system` against kind install guide
- KubeClipper: Confirmed `kcctl deploy`, default creds (admin/Thinkbig1), port 80 against getting-started docs
- Keylime: Confirmed `make helm-keylime-deploy` target exists in Makefile, cert-manager NOT referenced
- Konveyor: Confirmed `tackle-k8s.yaml` exists in repo, Tackle CR apiVersion `tackle.konveyor.io/v1alpha1`, namespace `konveyor-tackle`
- NSM: Confirmed `examples/spire/single_cluster` and `examples/basic` kustomization paths exist in `deployments-k8s` repo
- Tokenetes: Confirmed actual filenames are `tokenetes-deployment.yaml`, `tokenetes-service-account.yaml`, `tokenetes-service.yaml`
- Kuadrant: Confirmed helm repo serves chart `kuadrant-operator` v1.4.1, namespace `kuadrant-system`, CR apiVersion `kuadrant.io/v1beta1`

## Test plan

- [x] All 3 JSON files validate as valid JSON
- [ ] Spot-check commands match official docs