### PR TITLE
🐛 fix: enhance harbor-16732 mission with specific commands (#2031)

### DIFF
--- a/fixes/cncf-generated/harbor/harbor-16732-prevent-vulnerable-images-from-running-is-broken.json
+++ b/fixes/cncf-generated/harbor/harbor-16732-prevent-vulnerable-images-from-running-is-broken.json
@@ -1,0 +1,87 @@
+{
+  "version": "kc-mission-v1",
+  "name": "harbor-16732-prevent-vulnerable-images-from-running-is-broken",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "harbor: \"Prevent vulnerable images from running\" bypassed on first proxy cache pull",
+    "description": "When a Harbor project is configured as a proxy cache for an upstream registry (e.g., Docker Hub) with \"Prevent vulnerable images from running\" enabled, the first pull of an image bypasses vulnerability enforcement entirely. The image is served to the client before it is cached and scanned, so the vulnerability policy only takes effect on the second pull. This affects Harbor 2.2.1+ and has 11+ reactions from users whose security teams are impacted.\n\nError seen on second pull (but NOT on the first):\n```\nunknown: current image with 77 vulnerabilities cannot be pulled due to configured policy in 'Prevent images with vulnerability severity of \"Low\" or higher from running.' To continue with pull, please contact your project administrator to exempt matched vulnerabilities through configuring the CVE allowlist.\n```",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Reproduce: configure a Harbor proxy cache project with vulnerability prevention",
+        "description": "Create a Harbor project configured as a proxy cache for Docker Hub with vulnerability prevention enabled:\n1. In the Harbor UI, create a new project (e.g., `test`) with \"Proxy Cache\" enabled, pointing to a Docker Hub registry endpoint.\n2. Under **Project > Configuration**, enable:\n   - \"Automatically scan images on push\"\n   - \"Prevent vulnerable images from running\" (set severity to \"Low\")\n   - Leave the CVE allowlist empty.\n\nVerify the settings via the Harbor API:\n```bash\n# Check project configuration\ncurl -s -u admin:Harbor12345 \\\n  https://<harbor-host>/api/v2.0/projects/<project-name> | jq '.metadata'\n```\nExpected metadata includes `auto_scan: \"true\"` and `prevent_vul: \"true\"` with `severity: \"low\"`."
+      },
+      {
+        "title": "Demonstrate the bypass: first pull succeeds despite vulnerabilities",
+        "description": "Pull a known-vulnerable image through the proxy cache for the first time:\n```bash\ndocker pull <harbor-host>/test/rancher/mirrored-coreos-etcd:v3.5.3\n```\nThis pull succeeds even though the image contains critical vulnerabilities. Harbor proxies the request directly to Docker Hub and streams layers to the client before caching or scanning the image.\n\nAfter the first pull, verify the image was cached and scanned:\n```bash\n# Check that Harbor now shows vulnerabilities for the cached image\ncurl -s -u admin:Harbor12345 \\\n  https://<harbor-host>/api/v2.0/projects/test/repositories/rancher%2Fmirrored-coreos-etcd/artifacts/v3.5.3 \\\n  | jq '.scan_overview'\n```\n\nAttempt a second pull — this one is correctly blocked:\n```bash\ndocker pull <harbor-host>/test/rancher/mirrored-coreos-etcd:v3.5.3\n# Error: unknown: current image with 77 vulnerabilities cannot be pulled\n# due to configured policy in 'Prevent images with vulnerability severity\n# of \"Low\" or higher from running.'\n```"
+      },
+      {
+        "title": "Understand the root cause: proxy cache flow serves before scanning",
+        "description": "Harbor's proxy cache processes requests in this order:\n1. Receive pull request from client\n2. Fetch image from upstream registry\n3. **Stream image layers to the client** (pull succeeds)\n4. Store image in local cache\n5. Trigger vulnerability scan on cached image\n\nBecause the image is served to the client (step 3) before it is cached and scanned (steps 4-5), the vulnerability prevention policy has no image scan data to evaluate on the first pull. The policy only takes effect on subsequent pulls when scan results exist.\n\nThis is confirmed as by-design behavior by Harbor contributors, but it creates a security gap where the first pull of any image through a proxy cache always bypasses vulnerability enforcement."
+      },
+      {
+        "title": "Mitigate: use a Kubernetes admission controller to block unscanned images",
+        "description": "Since Harbor cannot enforce vulnerability policies on the first proxy cache pull, deploy a Kubernetes admission controller as a defense-in-depth layer:\n\n**Option A: Use an OPA/Gatekeeper policy to require image scan results:**\n```yaml\napiVersion: templates.gatekeeper.sh/v1\nkind: ConstraintTemplate\nmetadata:\n  name: harborimagescanrequired\nspec:\n  crd:\n    spec:\n      names:\n        kind: HarborImageScanRequired\n  targets:\n    - target: admission.k8s.gatekeeper.sh\n      rego: |\n        package harborimagescanrequired\n        violation[{\"msg\": msg}] {\n          container := input.review.object.spec.containers[_]\n          image := container.image\n          contains(image, \"<harbor-host>\")\n          # Call Harbor API to check if scan results exist\n          # Block if no scan data is available\n          msg := sprintf(\"Image %v has not been scanned by Harbor\", [image])\n        }\n```\n\n**Option B: Pre-pull and scan images before deploying to production:**\n```bash\n# Pre-pull an image to trigger caching and scanning\ndocker pull <harbor-host>/test/<image>:<tag>\n\n# Wait for scan to complete\nfor i in $(seq 1 30); do\n  SCAN_STATUS=$(curl -s -u admin:Harbor12345 \\\n    \"https://<harbor-host>/api/v2.0/projects/test/repositories/<image>/artifacts/<tag>\" \\\n    | jq -r '.scan_overview | to_entries[0].value.scan_status')\n  if [ \"$SCAN_STATUS\" = \"Success\" ]; then\n    echo \"Scan complete\"\n    break\n  fi\n  echo \"Waiting for scan... ($SCAN_STATUS)\"\n  sleep 10\ndone\n\n# Now subsequent pulls in the cluster will be subject to vulnerability policy\n```\n\n**Option C: Avoid proxy cache for security-sensitive projects.** Use Harbor's replication feature to pull and scan images ahead of time instead of on-demand proxy caching."
+      },
+      {
+        "title": "Verify the mitigation is effective",
+        "description": "After deploying the chosen mitigation, verify that vulnerable images cannot reach your cluster:\n```bash\n# If using admission controller, try deploying a pod with a known-vulnerable image\nkubectl run test-vuln --image=<harbor-host>/test/rancher/mirrored-coreos-etcd:v3.5.3 --dry-run=server\n# Should be rejected by the admission controller\n\n# If using pre-pull strategy, confirm scan results exist before deployment\ncurl -s -u admin:Harbor12345 \\\n  \"https://<harbor-host>/api/v2.0/projects/test/repositories/rancher%2Fmirrored-coreos-etcd/artifacts/v3.5.3\" \\\n  | jq '{scan_status: .scan_overview | to_entries[0].value.scan_status, severity: .scan_overview | to_entries[0].value.severity}'\n\n# Confirm Harbor blocks the pull on second attempt\ndocker pull <harbor-host>/test/rancher/mirrored-coreos-etcd:v3.5.3\n# Expected: blocked by vulnerability policy\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "Harbor's \"Prevent vulnerable images from running\" policy is bypassed on the first pull through a proxy cache project because the proxy cache architecture streams image layers directly to the client before caching and scanning. The vulnerability scan only runs after the image is stored locally, so the policy has no scan data to enforce on the initial request. This is confirmed by-design behavior (the proxy cannot scan what it has not yet cached). Mitigations include: (1) deploying a Kubernetes admission controller (OPA/Gatekeeper or Kyverno) to reject pods using unscanned images, (2) pre-pulling images to trigger caching and scanning before production use, or (3) using Harbor replication instead of proxy caching for security-critical projects.",
+      "codeSnippets": [
+        "# Harbor project configuration showing vulnerability prevention settings\n# metadata.auto_scan: \"true\"\n# metadata.prevent_vul: \"true\"\n# metadata.severity: \"low\"\ncurl -s -u admin:Harbor12345 \\\n  https://<harbor-host>/api/v2.0/projects/<project-name> | jq '.metadata'",
+        "# Error message seen on second pull (but NOT first) when vulnerability policy blocks:\n# unknown: current image with 77 vulnerabilities cannot be pulled due to\n# configured policy in 'Prevent images with vulnerability severity of \"Low\"\n# or higher from running.' To continue with pull, please contact your project\n# administrator to exempt matched vulnerabilities through configuring the\n# CVE allowlist.",
+        "# Pre-pull script to trigger caching and scanning before production deployment\nSCAN_POLL_INTERVAL_SEC=10\nSCAN_POLL_MAX_ATTEMPTS=30\n\ndocker pull <harbor-host>/test/<image>:<tag>\nfor i in $(seq 1 $SCAN_POLL_MAX_ATTEMPTS); do\n  SCAN_STATUS=$(curl -s -u admin:Harbor12345 \\\n    \"https://<harbor-host>/api/v2.0/projects/test/repositories/<image>/artifacts/<tag>\" \\\n    | jq -r '.scan_overview | to_entries[0].value.scan_status')\n  if [ \"$SCAN_STATUS\" = \"Success\" ]; then\n    echo \"Scan complete — vulnerability policy now enforced\"\n    break\n  fi\n  echo \"Waiting for scan... ($SCAN_STATUS)\"\n  sleep $SCAN_POLL_INTERVAL_SEC\ndone",
+        "# Harbor proxy cache request flow (explains the bypass):\n# 1. Client sends pull request to Harbor\n# 2. Harbor fetches image from upstream registry (e.g., Docker Hub)\n# 3. Harbor streams layers to client (pull succeeds — NO scan check)\n# 4. Harbor stores image in local cache\n# 5. Harbor triggers vulnerability scan on cached image\n# 6. Subsequent pulls ARE subject to vulnerability policy"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "harbor",
+      "graduated",
+      "security",
+      "troubleshoot",
+      "proxy-cache",
+      "vulnerability-scanning"
+    ],
+    "cncfProjects": [
+      "harbor"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/goharbor/harbor/issues/16732",
+      "repo": "https://github.com/goharbor/harbor"
+    },
+    "reactions": 11,
+    "comments": 9,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl",
+      "helm",
+      "docker",
+      "curl",
+      "jq"
+    ],
+    "description": "A running Kubernetes cluster with Harbor 2.2+ deployed as a proxy cache for an upstream registry (e.g., Docker Hub). Docker CLI configured to use the Harbor registry."
+  },
+  "security": {
+    "scannedAt": "2026-04-16T00:00:00.000Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## Summary
- Adds detailed mission JSON for Harbor issue #16732 ("Prevent vulnerable images from running" bypassed on first proxy cache pull)
- Includes exact Harbor API commands, the actual error message, and root cause analysis explaining the proxy cache flow (stream-then-cache architecture)
- Provides three mitigation strategies: OPA/Gatekeeper admission controller, pre-pull scanning script, and Harbor replication as an alternative to proxy caching
- Verified against upstream issue context at https://github.com/goharbor/harbor/issues/16732 (11 reactions, confirmed by-design by Harbor contributors)

## Test plan
- [x] JSON validates with `python3 -m json.tool`
- [x] `node scripts/scanner.mjs` runs clean
- [x] All Harbor API endpoints and commands reference real Harbor v2.0 API paths
- [x] Error message matches the actual error from the upstream issue

Fixes #2031