### PR TITLE
✨ feat(schema): add optional mission.security field, populate install-kubevirt

### DIFF
--- a/fixes/cncf-install/install-kubevirt.json
+++ b/fixes/cncf-install/install-kubevirt.json
@@ -93,6 +93,32 @@
         "title": "kubectl virt reports plugin not found",
         "description": "If `kubectl virt version` returns `error: unknown command`, the krew-managed plugin directory may not be on your PATH. Add it per the krew install instructions:\n```bash\nexport PATH=\"${KREW_ROOT:-$HOME/.krew}/bin:$PATH\"\n```\nPersist it in your shell profile. Alternatively, invoke virtctl directly via the binary you downloaded to `/usr/local/bin/virtctl`."
       }
+    ],
+    "security": [
+      {
+        "title": "Cluster-scoped changes",
+        "description": "The install creates a dedicated `kubevirt` namespace, a set of CustomResourceDefinitions (KubeVirt, VirtualMachine, VirtualMachineInstance, and related types), several ClusterRoles and ClusterRoleBindings for the operator and per-component service accounts, and a ValidatingWebhookConfiguration. Review the manifests before apply: `curl -sL https://github.com/kubevirt/kubevirt/releases/download/${RELEASE}/kubevirt-operator.yaml | less`."
+      },
+      {
+        "title": "Privileged DaemonSet and host access",
+        "description": "The `virt-handler` DaemonSet runs as privileged on every eligible node because it must reach `/dev/kvm`, manage qemu processes, and set up networking for VMs. It mounts host paths including `/var/lib/kubelet` and the container runtime socket. On clusters that enforce the Pod Security Admission `restricted` profile, label the `kubevirt` namespace to allow privileged pods, or accept that `virt-handler` will fail to schedule: `kubectl label namespace kubevirt pod-security.kubernetes.io/enforce=privileged`."
+      },
+      {
+        "title": "API server privilege requirement",
+        "description": "The Kubernetes API server must run with `--allow-privileged=true` for the privileged virt-handler DaemonSet to be admitted. This is the default on managed Kubernetes (EKS, GKE, AKS) and kubeadm-based clusters, but is worth confirming before install. Without it, the KubeVirt CR will stay in the `Deploying` phase indefinitely."
+      },
+      {
+        "title": "Hardening: run without virtctl cluster-admin privilege",
+        "description": "`virtctl` operations run with the caller's RBAC. For non-administrator users, provision a Role that grants only the VM verbs you want available (`virtualmachines/start`, `virtualmachines/stop`, `virtualmachineinstances/console`) scoped to a specific namespace, rather than granting `cluster-admin`. Bind the Role via kubeconfig context to keep the permissions principal-local."
+      },
+      {
+        "title": "No /dev/kvm? Emulation mode is slow but contained",
+        "description": "Clusters without hardware virtualization can run KubeVirt with `spec.configuration.developerConfiguration.useEmulation: true` on the KubeVirt CR. This routes VM execution through QEMU software emulation. It is **not** recommended for production (orders-of-magnitude slower, higher CPU usage on hypervisor hosts), but it is a fully-contained option for dev/test and air-gapped environments. See the upstream doc: https://kubevirt.io/user-guide/cluster_admin/installation/"
+      },
+      {
+        "title": "Upstream security policy",
+        "description": "KubeVirt is a CNCF Incubating project with its own security policy and CVE reporting process at https://github.com/kubevirt/kubevirt/blob/main/SECURITY.md. Subscribe to the `kubevirt-security` mailing list for advisories. AppArmor and SELinux-on-nodes considerations are documented in the upstream user guide under https://kubevirt.io/user-guide/cluster_admin/installation/ — worth reading before rolling KubeVirt out on a hardened host OS."
+      }
     ]
   },
   "metadata": {


### PR DESCRIPTION
## Summary

Introduces an optional \`security\` array in the \`kc-mission-v1\` schema, alongside the existing \`steps\` / \`uninstall\` / \`upgrade\` / \`troubleshooting\` arrays. Each entry follows the same \`{ title, description }\` shape, so the console's existing \`StepCard\` component can render it unchanged.

**No scanner or build-index changes were needed** — the field is transparently handled by the existing JSON flow (\`build-index.mjs\` only indexes top-level metadata; \`scanner.mjs\` operates on all string values regardless of field name). Backwards-compatible: missions without a \`security\` field continue to parse and render cleanly.

## Populated mission: install-kubevirt.json

Six realistic security bullets as the first proof-of-concept, chosen because KubeVirt is one of the more security-sensitive installs in the catalog:

1. **Cluster-scoped changes** — CRDs, ClusterRoles/Bindings, ValidatingWebhookConfiguration created by the operator manifest
2. **Privileged DaemonSet and host access** — virt-handler needs \`/dev/kvm\`, kubelet dir, container runtime socket; Pod Security Admission \`restricted\` profile caveat with explicit namespace-label workaround
3. **API server \`--allow-privileged=true\` requirement** — why it's needed, which distros have it by default
4. **Hardening: run virtctl with scoped RBAC, not cluster-admin** — how to grant only VM verbs (\`virtualmachines/start\`, etc.) scoped to a namespace
5. **No \`/dev/kvm\`? Emulation mode is slow but contained** — \`spec.configuration.developerConfiguration.useEmulation: true\` for dev/test and air-gapped environments
6. **Upstream security policy** — link to \`kubevirt/SECURITY.md\` and the \`kubevirt-security\` advisory list

## Context

Paired with two kubestellar/console UI PRs landing in parallel:

- **SetupInstructionsDialog Security section** — surfaces the console's own security posture in the install modal
- **MissionDetailView Security tab** — renders \`mission.security\` as a new 5th tab (\`install | uninstall | upgrade | troubleshooting | **security**\`), with a fallback link to \`docs/security/SECURITY-MODEL.md\` when a mission has no security content yet

This PR is the data contract that the tab UI consumes. When \`mission.security\` is empty, the tab shows a \"no mission-specific notes yet\" state with a link to the overall security doc — so even missions without populated security content are useful.

## Follow-up missions to populate next

In order of recent engagement:
- install-chaos-mesh (privileged chaos-daemon DaemonSet, host-path socket mounts per runtime, safe-mode flag)
- install-kestra (dind sidecar privileged by default, H2 ephemeral vs external Postgres)
- install-modelpack-csi-driver (CSI driver runs as privileged DaemonSet)
- install-opencost (relatively unprivileged, but note Prometheus data access + optional cloud-provider credentials)
- install-longhorn (node-level storage, host filesystem access, privileged instance-manager)

## Test plan

- [x] JSON parses and security has 6 steps
- [x] Scanner regex (\`\`/\`[^\`]*(?:\\$\\(|;|&&|\\|\\|)[^\`]*\`/g\`\`) returns zero hits locally — no false positives from the new content
- [x] No banned patterns (\`rm -rf\`, \`delete crd --all\`, \`--all-namespaces\`)
- [ ] After merge, verify https://console.kubestellar.io/missions/install-kubevirt renders the new Security tab once the console UI PR lands