### PR TITLE
🌱 opentelemetry-collector: [mdatagen] Consider linking metrics/attributes from metadata.yaml to SemConv

### DIFF
--- a/fixes/cncf-generated/opentelemetry-collector/opentelemetry-collector-13297-mdatagen-consider-linking-metrics-attributes-from-.json
+++ b/fixes/cncf-generated/opentelemetry-collector/opentelemetry-collector-13297-mdatagen-consider-linking-metrics-attributes-from-.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "opentelemetry-collector-13297-mdatagen-consider-linking-metrics-attributes-from-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "opentelemetry-collector: [mdatagen] Consider linking metrics/attributes from metadata.yaml to SemConv definitions",
+    "description": "[mdatagen] Consider linking metrics/attributes from metadata.yaml to SemConv definitions. Requested by 9+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current opentelemetry-collector deployment",
+        "description": "Verify your opentelemetry-collector version and configuration:\n```bash\nkubectl get pods -n opentelemetry-collector -l app.kubernetes.io/name=opentelemetry-collector\nhelm list -n opentelemetry-collector 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working opentelemetry-collector installation."
+      },
+      {
+        "title": "Review opentelemetry-collector configuration",
+        "description": "Inspect the relevant opentelemetry-collector configuration:\n```bash\nkubectl get all -n opentelemetry-collector -l app.kubernetes.io/name=opentelemetry-collector\nkubectl get configmap -n opentelemetry-collector -l app.kubernetes.io/part-of=opentelemetry-collector\n```\n`mdatagen` allows today to set [sem_conv_version](https://github.com/open-telemetry/opentelemetry-collector/blob/4ca0f1829e0a348738caab8799237d395a975888/cmd/mdatagen/metadata-schema.yaml#L42) within the `metdata.yaml` file."
+      },
+      {
+        "title": "Apply the fix for [mdatagen] Consider linking metrics/attributes from…",
+        "description": "It seems that OpenTelemetry-Go already generates code based on SemConv (using Weaver).\n\nIt looks like there is some overlap between mdatagen and OpenTelemetry-Go.\n\nFor example https://github.com/open-telemetry/opentelemetry-go/blob/main/semconv/v1.34.0/cpuconv/metric.go#L240-L259 looks quite close to what mdatagen generates at\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n opentelemetry-collector -l app.kubernetes.io/name=opentelemetry-collector\nkubectl get events -n opentelemetry-collector --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[mdatagen] Consider linking metrics/attributes from…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "It seems that OpenTelemetry-Go already generates code based on SemConv (using Weaver).\n\nIt looks like there is some overlap between mdatagen and OpenTelemetry-Go.\n\nFor example https://github.com/open-telemetry/opentelemetry-go/blob/main/semconv/v1.34.0/cpuconv/metric.go#L240-L259 looks quite close to what mdatagen generates at",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "opentelemetry-collector",
+      "incubating",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "opentelemetry-collector"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/open-telemetry/opentelemetry-collector/issues/13297",
+      "repo": "https://github.com/open-telemetry/opentelemetry-collector"
+    },
+    "reactions": 9,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with opentelemetry-collector installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-10T06:48:51.860Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: opentelemetry-collector — [mdatagen] Consider linking metrics/attributes from metadata.yaml to SemConv definitions

**Type:** feature | **Source:** https://github.com/open-telemetry/opentelemetry-collector/issues/13297 (9 reactions)
**File:** `fixes/cncf-generated/opentelemetry-collector/opentelemetry-collector-13297-mdatagen-consider-linking-metrics-attributes-from-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*