### PR TITLE
🌱 flux: Feature Request: Allow `flux diff ks` when the `Kustomization` does not already

### DIFF
--- a/fixes/cncf-generated/flux/flux-5439-feature-request-allow-flux-diff-ks-when-the-kustomization-does-not-alr.json
+++ b/fixes/cncf-generated/flux/flux-5439-feature-request-allow-flux-diff-ks-when-the-kustomization-does-not-alr.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "flux-5439-feature-request-allow-flux-diff-ks-when-the-kustomization-does-not-alr",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "flux: Feature Request: Allow `flux diff ks` when the `Kustomization` does not already exist",
+    "description": "Feature Request: Allow `flux diff ks` when the `Kustomization` does not already exist. Requested by 6+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current flux deployment",
+        "description": "Verify your flux version and configuration:\n```bash\nkubectl get pods -n flux -l app.kubernetes.io/name=flux\nhelm list -n flux 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working flux installation."
+      },
+      {
+        "title": "Review flux configuration",
+        "description": "Inspect the relevant flux configuration:\n```bash\nkubectl get all -n flux -l app.kubernetes.io/name=flux\nkubectl get configmap -n flux -l app.kubernetes.io/part-of=flux\n```\nRelated: #3270\n\n`flux diff` is great for identifying changes when the `Kustomization` object already exists on the cluster."
+      },
+      {
+        "title": "Apply the fix for Feature Request: Allow `flux diff ks` when the…",
+        "description": "One half of changes necessary to resolve https://github.com/fluxcd/flux2/issues/5781 ; makes use of changes introduced in the `pkg` dependency by https://github.com/fluxcd/pkg/pull/1153\n\nAs suggested, this change keeps the current behavior for building kustomizations internally as part of `flux build kustomization ...`, but allows users to opt-in with the `--in-memory-build` flag, which will use `filesys.MakeFsInMemory()`. \n\nTo keep things a bit cleaner, I opted to add a filesystem \"backend\"\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n flux -l app.kubernetes.io/name=flux\nkubectl get events -n flux --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Feature Request: Allow `flux diff ks` when the…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "One half of changes necessary to resolve https://github.com/fluxcd/flux2/issues/5781 ; makes use of changes introduced in the `pkg` dependency by https://github.com/fluxcd/pkg/pull/1153\n\nAs suggested, this change keeps the current behavior for building kustomizations internally as part of `flux build kustomization ...`, but allows users to opt-in with the `--in-memory-build` flag, which will use",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "flux",
+      "graduated",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "flux"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/fluxcd/flux2/issues/5439",
+      "repo": "https://github.com/fluxcd/flux2",
+      "pr": "https://github.com/fluxcd/flux2/pull/5794"
+    },
+    "reactions": 6,
+    "comments": 5,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with flux installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-14T06:38:26.846Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: flux — Feature Request: Allow `flux diff ks` when the `Kustomization` does not already exist

**Type:** feature | **Source:** https://github.com/fluxcd/flux2/issues/5439 (6 reactions)
**Fix PR:** https://github.com/fluxcd/flux2/pull/5794
**File:** `fixes/cncf-generated/flux/flux-5439-feature-request-allow-flux-diff-ks-when-the-kustomization-does-not-alr.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*