### PR TITLE
🐛 Use COPILOT_GITHUB_TOKEN org secret for Copilot API

### DIFF
--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Generate missions (batch ${{ matrix.batch }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COPILOT_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           COPILOT_MODEL: claude-opus-4.6
           MIN_REACTIONS: ${{ inputs.min_reactions || '10' }}
           TARGET_PROJECTS: ${{ inputs.projects || '' }}


### PR DESCRIPTION
## Summary
- Pass `COPILOT_GITHUB_TOKEN` org secret as `COPILOT_TOKEN` env var in the generation workflow
- The Copilot enterprise endpoint rejects the standard `GITHUB_TOKEN` (GitHub App Server-To-Server tokens not supported)
- The org-level PAT has Copilot access and works with the endpoint

Follow-up to #332.