### PR TITLE
✨ Update Armada install mission to use Armada Operator

### DIFF
--- a/fixes/cncf-install/install-armada.json
+++ b/fixes/cncf-install/install-armada.json
@@ -6,43 +6,55 @@
   "authorGithub": "kubestellar",
   "mission": {
     "title": "Install and Configure Armada on Kubernetes",
-    "description": "Armada is a CNCF sandbox project for multi-cluster batch job scheduling. It enables efficient queuing, scheduling, and management of high-throughput compute workloads across multiple Kubernetes clusters, ideal for enterprises with large-scale batch processing needs.",
+    "description": "Armada is a CNCF sandbox project for multi-cluster batch job scheduling. It enables efficient queuing, scheduling, and management of high-throughput compute workloads across multiple Kubernetes clusters. This mission covers both the recommended Armada Operator method and the manual Helm-based approach.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Install prerequisites",
-        "description": "Armada requires several dependencies to be installed first. Ensure the following are running in your cluster:\n\n- **PostgreSQL** — persistent storage for job metadata\n- **Redis** — caching layer\n- **Apache Pulsar** — message broker for inter-component communication\n\nYou can install these via Helm:\n```bash\nhelm repo add bitnami https://charts.bitnami.com/bitnami\nhelm install postgresql bitnami/postgresql --namespace armada --create-namespace\nhelm install redis bitnami/redis --namespace armada\nhelm repo add apache https://pulsar.apache.org/charts\nhelm install pulsar apache/pulsar --namespace armada\n```"
+        "title": "Install the Armada Operator (recommended)",
+        "description": "The Armada Operator is the recommended way to install Armada. It uses Custom Resource Definitions (CRDs) to manage the lifecycle of Armada services.\n\n```bash\nhelm repo add gresearch https://g-research.github.io/charts\nhelm repo update\nhelm install armada-operator gresearch/armada-operator --namespace armada-system --create-namespace\n```\n\nVerify the operator is running:\n```bash\nkubectl get pods --namespace armada-system\n```"
       },
       {
-        "title": "Add the Armada Helm repository",
-        "description": "Add the G-Research Helm repository:\n```bash\nhelm repo add gresearch https://g-research.github.io/charts\nhelm repo update\n```"
+        "title": "Install Armada dependencies",
+        "description": "Armada requires several external dependencies:\n\n- **PostgreSQL** — persistent storage for job metadata\n- **Redis** — caching layer\n- **Apache Pulsar** — message broker for inter-component communication\n- **kube-prometheus-stack** — monitoring\n\nInstall via Helm:\n```bash\nhelm repo add bitnami https://charts.bitnami.com/bitnami\nhelm repo add apache https://pulsar.apache.org/charts\nhelm repo add prometheus-community https://prometheus-community.github.io/helm-charts\nhelm repo update\n\nhelm install postgresql bitnami/postgresql --namespace armada --create-namespace\nhelm install redis bitnami/redis --namespace armada\nhelm install pulsar apache/pulsar --namespace armada\nhelm install kube-prometheus-stack prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace\n```\n\nWait for all dependencies to be ready:\n```bash\nkubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgresql --namespace armada --timeout=300s\nkubectl wait --for=condition=ready pod -l app.kubernetes.io/name=redis --namespace armada --timeout=300s\n```"
       },
       {
-        "title": "Install Armada server using Helm",
-        "description": "Install the Armada server. You will need to configure the values to point to your PostgreSQL, Redis, and Pulsar instances:\n```bash\nhelm install armada-server gresearch/armada --namespace armada --version 0.20.36\n```\n\nFor a complete deployment, you also need the executor (per worker cluster) and scheduler:\n```bash\nhelm install armada-executor gresearch/armada-executor --namespace armada\nhelm install armada-scheduler gresearch/armada-scheduler --namespace armada\n```"
+        "title": "Deploy Armada components via CRDs",
+        "description": "With the Armada Operator running and dependencies ready, deploy Armada components using Custom Resources:\n\n```bash\nkubectl create namespace armada\nkubectl apply -n armada -f https://raw.githubusercontent.com/armadaproject/armada-operator/main/dev/quickstart/armada-crs.yaml\n```\n\nThis deploys:\n- **Armada Server** — API server for job submission\n- **Armada Executor** — runs jobs on worker clusters\n- **Armada Scheduler** — schedules jobs across clusters\n- **Armada Lookout** — web UI for monitoring jobs (exposed on NodePort 30000)\n- **Armada Lookout Ingester** — ingests events for the Lookout UI\n- **Armada Event Ingester** — processes job events\n\nVerify all components are running:\n```bash\nkubectl get pods --namespace armada\n```"
+      },
+      {
+        "title": "Apply default PriorityClass",
+        "description": "Armada requires a default PriorityClass for all jobs:\n\n```bash\nkubectl apply -f https://raw.githubusercontent.com/armadaproject/armada-operator/main/dev/quickstart/priority-class.yaml\n```"
+      },
+      {
+        "title": "Install armadactl CLI",
+        "description": "Download the armadactl binary for interacting with the Armada API:\n\n```bash\n# Download the latest armadactl for your platform from:\n# https://github.com/armadaproject/armada/releases/latest\n\n# Create a config file:\nmkdir -p ~/.armada\ncat > ~/.armadactl.yaml << EOF\ncurrentContext: main\ncontexts:\n  main:\n    armadaUrl: localhost:30002\nEOF\n```\n\nTest the connection:\n```bash\narmadactl create queue example\narmadactl submit dev/quickstart/example-job.yaml\n```"
       },
       {
         "title": "Verify the installation",
-        "description": "Check that the Armada components are running:\n```bash\nkubectl get pods --namespace armada\n```\n\nYou should see pods for armada-server, armada-executor, and armada-scheduler."
+        "description": "Check that all Armada components are running:\n```bash\nkubectl get pods --namespace armada\nkubectl get pods --namespace armada-system\n```\n\nAccess the Lookout UI at `http://localhost:30000` to monitor jobs.\n\nYou should see pods for armada-server, armada-executor, armada-scheduler, armada-lookout, and the ingester components."
       }
     ],
     "resolution": {
-      "summary": "A successful installation shows the Armada server, executor, and scheduler pods running in the 'armada' namespace, with connectivity to PostgreSQL, Redis, and Pulsar.",
+      "summary": "A successful installation shows the Armada Operator running in 'armada-system', all Armada components (server, executor, scheduler, lookout, ingesters) running in the 'armada' namespace, and the Lookout UI accessible on port 30000.",
       "codeSnippets": [
-        "helm repo add gresearch https://g-research.github.io/charts\nhelm repo update",
-        "helm install armada-server gresearch/armada --namespace armada --create-namespace --version 0.20.36",
+        "helm repo add gresearch https://g-research.github.io/charts\nhelm install armada-operator gresearch/armada-operator --namespace armada-system --create-namespace",
+        "kubectl apply -n armada -f https://raw.githubusercontent.com/armadaproject/armada-operator/main/dev/quickstart/armada-crs.yaml",
         "kubectl get pods --namespace armada"
       ]
     },
     "uninstall": [
       {
-        "title": "Remove Armada Helm releases",
-        "description": "Uninstall all Armada components:\n```bash\nhelm uninstall armada-server --namespace armada\nhelm uninstall armada-executor --namespace armada\nhelm uninstall armada-scheduler --namespace armada\n```"
+        "title": "Remove Armada components",
+        "description": "Delete the Armada Custom Resources and namespace:\n```bash\nkubectl delete -n armada -f https://raw.githubusercontent.com/armadaproject/armada-operator/main/dev/quickstart/armada-crs.yaml\nkubectl delete namespace armada\n```"
       },
       {
-        "title": "Remove the namespace",
-        "description": "Delete the namespace and all remaining resources:\n```bash\nkubectl delete namespace armada\n```"
+        "title": "Remove Armada Operator",
+        "description": "Uninstall the operator and clean up CRDs:\n```bash\nhelm uninstall armada-operator --namespace armada-system\nkubectl delete namespace armada-system\n```"
+      },
+      {
+        "title": "Remove dependencies",
+        "description": "Uninstall PostgreSQL, Redis, Pulsar, and Prometheus:\n```bash\nhelm uninstall postgresql --namespace armada\nhelm uninstall redis --namespace armada\nhelm uninstall pulsar --namespace armada\nhelm uninstall kube-prometheus-stack --namespace monitoring\nkubectl delete namespace monitoring\n```"
       }
     ],
     "upgrade": [
@@ -51,18 +63,22 @@
         "description": "Update the repository to get the latest chart versions:\n```bash\nhelm repo update\n```"
       },
       {
-        "title": "Upgrade Armada",
-        "description": "Upgrade the Armada server:\n```bash\nhelm upgrade armada-server gresearch/armada --namespace armada\n```"
+        "title": "Upgrade Armada Operator",
+        "description": "Upgrade the operator to the latest version:\n```bash\nhelm upgrade armada-operator gresearch/armada-operator --namespace armada-system\n```\n\nThe operator will automatically reconcile and update the managed Armada components."
       },
       {
         "title": "Verify the upgrade",
-        "description": "Check pod status after upgrade:\n```bash\nkubectl get pods --namespace armada\n```"
+        "description": "Check pod status after upgrade:\n```bash\nkubectl get pods --namespace armada-system\nkubectl get pods --namespace armada\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods in CrashLoopBackOff",
-        "description": "Usually caused by missing or misconfigured dependencies. Check the logs:\n```bash\nkubectl logs -l app=armada-server --namespace armada\n```\n\nVerify that PostgreSQL, Redis, and Pulsar are running and accessible."
+        "title": "Operator pods not starting",
+        "description": "Check the operator logs:\n```bash\nkubectl logs -l app.kubernetes.io/name=armada-operator --namespace armada-system\n```\n\nEnsure cert-manager is installed if webhooks are enabled:\n```bash\nkubectl get pods -n cert-manager\n```"
+      },
+      {
+        "title": "Armada components in CrashLoopBackOff",
+        "description": "Usually caused by missing or misconfigured dependencies. Check the logs:\n```bash\nkubectl logs -l app=armada-server --namespace armada\n```\n\nVerify that PostgreSQL, Redis, and Pulsar are running and accessible:\n```bash\nkubectl get pods --namespace armada | grep -E 'postgresql|redis|pulsar'\n```"
       },
       {
         "title": "Database connection errors",
@@ -70,7 +86,15 @@
       },
       {
         "title": "Pulsar connection issues",
-        "description": "Verify Pulsar is running:\n```bash\nkubectl get pods --namespace armada | grep pulsar\n```"
+        "description": "Verify Pulsar is running and all components are healthy:\n```bash\nkubectl get pods --namespace armada | grep pulsar\nkubectl logs -l app=armada-server --namespace armada | grep -i pulsar\n```"
+      },
+      {
+        "title": "kube-prometheus-stack not installing",
+        "description": "If you get template errors, upgrade Helm to v3.16.2 or later:\n```bash\nhelm version\n```"
+      },
+      {
+        "title": "Lookout UI not accessible",
+        "description": "Verify Lookout is running and the NodePort is exposed:\n```bash\nkubectl get svc --namespace armada | grep lookout\nkubectl get pods --namespace armada | grep lookout\n```"
       }
     ]
   },
