### PR TITLE
🐛 Fix SpinKube, SlimFaas, and Score install missions

### DIFF
--- a/solutions/cncf-install/install-score.json
+++ b/solutions/cncf-install/install-score.json
@@ -5,14 +5,14 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Score on Kubernetes",
-    "description": "The Score Specification provides a developer-centric and platform-agnostic workload specification to improve developer productivity and experience. Installing Score allows you to define and manage your workloads in a consistent manner across different environments.",
+    "title": "Install and Use Score for Kubernetes Workload Deployment",
+    "description": "Score is a developer-centric, platform-agnostic workload specification. The score-k8s CLI translates Score YAML into Kubernetes manifests, letting you define workloads once and deploy across environments. Score is a client-side CLI tool — it does not run inside your cluster.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Install the Score CLI",
-        "description": "Download and install the Score CLI tool for Kubernetes. Score provides `score-k8s` and `score-compose` commands for translating workload specifications.\n```bash\n# Download the binary from GitHub releases\ncurl -sL https://github.com/score-spec/score-k8s/releases/latest/download/score-k8s_$(uname -s)_$(uname -m).tar.gz | tar xz\nsudo mv score-k8s /usr/local/bin/\nscore-k8s version\n```"
+        "title": "Install the score-k8s CLI",
+        "description": "Install score-k8s using one of these methods:\n\n**Homebrew (macOS/Linux):**\n```bash\nbrew install score-spec/tap/score-k8s\n```\n\n**Go install:**\n```bash\ngo install -v github.com/score-spec/score-k8s/cmd/score-k8s@latest\n```\n\n**Binary download:**\n```bash\n# Download from https://github.com/score-spec/score-k8s/releases\n# Example for Linux amd64:\nwget https://github.com/score-spec/score-k8s/releases/download/0.10.1/score-k8s_0.10.1_linux_amd64.tar.gz\ntar xzf score-k8s_0.10.1_linux_amd64.tar.gz\nsudo mv score-k8s /usr/local/bin/\n```\n\nVerify the installation:\n```bash\nscore-k8s version\n```"
       },
       {
         "title": "Initialize a Score project",
@@ -20,11 +20,11 @@
       },
       {
         "title": "Create a Score workload specification",
-        "description": "Create or edit `score.yaml` to define your workload:\n```yaml\napiVersion: score.dev/v1b1\nmetadata:\n  name: my-workload\ncontainers:\n  main:\n    image: nginx:1.25\n    ports:\n      http:\n        port: 80\n        protocol: TCP\n```"
+        "description": "Edit `score.yaml` to define your workload. Ports are defined under `service`, not under `containers`:\n```yaml\napiVersion: score.dev/v1b1\nmetadata:\n  name: my-workload\ncontainers:\n  main:\n    image: nginx:1.25\nservice:\n  ports:\n    http:\n      port: 80\n      protocol: TCP\n```"
       },
       {
-        "title": "Generate and deploy Kubernetes manifests",
-        "description": "Use score-k8s to generate Kubernetes manifests and deploy:\n```bash\nscore-k8s generate score.yaml | kubectl apply -f -\n```"
+        "title": "Generate Kubernetes manifests and deploy",
+        "description": "Generate manifests from your Score file and apply them:\n```bash\nscore-k8s generate score.yaml\nkubectl apply -f manifests.yaml\n```\nThe `generate` command writes output to `manifests.yaml` by default. To pipe directly:\n```bash\nscore-k8s generate score.yaml -o - | kubectl apply -f -\n```"
       },
       {
         "title": "Verify the deployment",
@@ -32,44 +32,41 @@
       }
     ],
     "resolution": {
-      "summary": "Score CLI is installed and you can translate Score workload specifications into Kubernetes manifests for deployment.",
+      "summary": "The score-k8s CLI is installed locally and can translate Score workload specifications into Kubernetes manifests. Score runs entirely client-side — no cluster-side components are installed.",
       "codeSnippets": [
-        "score-k8s generate score.yaml | kubectl apply -f -",
+        "score-k8s generate score.yaml",
+        "kubectl apply -f manifests.yaml",
         "kubectl get pods"
       ]
     },
     "uninstall": [
       {
         "title": "Remove deployed workloads",
-        "description": "Delete the resources created from Score:\n```bash\nscore-k8s generate score.yaml | kubectl delete -f -\n```"
+        "description": "Delete the resources created from Score:\n```bash\nkubectl delete -f manifests.yaml\n```\nNote: resource cleanup in score-k8s is not fully implemented yet. Verify all resources are removed:\n```bash\nkubectl get all | grep my-workload\n```"
       },
       {
-        "title": "Uninstall Score CLI",
-        "description": "Remove the Score CLI:\n```bash\nsudo rm /usr/local/bin/score-k8s\n```"
+        "title": "Uninstall the Score CLI",
+        "description": "Remove the CLI binary:\n```bash\n# If installed via Homebrew:\nbrew uninstall score-k8s\n\n# If installed manually:\nsudo rm /usr/local/bin/score-k8s\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Update Score CLI",
-        "description": "Download the latest version:\n```bash\ncurl -sL https://github.com/score-spec/score-k8s/releases/latest/download/score-k8s_$(uname -s)_$(uname -m).tar.gz | tar xz\nsudo mv score-k8s /usr/local/bin/\nscore-k8s version\n```"
+        "title": "Update the Score CLI",
+        "description": "Upgrade to the latest version:\n```bash\n# Homebrew:\nbrew upgrade score-k8s\n\n# Go install:\ngo install -v github.com/score-spec/score-k8s/cmd/score-k8s@latest\n\n# Manual: download the latest release from\n# https://github.com/score-spec/score-k8s/releases\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods stuck in CrashLoopBackOff",
-        "description": "If your Score pods are in a CrashLoopBackOff state, you can check the logs to diagnose the issue. Use the following command to view the logs of a specific pod:\n```bash\nkubectl logs <pod-name> --namespace score\n```"
+        "title": "Generated pods stuck in CrashLoopBackOff",
+        "description": "This is an issue with the workload definition, not Score itself. Check the pod logs:\n```bash\nkubectl logs <pod-name>\nkubectl describe pod <pod-name>\n```\nVerify your `score.yaml` references a valid container image and correct port configuration."
       },
       {
-        "title": "Service not reachable",
-        "description": "If you cannot access the Score service, ensure that the service is running and check the port-forwarding command. Verify the service status with:\n```bash\nkubectl get svc --namespace score\n```"
+        "title": "Generate command fails with validation error",
+        "description": "Ensure your `score.yaml` follows the v1b1 spec. Common mistakes:\n- Ports must be under `service.ports`, not `containers.*.ports`\n- `apiVersion` must be `score.dev/v1b1`\n- Container names must be alphanumeric\n\nRe-initialize to get a valid template:\n```bash\nscore-k8s init --overwrite\n```"
       },
       {
-        "title": "Helm upgrade fails with version conflict",
-        "description": "If you encounter a version conflict during the Helm upgrade, ensure that you are using a compatible version of the Score chart. You can check the available versions with:\n```bash\nhelm search repo score --versions\n```"
-      },
-      {
-        "title": "Insufficient resources for Score pods",
-        "description": "If the Score pods are failing to start due to insufficient resources, you may need to adjust the resource limits in the deployment. Check the events for the pods to see resource-related errors:\n```bash\nkubectl describe pod <pod-name> --namespace score\n```"
+        "title": "Binary not found after install",
+        "description": "Ensure the binary is on your PATH:\n```bash\nwhich score-k8s\necho $PATH\n```\nIf installed via `go install`, ensure `$GOPATH/bin` (or `$HOME/go/bin`) is in your PATH."
       }
     ]
   },
