### PR TITLE
fix: correct typo in troubleshooting README title

### DIFF
--- a/fixes/troubleshooting/README.md
+++ b/fixes/troubleshooting/README.md
@@ -1,1 +1,1 @@
-# trouuleshooting Solutions\n\nCommunity-contributed AI mission solutions for troubleshooting scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.
+# troubleshooting Solutions\n\nCommunity-contributed AI mission solutions for troubleshooting scenarios.\n\nSee the [root README](../../README.md) for how to import solutions into KubeStellar Console.


### PR DESCRIPTION
## Description

Fixes a typo in the troubleshooting README title in `fixes/troubleshooting/README.md`.
This is a documentation-only change and does not affect code or behavior.

## Related Issue

Fixes #<issue-number>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [x] I have signed off my commits (`git commit -s`)
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass

## Additional Notes

Only the README title typo was corrected (`trouuleshooting` -> `troubleshooting`).
No other files or content were changed.

#2023 