### PR TITLE
🌱 falcosidekick: Create Configurable Toggle To enable/disable `falco_events` prom metric

### DIFF
--- a/fixes/cncf-generated/falcosidekick/falcosidekick-1132-create-configurable-toggle-to-enable-disable-falco-events-pro.json
+++ b/fixes/cncf-generated/falcosidekick/falcosidekick-1132-create-configurable-toggle-to-enable-disable-falco-events-pro.json
@@ -1,0 +1,81 @@
+{
+  "version": "kc-mission-v1",
+  "name": "falcosidekick-1132-create-configurable-toggle-to-enable-disable-falco-events-pro",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "falcosidekick: Create Configurable Toggle To enable/disable `falco_events` prom metric",
+    "description": "Create Configurable Toggle To enable/disable `falco_events` prom metric. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current falcosidekick deployment",
+        "description": "Verify your falcosidekick version and configuration:\n```bash\nkubectl get pods -n falcosidekick -l app.kubernetes.io/name=falcosidekick\nhelm list -n falcosidekick 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working falcosidekick installation."
+      },
+      {
+        "title": "Review falcosidekick configuration",
+        "description": "Inspect the relevant falcosidekick configuration:\n```bash\nkubectl get all -n falcosidekick -l app.kubernetes.io/name=falcosidekick\nkubectl get configmap -n falcosidekick -l app.kubernetes.io/part-of=falcosidekick\n```\n**Motivation**\n\n👋 Hi sidekick project! \n\nI'm not sure if this is bug or a feature request. Our instances of sidekick are periodically OOMing."
+      },
+      {
+        "title": "Apply the fix for Create Configurable Toggle To enable/disable `falco_events`…",
+        "description": "Hi,\n\nThank you for this detailed report. This is an old known issue with the prometheus metrics.\n\nI agree the metric `falco_events` is not relevant anymore. Since the last versions of Falco, Falco exposes itself this metric with a Prom endpoint, before that, it required the `falco-exporter`\n```yaml\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-nbkvb\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 1\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-ngr75\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 3\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-nhjlk\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 3\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<name\n```"
+      },
+      {
+        "title": "Upgrade falcosidekick to include the fix",
+        "description": "If the fix is included in a newer release, upgrade falcosidekick:\n```bash\nhelm repo update\nhelm upgrade falcosidekick falcosidekick/falcosidekick --namespace falcosidekick\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n falcosidekick\nhelm list -n falcosidekick\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n falcosidekick -l app.kubernetes.io/name=falcosidekick\nkubectl get events -n falcosidekick --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Create Configurable Toggle To enable/disable `falco_events`…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Hi,\n\nThank you for this detailed report. This is an old known issue with the prometheus metrics.\n\nI agree the metric `falco_events` is not relevant anymore. Since the last versions of Falco, Falco exposes itself this metric with a Prom endpoint, before that, it required the `falco-exporter` component which is now deprecated.",
+      "codeSnippets": [
+        "falco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-nbkvb\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 1\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-ngr75\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 3\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-nhjlk\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 3\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\",k8s_pod_name=\"<pod name here>-6c66cccf94-nmfct\",priority=\"Notice\",rule=\"<rule name here>\",source=\"syscall\"} 1\nfalco_events{hostname=\"falco-rw2n7\",k8s_ns_name=\"<namespace name here>\","
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "falcosidekick",
+      "graduated",
+      "security",
+      "feature"
+    ],
+    "cncfProjects": [
+      "falcosidekick"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/falcosecurity/falcosidekick/issues/1132",
+      "repo": "https://github.com/falcosecurity/falcosidekick"
+    },
+    "reactions": 1,
+    "comments": 16,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with falcosidekick installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-21T06:45:23.029Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: falcosidekick — Create Configurable Toggle To enable/disable `falco_events` prom metric

**Type:** feature | **Source:** https://github.com/falcosecurity/falcosidekick/issues/1132 (1 reactions)
**File:** `fixes/cncf-generated/falcosidekick/falcosidekick-1132-create-configurable-toggle-to-enable-disable-falco-events-pro.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*