@@ -79,15 +76,15 @@
       "configuration",
       "cncf",
       "app-definition",
-      "sandbox"
+      "sandbox",
+      "developer-tools"
     ],
     "cncfProjects": [
       "score"
     ],
     "targetResourceKinds": [
       "Deployment",
-      "Service",
-      "Namespace"
+      "Service"
     ],
     "difficulty": "beginner",
     "issueTypes": [
@@ -95,16 +92,16 @@
       "configuration"
     ],
     "installMethods": [
-      "kubectl"
+      "binary",
+      "brew",
+      "go-install"
     ],
     "maturity": "sandbox",
-    "projectVersion": "0.3.0",
-    "containerImages": [
-      "ghcr.io/score-spec/sample-app-gif:sha-2533037"
-    ],
+    "projectVersion": "0.10.1",
+    "containerImages": [],
     "sourceUrls": {
-      "docs": "https://score.dev/",
-      "repo": "https://github.com/score-spec/spec"
+      "docs": "https://docs.score.dev/",
+      "repo": "https://github.com/score-spec/score-k8s"
     },
     "qualityScore": 100
   },
@@ -113,10 +110,10 @@
     "tools": [
       "kubectl"
     ],
-    "description": "A running Kubernetes cluster with kubectl configured."
+    "description": "A Kubernetes cluster with kubectl configured. For installing the CLI: Homebrew, Go 1.22+, or wget/curl for binary download."
   },
   "security": {
-    "scannedAt": "2026-03-02T00:29:13.160Z",
+    "scannedAt": "2026-03-09T00:00:00.000Z",
     "scannerVersion": "cncf-install-gen-1.0.0",
     "sanitized": true,
     "findings": []

--- a/solutions/cncf-install/install-slimfaas.json
+++ b/solutions/cncf-install/install-slimfaas.json
@@ -5,52 +5,64 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Slimfaas on Kubernetes",
-    "description": "SlimFaas is a lightweight, plug-and-play Function-as-a-Service (FaaS) platform for Kubernetes. It is designed to be fast, simple, and extremely slim, making it an excellent choice for deploying serverless functions in a Kubernetes environment.",
+    "title": "Install and Configure SlimFaas on Kubernetes",
+    "description": "SlimFaas is a lightweight, plug-and-play Function-as-a-Service (FaaS) platform for Kubernetes. It scales functions to zero and back up on demand, with built-in pub/sub (sync and async) and a consensus layer for high availability.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Create a Namespace",
-        "description": "Create a dedicated namespace for SlimFaas to isolate its resources."
+        "title": "Clone the SlimFaas repository",
+        "description": "Clone the repository to get the deployment manifests:\n```bash\ngit clone https://github.com/AxaFrance/SlimFaas.git\ncd SlimFaas/demo\n```"
       },
       {
-        "title": "Deploy SlimFaas Components",
-        "description": "Apply the necessary manifests to deploy SlimFaas."
+        "title": "Deploy RBAC and SlimFaas",
+        "description": "Apply the ServiceAccount, Role, RoleBinding, and SlimFaas StatefulSet:\n```bash\nkubectl apply -f service-account-slimfaas.yml\nkubectl apply -f deployment-slimfaas.yml\n```\nThis creates the `slimfaas-demo` namespace, a ConfigMap, a 3-replica StatefulSet, and a ClusterIP service on port 5000."
       },
       {
-        "title": "Verify Deployment",
-        "description": "Check the status of the deployed pods to ensure everything is running smoothly."
+        "title": "Expose SlimFaas",
+        "description": "Expose the service via NodePort (or configure an Ingress):\n```bash\nkubectl apply -f slimfaas-nodeport.yml\n```\nSlimFaas will be accessible on NodePort 30021."
+      },
+      {
+        "title": "Deploy sample functions",
+        "description": "Deploy the demo functions to test scale-to-zero:\n```bash\nkubectl apply -f deployment-functions.yml\n```\nThis deploys sample Fibonacci functions (fibonacci1, fibonacci2, fibonacci3) that SlimFaas will scale to zero after idle timeout."
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that SlimFaas and the demo functions are running:\n```bash\nkubectl get statefulset -n slimfaas-demo\nkubectl get pods -n slimfaas-demo\nkubectl get svc -n slimfaas-demo\n```\nYou should see the slimfaas StatefulSet with 3 ready replicas and the function deployments."
       }
     ],
     "resolution": {
-      "summary": "A successful installation of SlimFaas will have the pods running in the 'slimfaas' namespace, and you will be able to access the service through port 8080. Additionally, resource limits will be configured as specified.",
-      "codeSnippets": []
+      "summary": "A successful installation shows the SlimFaas StatefulSet running with 3 replicas in the slimfaas-demo namespace. The service is accessible on port 5000 (ClusterIP) or NodePort 30021. Functions scale to zero after idle and wake on incoming requests.",
+      "codeSnippets": [
+        "kubectl get statefulset -n slimfaas-demo",
+        "kubectl get pods -n slimfaas-demo",
+        "curl http://<node-ip>:30021/function/fibonacci1/hello"
+      ]
     },
     "uninstall": [
       {
         "title": "Remove SlimFaas Resources",
-        "description": "Delete the SlimFaas components and the namespace."
+        "description": "Delete all resources and the namespace:\n```bash\nkubectl delete -f deployment-functions.yml\nkubectl delete -f slimfaas-nodeport.yml\nkubectl delete -f deployment-slimfaas.yml\nkubectl delete -f service-account-slimfaas.yml\n```\nNote: PersistentVolumeClaims created by the StatefulSet are not automatically deleted. Clean them up:\n```bash\nkubectl delete pvc --all -n slimfaas-demo\nkubectl delete namespace slimfaas-demo\n```"
       }
     ],
     "upgrade": [
       {
         "title": "Upgrade SlimFaas",
-        "description": "To upgrade SlimFaas, reapply the latest manifests."
+        "description": "Pull the latest manifests and reapply:\n```bash\ngit pull origin main\nkubectl apply -f deployment-slimfaas.yml\n```\nThe StatefulSet will perform a rolling update."
       }
     ],
     "troubleshooting": [
       {
         "title": "Pod Not Starting",
-        "description": "Check the pod logs for errors using the command: `kubectl logs <pod-name> -n slimfaas`."
+        "description": "Check the pod logs and events:\n```bash\nkubectl logs slimfaas-0 -n slimfaas-demo\nkubectl describe pod slimfaas-0 -n slimfaas-demo\n```"
       },
       {
-        "title": "Service Not Accessible",
-        "description": "Ensure that the service is correctly configured and check the service endpoints with: `kubectl get svc -n slimfaas`."
+        "title": "PVC Pending",
+        "description": "SlimFaas uses PersistentVolumeClaims for its consensus layer. If pods are stuck in Pending, check that your cluster has a default StorageClass with available PersistentVolumes:\n```bash\nkubectl get sc\nkubectl get pvc -n slimfaas-demo\n```"
       },
       {
-        "title": "Insufficient Resources",
-        "description": "If pods are in a pending state, verify that your cluster has enough resources (CPU/Memory) available."
+        "title": "Functions Not Scaling Up",
+        "description": "If functions remain at 0 replicas after receiving traffic, check SlimFaas logs for errors:\n```bash\nkubectl logs slimfaas-0 -n slimfaas-demo\n```\nVerify the ServiceAccount has the correct RBAC permissions to scale deployments."
       }
     ]
   },
