### PR TITLE
🐛 Use ORG_TOKEN PAT for issue creation to trigger ai-fix workflow

### DIFF
--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Discover issues and create Copilot tasks (batch ${{ matrix.batch }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TOKEN: ${{ secrets.ORG_TOKEN }}
           MIN_REACTIONS: ${{ inputs.min_reactions || '10' }}
           TARGET_PROJECTS: ${{ inputs.projects || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}

--- a/scripts/generate-cncf-missions.mjs
+++ b/scripts/generate-cncf-missions.mjs
@@ -25,6 +25,8 @@ import { scoreMission } from './quality-scorer.mjs'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+// PAT for issue creation — events from PATs trigger workflows (GITHUB_TOKEN events don't)
+const ISSUE_TOKEN = process.env.ISSUE_TOKEN || process.env.GITHUB_TOKEN
 const MIN_REACTIONS = parseInt(process.env.MIN_REACTIONS || '10', 10)
 const TARGET_PROJECTS = process.env.TARGET_PROJECTS
   ? process.env.TARGET_PROJECTS.split(',').map(s => s.trim()).filter(Boolean)
@@ -661,10 +663,11 @@ async function createCopilotIssue(project, issue, resolution, linkedPR) {
     return { dryRun: true, slug }
   }
 
-  // Create issue on console-kb using the workflow GITHUB_TOKEN (has issues:write permission)
-  const token = GITHUB_TOKEN
+  // Create issue using ISSUE_TOKEN (PAT) so the labeled event triggers the ai-fix workflow.
+  // Events from GITHUB_TOKEN don't trigger other workflows (GitHub's infinite-loop prevention).
+  const token = ISSUE_TOKEN
   if (!token) {
-    console.warn('    [SKIP] No GITHUB_TOKEN available for issue creation')
+    console.warn('    [SKIP] No ISSUE_TOKEN or GITHUB_TOKEN available for issue creation')
     return null
   }
 


### PR DESCRIPTION
## Summary
- Events created by `GITHUB_TOKEN` don't trigger other workflows (GitHub's infinite-loop prevention)
- Issue creation now uses `ORG_TOKEN` PAT so the `issues: [labeled]` event fires on the `ai-fix.yml` workflow
- This allows Copilot coding agent to be automatically assigned via the existing `ai-fix` → `reusable-ai-fix` chain
- Matches the pattern used by `auto-qa` on `kubestellar/console` (which uses `CONSOLE_AUTO` PAT)

## Test plan
- [ ] Trigger `Generate CNCF Missions` with `projects=cert-manager, max_issues=1, force_rescan=true`
- [ ] Verify an issue is created with correct labels
- [ ] Verify the `AI Fix with Copilot` workflow triggers (event type: `issues`)
- [ ] Verify Copilot coding agent gets assigned and starts working on a PR