### PR TITLE
🐛 Use GITHUB_TOKEN for issue creation instead of COPILOT_TOKEN

### DIFF
--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -88,7 +88,6 @@ jobs:
       - name: Discover issues and create Copilot tasks (batch ${{ matrix.batch }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COPILOT_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           MIN_REACTIONS: ${{ inputs.min_reactions || '10' }}
           TARGET_PROJECTS: ${{ inputs.projects || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}

--- a/scripts/generate-cncf-missions.mjs
+++ b/scripts/generate-cncf-missions.mjs
@@ -25,7 +25,6 @@ import { scoreMission } from './quality-scorer.mjs'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
-const COPILOT_TOKEN = process.env.COPILOT_TOKEN || process.env.GITHUB_TOKEN
 const MIN_REACTIONS = parseInt(process.env.MIN_REACTIONS || '10', 10)
 const TARGET_PROJECTS = process.env.TARGET_PROJECTS
   ? process.env.TARGET_PROJECTS.split(',').map(s => s.trim()).filter(Boolean)
@@ -662,10 +661,10 @@ async function createCopilotIssue(project, issue, resolution, linkedPR) {
     return { dryRun: true, slug }
   }
 
-  // Create issue on console-kb
-  const token = COPILOT_TOKEN
+  // Create issue on console-kb using the workflow GITHUB_TOKEN (has issues:write permission)
+  const token = GITHUB_TOKEN
   if (!token) {
-    console.warn('    [SKIP] No COPILOT_TOKEN or GITHUB_TOKEN for issue creation')
+    console.warn('    [SKIP] No GITHUB_TOKEN available for issue creation')
     return null
   }
 


### PR DESCRIPTION
## Summary
- The `COPILOT_GITHUB_TOKEN` PAT doesn't have `issues:write` permission on console-kb, causing 403 errors when the mission generation workflow tries to create Copilot task issues
- Switch to the workflow's built-in `GITHUB_TOKEN` which already has `issues: write` from the permissions block
- Remove the unused `COPILOT_TOKEN` env var and constant

## Test plan
- [ ] Trigger `Generate CNCF Missions` workflow with `projects=cert-manager, max_issues=2`
- [ ] Verify issues are created on console-kb with `ai-fix-requested` + `triage/accepted` labels
- [ ] Verify Copilot coding agent gets assigned to the issues