@@ -59,16 +71,21 @@
       "installation",
       "configuration",
       "cncf",
-      "app-definition",
+      "serverless",
+      "faas",
       "sandbox"
     ],
     "cncfProjects": [
       "slimfaas"
     ],
     "targetResourceKinds": [
-      "Deployment",
+      "StatefulSet",
       "Service",
-      "Namespace"
+      "Namespace",
+      "ServiceAccount",
+      "Role",
+      "RoleBinding",
+      "ConfigMap"
     ],
     "difficulty": "beginner",
     "issueTypes": [
@@ -85,19 +102,20 @@
     ],
     "sourceUrls": {
       "docs": "https://slimfaas.dev/",
-      "repo": "https://github.com/SlimPlanet/SlimFaas"
+      "repo": "https://github.com/AxaFrance/SlimFaas"
     },
     "qualityScore": 100
   },
   "prerequisites": {
     "kubernetes": ">=1.24",
     "tools": [
-      "kubectl"
+      "kubectl",
+      "git"
     ],
-    "description": "Ensure you have a running Kubernetes cluster and kubectl installed and configured to interact with it."
+    "description": "A Kubernetes cluster with a default StorageClass (for PersistentVolumeClaims), kubectl, and git."
   },
   "security": {
-    "scannedAt": "2026-03-02T01:11:40.141Z",
+    "scannedAt": "2026-03-09T00:00:00.000Z",
     "scannerVersion": "cncf-install-gen-1.0.0",
     "sanitized": true,
     "findings": []

--- a/solutions/cncf-install/install-spinkube.json
+++ b/solutions/cncf-install/install-spinkube.json
@@ -5,57 +5,65 @@
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install and Configure Spinkube on Kubernetes",
-    "description": "Spin Operator is a Kubernetes operator that enables platform engineers to deploy Spin applications as custom resources to their Kubernetes clusters. Installing it allows you to manage Spin applications efficiently within your Kubernetes environment.",
+    "title": "Install and Configure SpinKube (Spin Operator) on Kubernetes",
+    "description": "Spin Operator is a Kubernetes operator that enables platform engineers to deploy Spin applications (WebAssembly workloads) as custom resources. It requires cert-manager, a containerd-shim-spin runtime, and the Spin Operator Helm chart.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Create a Namespace",
-        "description": "First, create a namespace for the Spin Operator to run in. This helps to isolate the resources used by the operator."
+        "title": "Install cert-manager",
+        "description": "Spin Operator requires cert-manager for webhook certificate management. Install it if not already present:\n```bash\nkubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml\nkubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s\nkubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s\n```"
       },
       {
-        "title": "Apply the Custom Resource Definitions (CRDs)",
-        "description": "Next, apply the CRDs required by the Spin Operator. This step is crucial for the operator to manage Spin applications as custom resources."
+        "title": "Install the containerd-shim-spin runtime",
+        "description": "Spin applications need the containerd-shim-spin runtime on cluster nodes. Install via the Kwasm operator:\n```bash\nhelm repo add kwasm http://kwasm.sh/kwasm-operator/\nhelm install kwasm-operator kwasm/kwasm-operator \\\n  --namespace kwasm \\\n  --create-namespace \\\n  --set kwasmOperator.installerImage=ghcr.io/spinframework/containerd-shim-spin/node-installer:v0.23.0\n```\nThen annotate nodes to install the shim:\n```bash\nkubectl annotate node --all kwasm.sh/kwasm-node=true\n```\nAlternatively, if using k3d, create a cluster with the shim pre-installed:\n```bash\nk3d cluster create wasm-cluster \\\n  --image ghcr.io/spinframework/containerd-shim-spin/k3d:v0.23.0 \\\n  -p \"8081:80@loadbalancer\" \\\n  --agents 2\n```"
       },
       {
-        "title": "Deploy the Spin Operator",
-        "description": "Now, deploy the Spin Operator using the provided deployment manifest. This will create the necessary pods and services."
+        "title": "Apply CRDs, RuntimeClass, and ShimExecutor",
+        "description": "Apply the Spin Operator CRDs, RuntimeClass, and ShimExecutor resources:\n```bash\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.crds.yaml\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.runtime-class.yaml\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.shim-executor.yaml\n```"
+      },
+      {
+        "title": "Install the Spin Operator via Helm",
+        "description": "Install the Spin Operator using the OCI Helm chart:\n```bash\nhelm install spin-operator \\\n  --namespace spin-operator \\\n  --create-namespace \\\n  --version 0.6.1 \\\n  --wait \\\n  oci://ghcr.io/spinframework/charts/spin-operator\n```"
       },
       {
         "title": "Verify the Installation",
-        "description": "Finally, verify that the Spin Operator is running correctly by checking the status of the pods in the namespace."
+        "description": "Check that the operator pod is running:\n```bash\nkubectl get pods -n spin-operator\nkubectl get crds | grep spinframework\nkubectl get runtimeclass | grep wasmtime-spin\n```\nYou should see the spin-operator pod in Running state, SpinApp/SpinAppExecutor CRDs registered, and a wasmtime-spin-v2 RuntimeClass."
       }
     ],
     "uninstall": [
       {
         "title": "Remove the Spin Operator",
-        "description": "To uninstall the Spin Operator, delete the deployment and CRDs that were created. This will remove all associated resources."
+        "description": "Uninstall the operator and remove CRDs:\n```bash\nhelm uninstall spin-operator -n spin-operator\nkubectl delete -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.shim-executor.yaml\nkubectl delete -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.runtime-class.yaml\nkubectl delete -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.crds.yaml\nkubectl delete namespace spin-operator\n```"
       }
     ],
     "upgrade": [
       {
         "title": "Upgrade the Spin Operator",
-        "description": "To upgrade the Spin Operator, apply the latest version of the deployment manifest. Ensure to check for any breaking changes in the release notes."
+        "description": "Upgrade by applying the new CRDs and then upgrading the Helm release:\n```bash\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/<NEW_VERSION>/spin-operator.crds.yaml\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/<NEW_VERSION>/spin-operator.runtime-class.yaml\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/<NEW_VERSION>/spin-operator.shim-executor.yaml\nhelm upgrade spin-operator \\\n  --namespace spin-operator \\\n  --version <NEW_VERSION> \\\n  --wait \\\n  oci://ghcr.io/spinframework/charts/spin-operator\n```"
       }
     ],
     "troubleshooting": [
       {
         "title": "Pod is Not Running",
-        "description": "If the Spin Operator pod is not running, check the pod logs for errors using:\n```bash\nkubectl logs <pod-name> -n spin-operator\n```"
+        "description": "If the spin-operator pod is not running, check logs:\n```bash\nkubectl logs -l app.kubernetes.io/name=spin-operator -n spin-operator\n```\nCommon causes: cert-manager not ready, insufficient RBAC permissions."
       },
       {
         "title": "CRDs Not Found",
-        "description": "If you encounter issues with CRDs not being found, ensure that the CRDs were applied successfully. Reapply them if necessary:\n```bash\nkubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/deploy/crds/spinframework.io_spinapplications_crd.yaml\n```"
+        "description": "Verify CRDs are installed:\n```bash\nkubectl get crds | grep spinframework\n```\nIf missing, reapply:\n```bash\nkubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v0.6.1/spin-operator.crds.yaml\n```"
       },
       {
-        "title": "Insufficient Permissions",
-        "description": "If you receive permission errors, ensure that your Kubernetes context has the necessary permissions to create resources in the 'spin-operator' namespace."
+        "title": "SpinApp Pods Stuck in ContainerCreating",
+        "description": "This usually means the containerd-shim-spin runtime is not installed on the node. Verify:\n```bash\nkubectl get runtimeclass wasmtime-spin-v2\nkubectl get nodes -o jsonpath='{.items[*].metadata.annotations}' | grep kwasm\n```\nIf the Kwasm annotation is missing, annotate nodes:\n```bash\nkubectl annotate node --all kwasm.sh/kwasm-node=true\n```"
       }
     ],
     "resolution": {
-      "summary": "A successful installation of the Spin Operator will show the operator pods running in the 'spin-operator' namespace. You should also be able to access the sample Spin application via the port-forwarded local address.",
-      "codeSnippets": []
+      "summary": "A successful installation shows the spin-operator pod running in the spin-operator namespace, SpinApp and SpinAppExecutor CRDs registered, and a wasmtime-spin-v2 RuntimeClass available. You can now deploy Spin WebAssembly applications as SpinApp custom resources.",
+      "codeSnippets": [
+        "kubectl get pods -n spin-operator",
+        "kubectl get crds | grep spinframework",
+        "kubectl get runtimeclass | grep wasmtime-spin"
+      ]
     }
   },
   "metadata": {
@@ -64,14 +72,19 @@
       "configuration",
       "cncf",
       "runtime",
-      "sandbox"
+      "sandbox",
+      "webassembly",
+      "wasm"
     ],
     "cncfProjects": [
       "spinkube"
     ],
     "targetResourceKinds": [
       "Deployment",
-      "Namespace"
+      "Service",
+      "Namespace",
+      "CustomResourceDefinition",
+      "RuntimeClass"
     ],
     "difficulty": "intermediate",
     "issueTypes": [
@@ -79,7 +92,7 @@
       "configuration"
     ],
     "installMethods": [
-      "kubectl"
+      "helm"
     ],
     "maturity": "sandbox",
     "projectVersion": "v0.6.1",
