### PR TITLE
🌱 atlantis: HashiCorp GPG key expired - openpgp: key expired when downloading Terraform

### DIFF
--- a/fixes/cncf-generated/atlantis/atlantis-6405-hashicorp-gpg-key-expired-openpgp-key-expired-when-downloading-ter.json
+++ b/fixes/cncf-generated/atlantis/atlantis-6405-hashicorp-gpg-key-expired-openpgp-key-expired-when-downloading-ter.json
@@ -1,0 +1,82 @@
+{
+  "version": "kc-mission-v1",
+  "name": "atlantis-6405-hashicorp-gpg-key-expired-openpgp-key-expired-when-downloading-ter",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "atlantis: HashiCorp GPG key expired - openpgp: key expired when downloading Terraform",
+    "description": "HashiCorp GPG key expired - openpgp: key expired when downloading Terraform. This issue affects 40+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify atlantis troubleshoot symptoms",
+        "description": "Check for the issue in your atlantis deployment:\n```bash\nkubectl get pods -n atlantis -l app.kubernetes.io/name=atlantis\nkubectl logs -l app.kubernetes.io/name=atlantis -n atlantis --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review atlantis configuration",
+        "description": "Inspect the relevant atlantis configuration:\n```bash\nkubectl get all -n atlantis -l app.kubernetes.io/name=atlantis\nkubectl get configmap -n atlantis -l app.kubernetes.io/part-of=atlantis\n```\n### Overview of the Issue\n\nHashiCorp's GPG key (`72D7468F`) expired on April 18, 2026, causing Atlantis to fail when downloading Terraform binaries."
+      },
+      {
+        "title": "Apply the fix for HashiCorp GPG key expired - openpgp: key expired when…",
+        "description": "## What\n- Bumps `github.com/hashicorp/hc-install` from v0.9.2 to v0.9.4\n- Bumps Go from 1.25.4 to 1.25.8 in `go.mod` and `Dockerfile`\n- Bumps Go from 1.25.3 to 1.25.8 in `testing/Dockerfile`\n\n## Why\nhc-install v0.9.4 requires `go >= 1.25.8`. All Dockerfile base images updated to match.\n\n##\n```yaml\nerror downloading terraform version 1.14.8: unable to verify checksums signature: openpgp: key expired\n```"
+      },
+      {
+        "title": "Upgrade atlantis to include the fix",
+        "description": "If the fix is included in a newer release, upgrade atlantis:\n```bash\nhelm repo update\nhelm upgrade atlantis atlantis/atlantis --namespace atlantis\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n atlantis\nhelm list -n atlantis\n```"
+      },
+      {
+        "title": "Confirm HashiCorp GPG key expired - openpgp: key expired… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=atlantis -n atlantis --tail=50 --since=5m\nkubectl get events -n atlantis --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "## What\n- Bumps `github.com/hashicorp/hc-install` from v0.9.2 to v0.9.4\n- Bumps Go from 1.25.4 to 1.25.8 in `go.mod` and `Dockerfile`\n- Bumps Go from 1.25.3 to 1.25.8 in `testing/Dockerfile`\n\n## Why\nhc-install v0.9.4 requires `go >= 1.25.8`. All Dockerfile base images updated to match.",
+      "codeSnippets": [
+        "error downloading terraform version 1.14.8: unable to verify checksums signature: openpgp: key expired",
+        "error downloading terraform version 1.14.8: unable to verify checksums signature: openpgp: key expired\n​"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "atlantis",
+      "sandbox",
+      "app-definition",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "atlantis"
+    ],
+    "targetResourceKinds": [
+      "Deployment"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/runatlantis/atlantis/issues/6405",
+      "repo": "https://github.com/runatlantis/atlantis",
+      "pr": "https://github.com/runatlantis/atlantis/pull/6410"
+    },
+    "reactions": 40,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with atlantis installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-21T06:49:13.376Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: atlantis — HashiCorp GPG key expired - openpgp: key expired when downloading Terraform

**Type:** troubleshoot | **Source:** https://github.com/runatlantis/atlantis/issues/6405 (40 reactions)
**Fix PR:** https://github.com/runatlantis/atlantis/pull/6410
**File:** `fixes/cncf-generated/atlantis/atlantis-6405-hashicorp-gpg-key-expired-openpgp-key-expired-when-downloading-ter.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*