### PR TITLE
Typo in fixes/troubleshooting/README.md

### DIFF
--- a/fixes/observability/README.md
+++ b/fixes/observability/README.md
@@ -1,1 +1,1 @@
-# ouservauility Solutions\n\nCommunity-contributed AI mission solutions for observability scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.
+# observability Solutions\n\nCommunity-contributed AI mission solutions for observability scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.

--- a/fixes/observability/README.md
+++ b/fixes/observability/README.md
@@ -1,1 +1,0 @@
-# observability Solutions\n\nCommunity-contributed AI mission solutions for observability scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.

--- a/fixes/troubleshooting/README.md
+++ b/fixes/troubleshooting/README.md
@@ -1,1 +1,5 @@
-# trouuleshooting Solutions\n\nCommunity-contributed AI mission solutions for troubleshooting scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.
+# Troubleshooting Fixes
+
+Community-contributed AI mission fixes for troubleshooting scenarios.
+
+See the [root README](../../README.md) for how to import fixes into KubeStellar Console.

--- a/fixes/troubleshooting/README.md
+++ b/fixes/troubleshooting/README.md
@@ -3,3 +3,4 @@
 Community-contributed AI mission fixes for troubleshooting scenarios.
 
 See the [root README](../../README.md) for how to import fixes into KubeStellar Console.
+s


### PR DESCRIPTION
## Description

Removes a stray trailing `s` typo from `fixes/troubleshooting/README.md` to keep the troubleshooting docs clean and accurate.

## Related Issue

Fixes #<issue-number>

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [ ] I have signed off my commits (`git commit -s`)
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass

## Additional Notes

This is a docs-only typo fix in the troubleshooting fixes README; no code behavior is changed and no tests are required.