### PR TITLE
🌱 litellm: [Bug]: LiteLLM 1.82.1 OpenRouter Model IDs no longer working

### DIFF
--- a/fixes/cncf-generated/litellm/litellm-22667-bug-litellm-1-82-1-openrouter-model-ids-no-longer-working.json
+++ b/fixes/cncf-generated/litellm/litellm-22667-bug-litellm-1-82-1-openrouter-model-ids-no-longer-working.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "litellm-22667-bug-litellm-1-82-1-openrouter-model-ids-no-longer-working",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "litellm: [Bug]: LiteLLM 1.82.1 OpenRouter Model IDs no longer working",
+    "description": "[Bug]: LiteLLM 1.82.1 OpenRouter Model IDs no longer working. This issue affects 18+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify litellm troubleshoot symptoms",
+        "description": "Check for the issue in your litellm deployment:\n```bash\nkubectl get pods -n litellm -l app.kubernetes.io/name=litellm\nkubectl logs -l app.kubernetes.io/name=litellm -n litellm --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review litellm configuration",
+        "description": "Inspect the relevant litellm configuration:\n```bash\nkubectl get all -n litellm -l app.kubernetes.io/name=litellm\nkubectl get configmap -n litellm -l app.kubernetes.io/part-of=litellm\n```\n### Check for existing issues\n\n### What happened?\n\n´´´\nError fetching response 400 litellm.BadRequestError: OpenrouterException - {\"error\":{\"message\":\"openrouter/google/gemini-3-flash-preview is not a valid model"
+      },
+      {
+        "title": "Apply the fix for [Bug]: LiteLLM 1.82.1 OpenRouter Model IDs no longer working",
+        "description": "We hit the same issue after upgrading to 1.82.3. All OpenRouter models started returning `400 \"not a valid model ID\"` — the proxy was sending `openrouter/google/gemini-3-pro-preview` instead of `google/gemini-3-pro-preview`.\n\nRoot cause is the early-return in `get_llm_provider()` added by #22320\n```yaml\nError fetching response:Error: 400 litellm.BadRequestError: OpenrouterException - {\"error\":{\"message\":\"openrouter/google/gemini-3-flash-preview is not a valid model ID\",\"code\":400},\"user_id\":\"user_2s3Tb9aAYUh7JZG8C0uQRqpHIts\"}. Received Model Group=openrouter/google/gemini-3-flash-preview\nAvailable Model Group Fallbacks=None\n```"
+      },
+      {
+        "title": "Confirm [Bug]: LiteLLM 1.82.1 OpenRouter Model IDs no… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=litellm -n litellm --tail=50 --since=5m\nkubectl get events -n litellm --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "We hit the same issue after upgrading to 1.82.3. All OpenRouter models started returning `400 \"not a valid model ID\"` — the proxy was sending `openrouter/google/gemini-3-pro-preview` instead of `google/gemini-3-pro-preview`.\n\nRoot cause is the early-return in `get_llm_provider()` added by #22320 (commit `09ef5e67`).",
+      "codeSnippets": [
+        "Error fetching response:Error: 400 litellm.BadRequestError: OpenrouterException - {\"error\":{\"message\":\"openrouter/google/gemini-3-flash-preview is not a valid model ID\",\"code\":400},\"user_id\":\"user_2s3Tb9aAYUh7JZG8C0uQRqpHIts\"}. Received Model Group=openrouter/google/gemini-3-flash-preview\nAvailable Model Group Fallbacks=None",
+        "OpenrouterException - {\"error\":{\"message\":\"openrouter/nvidia/nemotron-3-super-120b-a12b:free is not a valid model ID\",\"code\":400},\"user_id\":\"user_xxxx\"}."
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "litellm",
+      "community",
+      "llm-gateway",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "litellm"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/BerriAI/litellm/issues/22667",
+      "repo": "https://github.com/BerriAI/litellm"
+    },
+    "reactions": 18,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with litellm installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-16T07:02:47.554Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: litellm — [Bug]: LiteLLM 1.82.1 OpenRouter Model IDs no longer working

**Type:** troubleshoot | **Source:** https://github.com/BerriAI/litellm/issues/22667 (18 reactions)
**File:** `fixes/cncf-generated/litellm/litellm-22667-bug-litellm-1-82-1-openrouter-model-ids-no-longer-working.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*