### PR TITLE
🌱 vault: Vault 2.0.0 Docker image fails to start: unable to set CAP_SETFCAP effective

### DIFF
--- a/fixes/cncf-generated/vault/vault-31919-vault-2-0-0-docker-image-fails-to-start-unable-to-set-cap-setfcap-ef.json
+++ b/fixes/cncf-generated/vault/vault-31919-vault-2-0-0-docker-image-fails-to-start-unable-to-set-cap-setfcap-ef.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "vault-31919-vault-2-0-0-docker-image-fails-to-start-unable-to-set-cap-setfcap-ef",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "vault: Vault 2.0.0 Docker image fails to start: unable to set CAP_SETFCAP effective capability",
+    "description": "Vault 2.0.0 Docker image fails to start: unable to set CAP_SETFCAP effective capability. This issue affects 13+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify vault troubleshoot symptoms",
+        "description": "Check for the issue in your vault installation:\n```bash\nvault version\nvault status\n```\nLook for errors or warnings that may indicate the issue."
+      },
+      {
+        "title": "Review vault configuration",
+        "description": "Review the relevant vault configuration:\nAfter upgrading Docker image from `1.21.4` to `2.0.0`, the container fails during startup with the following message:\n\n```\nunable to set CAP_SETFCAP effective capability: Operation not permitted\n```\n\nThis happens because the container now runs as"
+      },
+      {
+        "title": "Apply the fix for Vault 2.0.0 Docker image fails to start: unable to set…",
+        "description": "the suggested workaround works fine for the development server, which does not use memory locking (`Mlock: supported: true, enabled: false`), but it fails in production mode.\n\nTrying [another example from the image\n```yaml\nunable to set CAP_SETFCAP effective capability: Operation not permitted\n```"
+      },
+      {
+        "title": "Confirm Vault 2.0.0 Docker image fails to start: unable… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest vault to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "the suggested workaround works fine for the development server, which does not use memory locking (`Mlock: supported: true, enabled: false`), but it fails in production mode.",
+      "codeSnippets": [
+        "unable to set CAP_SETFCAP effective capability: Operation not permitted",
+        "docker run --rm  --cap-add=IPC_LOCK --name=dev-vault hashicorp/vault",
+        "unable to set CAP_SETFCAP effective capability: Operation not permitted"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "vault",
+      "community",
+      "secrets",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "vault"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/hashicorp/vault/issues/31919",
+      "repo": "https://github.com/hashicorp/vault"
+    },
+    "reactions": 13,
+    "comments": 5,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "vault"
+    ],
+    "description": "A working vault installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-04-21T07:05:22.496Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: vault — Vault 2.0.0 Docker image fails to start: unable to set CAP_SETFCAP effective capability

**Type:** troubleshoot | **Source:** https://github.com/hashicorp/vault/issues/31919 (13 reactions)
**File:** `fixes/cncf-generated/vault/vault-31919-vault-2-0-0-docker-image-fails-to-start-unable-to-set-cap-setfcap-ef.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*