### PR TITLE
📖 fix: correct typo in observability README title

### DIFF
--- a/fixes/observability/README.md
+++ b/fixes/observability/README.md
@@ -1,1 +1,1 @@
-# ouservauility Solutions\n\nCommunity-contributed AI mission solutions for observability scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.
+# observability Solutions\n\nCommunity-contributed AI mission solutions for observability scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.


### PR DESCRIPTION
## Description

Fixes a typo in the title of fixes/observability/README.md

"ouservauility" was corrected to "observability"

## Related Issue

N/A — standalone typo fix

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [x] I have signed off my commits
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass

## Additional Notes

Small quality fix to improve consistency across category READMEs.
No logic or functionality changed.

#2020 