@@ -80,7 +104,9 @@
       "configuration",
       "cncf",
       "app-definition",
-      "sandbox"
+      "sandbox",
+      "batch-scheduling",
+      "multi-cluster"
     ],
     "cncfProjects": [
       "armada"
@@ -88,7 +114,8 @@
     "targetResourceKinds": [
       "Deployment",
       "Namespace",
-      "Service"
+      "Service",
+      "CustomResourceDefinition"
     ],
     "difficulty": "advanced",
     "issueTypes": [
@@ -96,16 +123,19 @@
       "configuration"
     ],
     "installMethods": [
-      "helm"
+      "helm",
+      "operator"
     ],
     "maturity": "sandbox",
-    "projectVersion": "v0.20.36",
+    "projectVersion": "v0.20.40",
     "containerImages": [
-      "gresearch/armada-server:v0.20.36"
+      "gresearch/armada-server:v0.20.40",
+      "gresearch/armada-operator:latest"
     ],
     "sourceUrls": {
       "docs": "https://armadaproject.io",
       "repo": "https://github.com/armadaproject/armada",
+      "operator": "https://github.com/armadaproject/armada-operator",
       "helm": "https://g-research.github.io/charts"
     },
     "qualityScore": 100
@@ -116,10 +146,10 @@
       "helm",
       "kubectl"
     ],
