### PR TITLE
🌱 harbor: "Prevent vulnerable images from running" is broken

### DIFF
--- a/fixes/cncf-generated/harbor/harbor-16732-prevent-vulnerable-images-from-running-is-broken.json
+++ b/fixes/cncf-generated/harbor/harbor-16732-prevent-vulnerable-images-from-running-is-broken.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "harbor-16732-prevent-vulnerable-images-from-running-is-broken",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "harbor: \"Prevent vulnerable images from running\" is broken",
+    "description": "\"Prevent vulnerable images from running\" is broken. This issue affects 11+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify harbor troubleshoot symptoms",
+        "description": "Check for the issue in your harbor setup:\nCheck your harbor dependency version in your project manifest.\nCheck your build output and test logs for errors related to this issue."
+      },
+      {
+        "title": "Review harbor configuration",
+        "description": "Review the relevant harbor configuration:\nAs the title says, \"Prevent vulnerable images from running\" is broken. It works fine for images that have been scanned, but there are times that images can make it into the registry without being scanned."
+      },
+      {
+        "title": "Apply the fix for \"Prevent vulnerable images from running\" is broken",
+        "description": "Apply the configuration change to resolve the issue:\n```yaml\n> docker pull my-registry/test/rancher/mirrored-coreos-etcd:v3.5.3\nv3.5.3: Pulling from rancher/mirrored-coreos-etcd\ndbba69284b27: Pull complete\n7aafad10ecdb: Pull complete\nf495bd50cdec: Pull complete\n13d34bcbe78f: Pull complete\nbb931e01bb50: Pull complete\na3f9b9b98618: Pull complete\n93a8b8e7955a: Pull complete\nDigest: sha256:a1011f42ce95738fea37d0693a7cb34826c1f7d0301ea14de4c300735377d8e4\nStatus: Downloaded newer image for my-registry/test/rancher/mirrored-coreos-etcd:v3.5.3\nmy-registry/test/rancher/mirrored-coreos-etcd:v3.5.3\n```"
+      },
+      {
+        "title": "Confirm \"Prevent vulnerable images from running\" is broken is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest harbor to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "See the source issue for the community-verified solution: https://github.com/goharbor/harbor/issues/16732",
+      "codeSnippets": [
+        "> docker pull my-registry/test/rancher/mirrored-coreos-etcd:v3.5.3\nv3.5.3: Pulling from rancher/mirrored-coreos-etcd\ndbba69284b27: Pull complete\n7aafad10ecdb: Pull complete\nf495bd50cdec: Pull complete\n13d34bcbe78f: Pull complete\nbb931e01bb50: Pull complete\na3f9b9b98618: Pull complete\n93a8b8e7955a: Pull complete\nDigest: sha256:a1011f42ce95738fea37d0693a7cb34826c1f7d0301ea14de4c300735377d8e4\nStatus: Downloaded newer image for my-registry/test/rancher/mirrored-coreos-etcd:v3.5.3\nmy-registry/test/rancher/mirrored-coreos-etcd:v3.5.3"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "harbor",
+      "graduated",
+      "security",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "harbor"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/goharbor/harbor/issues/16732",
+      "repo": "https://github.com/goharbor/harbor"
+    },
+    "reactions": 11,
+    "comments": 9,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "docker-compose",
+      "curl"
+    ],
+    "description": "A working harbor installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-04-16T06:40:04.233Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: harbor — "Prevent vulnerable images from running" is broken

**Type:** troubleshoot | **Source:** https://github.com/goharbor/harbor/issues/16732 (11 reactions)
**File:** `fixes/cncf-generated/harbor/harbor-16732-prevent-vulnerable-images-from-running-is-broken.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*