@@ -89,19 +102,20 @@
     "sourceUrls": {
       "docs": "https://www.spinkube.dev/docs/overview/",
       "repo": "https://github.com/spinframework/spin-operator",
-      "helm": "https://github.com/spinframework/spin-operator/tree/main/charts/spin-operator/"
+      "helm": "oci://ghcr.io/spinframework/charts/spin-operator"
     },
     "qualityScore": 100
   },
   "prerequisites": {
-    "kubernetes": ">=1.24",
+    "kubernetes": ">=1.26",
     "tools": [
-      "kubectl"
+      "kubectl",
+      "helm"
     ],
-    "description": "Ensure that you have a working Kubernetes cluster and kubectl installed and configured to communicate with your cluster."
+    "description": "A Kubernetes cluster (>=1.26), kubectl, Helm 3, and cert-manager installed. Nodes must support the containerd-shim-spin runtime (installed via Kwasm operator or a pre-built k3d image)."
   },
   "security": {
-    "scannedAt": "2026-03-02T23:21:44.357Z",
+    "scannedAt": "2026-03-09T00:00:00.000Z",
     "scannerVersion": "cncf-install-gen-1.0.0",
     "sanitized": true,
     "findings": []


### PR DESCRIPTION
## Summary
- **SpinKube**: Rewrote entirely — added cert-manager + Kwasm prerequisites, CRD/RuntimeClass/ShimExecutor apply steps, switched to Helm OCI chart install, fixed broken CRD URL
- **SlimFaas**: Fixed namespace (`slimfaas-demo` not `slimfaas`), port (`5000` not `8080`), resource type (`StatefulSet` not `Deployment`), added git prereq and PVC cleanup, added actual kubectl commands
- **Score**: Fixed download URL (lowercase OS, versioned path), score.yaml spec (`service.ports` not `containers.ports`), generate command (writes file, not stdout), replaced fabricated Helm troubleshooting, updated version to `0.10.1`

## Test plan
- [ ] Verify missions render correctly on console.kubestellar.io after merge