-    "description": "Requires a Kubernetes cluster with Helm and kubectl. Armada depends on PostgreSQL, Redis, and Apache Pulsar, which must be installed before deploying Armada."
+    "description": "Requires a Kubernetes cluster with Helm and kubectl. The Armada Operator manages the lifecycle of Armada components. External dependencies (PostgreSQL, Redis, Apache Pulsar, kube-prometheus-stack) must be installed separately."
   },
   "security": {
-    "scannedAt": "2026-03-11T15:00:00.000Z",
+    "scannedAt": "2026-04-23T06:50:00.000Z",
     "scannerVersion": "manual-review-1.0.0",
     "sanitized": true,
     "findings": []


### PR DESCRIPTION
Updates the Armada install mission based on feedback from Armada maintainer @dejanzele ([armadaproject/armada#4761](https://github.com/armadaproject/armada/issues/4761)).

### Changes
- **Primary install method → Armada Operator** (recommended by maintainers)
- **Version bump**: v0.20.36 → v0.20.40
- **New steps**: Operator install, CRD-based deployment, PriorityClass, armadactl CLI, Lookout UI
- **Dependencies**: Added kube-prometheus-stack
- **Troubleshooting**: Added operator-specific sections (cert-manager, Lookout, prometheus)
- **Metadata**: Added `operator` install method, operator repo URL, new tags