### PR TITLE
🌱 envoy: Expose stats api to lua filter scripts

### DIFF
--- a/fixes/cncf-generated/envoy/envoy-3538-expose-stats-api-to-lua-filter-scripts.json
+++ b/fixes/cncf-generated/envoy/envoy-3538-expose-stats-api-to-lua-filter-scripts.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "envoy-3538-expose-stats-api-to-lua-filter-scripts",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "envoy: Expose stats api to lua filter scripts",
+    "description": "Expose stats api to lua filter scripts. Requested by 41+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current envoy deployment",
+        "description": "Verify your envoy version and configuration:\n```bash\nkubectl get pods -n envoy -l app.kubernetes.io/name=envoy\nhelm list -n envoy 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working envoy installation."
+      },
+      {
+        "title": "Review envoy configuration",
+        "description": "Inspect the relevant envoy configuration:\n```bash\nkubectl get all -n envoy -l app.kubernetes.io/name=envoy\nkubectl get configmap -n envoy -l app.kubernetes.io/part-of=envoy\n```\n*Title*: Expose stats api to lua filter scripts\n\n*Description*: It would be great if lua filter scripts could somehow hook into the envoy stats infrastructure so that, for instance, they could increment custom counters based on conditions"
+      },
+      {
+        "title": "Apply the fix for Expose stats api to lua filter scripts",
+        "description": "it was a local branch with everything hacked up, so I didn't push it.\n```yaml\nmetrics.inc(request_handle, \"my.metric.name\", { \"my_tag:\" .. tag_value })\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n envoy -l app.kubernetes.io/name=envoy\nkubectl get events -n envoy --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Expose stats api to lua filter scripts\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "it was a local branch with everything hacked up, so I didn't push it.",
+      "codeSnippets": [
+        "metrics.inc(request_handle, \"my.metric.name\", { \"my_tag:\" .. tag_value })"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "envoy",
+      "graduated",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "envoy"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/envoyproxy/envoy/issues/3538",
+      "repo": "https://github.com/envoyproxy/envoy"
+    },
+    "reactions": 41,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with envoy installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-22T06:43:14.437Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: envoy — Expose stats api to lua filter scripts

**Type:** feature | **Source:** https://github.com/envoyproxy/envoy/issues/3538 (41 reactions)
**File:** `fixes/cncf-generated/envoy/envoy-3538-expose-stats-api-to-lua-filter-scripts.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*