### PR TITLE
✨ add k0rdent and kflashback install missions

### DIFF
--- a/fixes/platform-install/platform-k0rdent.json
+++ b/fixes/platform-install/platform-k0rdent.json
@@ -1,0 +1,99 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-k0rdent",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "metadata": {
+    "cncfProjects": ["k0rdent"]
+  },
+  "mission": {
+    "title": "Install and Configure k0rdent (Kubernetes Cluster Lifecycle Manager)",
+    "description": "k0rdent is an open-source platform for deploying and managing Kubernetes clusters at scale. It functions as a super control plane, orchestrating multiple Kubernetes clusters across on-premises, cloud, and hybrid environments using a declarative GitOps approach. Built on Cluster API (CAPI), it supports infrastructure providers like AWS, Azure, vSphere, and bare metal. k0rdent provides centralized lifecycle management — provisioning, configuration, updates, and observability — from a single management cluster.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Ensure you have a management cluster",
+        "description": "k0rdent requires a Kubernetes cluster to serve as the management cluster. You can use any existing cluster (kind, k0s, EKS, etc.).\n\n```bash\n\nkubectl cluster-info\n\n```\n\n> Verify your kubeconfig points to the cluster that will become the k0rdent management cluster.",
+        "commands": [
+          "kubectl cluster-info"
+        ]
+      },
+      {
+        "title": "Install k0rdent via Helm",
+        "description": "Install the k0rdent Cluster Manager (kcm) using the official OCI Helm chart from GHCR.\n\n```bash\n\nhelm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 1.8.0 -n kcm-system --create-namespace\n\n```\n\n> This deploys the KCM operator which then provisions CAPI and other subcomponents. The entire process takes a few minutes.",
+        "commands": [
+          "helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 1.8.0 -n kcm-system --create-namespace"
+        ]
+      },
+      {
+        "title": "Wait for k0rdent components to be ready",
+        "description": "The KCM operator deploys several subcomponents including Cluster API controllers. Wait for all pods to become ready.\n\n```bash\n\nkubectl -n kcm-system wait --for=condition=Ready pods --all --timeout=300s\n\n```\n\n> All pods in kcm-system should reach Running/Ready state within a few minutes.",
+        "commands": [
+          "kubectl -n kcm-system wait --for=condition=Ready pods --all --timeout=300s"
+        ]
+      },
+      {
+        "title": "Verify the k0rdent installation",
+        "description": "Check that the Management object and core components are healthy.\n\n```bash\n\nkubectl get management.k0rdent\n\nkubectl get pods -n kcm-system\n\nkubectl get clustertemplate -n kcm-system\n\n```\n\n> You should see the kcm Management resource, running controller pods, and available cluster templates.",
+        "commands": [
+          "kubectl get management.k0rdent",
+          "kubectl get pods -n kcm-system",
+          "kubectl get clustertemplate -n kcm-system"
+        ]
+      },
+      {
+        "title": "Configure infrastructure credentials (example: AWS)",
+        "description": "To provision child clusters, k0rdent needs credentials for your infrastructure provider. This example shows AWS — adapt for Azure, vSphere, or other providers.\n\n```bash\n\nkubectl create secret generic aws-credentials -n kcm-system --from-literal=AccessKeyID=$AWS_ACCESS_KEY_ID --from-literal=SecretAccessKey=$AWS_SECRET_ACCESS_KEY\n\n```\n\n> Replace with your actual credentials. See [k0rdent docs](https://docs.k0rdent.io/latest/admin/installation/prepare-mgmt-cluster/) for provider-specific setup including Azure, vSphere, and bare metal.",
+        "commands": [
+          "kubectl create secret generic aws-credentials -n kcm-system --from-literal=AccessKeyID=$AWS_ACCESS_KEY_ID --from-literal=SecretAccessKey=$AWS_SECRET_ACCESS_KEY"
+        ]
+      },
+      {
+        "title": "Create a child cluster (example)",
+        "description": "Deploy a managed child cluster using a k0rdent ClusterDeployment. This example creates a basic cluster — customize the template and parameters for your environment.\n\n```bash\n\nkubectl apply -f - <<EOF\napiVersion: k0rdent.mirantis.com/v1alpha1\nkind: ClusterDeployment\nmetadata:\n  name: my-child-cluster\n  namespace: kcm-system\nspec:\n  template: aws-standalone-cp-0-1-8\n  credential: aws-credentials\n  config:\n    region: us-east-1\n    controlPlane:\n      instanceType: t3.medium\n    worker:\n      instanceType: t3.medium\n      replicas: 2\nEOF\n\n```\n\n> This provisions a 2-worker Kubernetes cluster on AWS. Monitor progress with `kubectl get clusterdeployment -n kcm-system -w`.",
+        "commands": [
+          "kubectl apply -f - <<EOF\napiVersion: k0rdent.mirantis.com/v1alpha1\nkind: ClusterDeployment\nmetadata:\n  name: my-child-cluster\n  namespace: kcm-system\nspec:\n  template: aws-standalone-cp-0-1-8\n  credential: aws-credentials\n  config:\n    region: us-east-1\n    controlPlane:\n      instanceType: t3.medium\n    worker:\n      instanceType: t3.medium\n      replicas: 2\nEOF"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall k0rdent",
+        "description": "Remove k0rdent and all managed resources from the management cluster.\n\n```bash\n\nkubectl delete clusterdeployments --all -n kcm-system\n\nkubectl delete management.k0rdent kcm\n\nhelm uninstall kcm -n kcm-system\n\nkubectl delete ns kcm-system\n\n```\n\n> Warning: Delete all ClusterDeployments first to properly deprovision child clusters before removing k0rdent.",
+        "commands": [
+          "kubectl delete clusterdeployments --all -n kcm-system",
+          "kubectl delete management.k0rdent kcm",
+          "helm uninstall kcm -n kcm-system",
+          "kubectl delete ns kcm-system"
+        ]
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Upgrade k0rdent",
+        "description": "Upgrade to a newer version of k0rdent using Helm.\n\n```bash\n\nhelm upgrade kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 1.8.0 -n kcm-system\n\nkubectl -n kcm-system wait --for=condition=Ready pods --all --timeout=300s\n\n```\n\n> Replace the version number with the desired release. Check [k0rdent releases](https://github.com/k0rdent/kcm/releases) for available versions.",
+        "commands": [
+          "helm upgrade kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 1.8.0 -n kcm-system",
+          "kubectl -n kcm-system wait --for=condition=Ready pods --all --timeout=300s"
+        ]
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pods stuck in Pending or CrashLoopBackOff",
+        "description": "**Cause:** Insufficient resources on the management cluster or webhook certificate issues.\n\n**Fix:**\nCheck pod events: `kubectl describe pods -n kcm-system`. Ensure your management cluster has at least 4 CPU and 8GB RAM available. For certificate issues, delete the webhook and let it regenerate."
+      },
+      {
+        "title": "ClusterDeployment stuck in Provisioning",
+        "description": "**Cause:** Infrastructure credentials may be invalid or the provider may have quota limits.\n\n**Fix:**\nCheck the CAPI cluster status: `kubectl get clusters -n kcm-system`. Inspect machine objects: `kubectl get machines -n kcm-system`. Verify credentials in the referenced Secret are correct and the account has sufficient permissions."
+      },
+      {
+        "title": "No ClusterTemplates available",
+        "description": "**Cause:** k0rdent may still be initializing or the Management object hasn't been fully reconciled.\n\n**Fix:**\nWait a few minutes for the KCM operator to finish bootstrapping. Check: `kubectl get management.k0rdent kcm -o yaml` and look at the status conditions."
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/platform-kflashback.json
+++ b/fixes/platform-install/platform-kflashback.json
@@ -1,0 +1,98 @@
+{
+  "version": "kc-mission-v1",
+  "name": "platform-kflashback",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "metadata": {
+    "cncfProjects": ["kflashback"]
+  },
+  "mission": {
+    "title": "Install and Configure kflashback (Kubernetes Resource History)",
+    "description": "kflashback is a Kubernetes operator that tracks resource history — every create, update, and delete — with revision diffs, AI-powered insights, and anomaly detection. It records a complete audit trail of your cluster's state over time with configurable retention policies. Supports local LLMs (Ollama) or cloud providers (OpenAI, Anthropic) for natural-language queries like \"What changed in the last hour?\" and automatic anomaly detection.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install kflashback CRDs",
+        "description": "Apply the Custom Resource Definitions that kflashback uses to store configuration and tracking policies.\n\n```bash\n\nkubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_kflashbackconfigs.yaml\n\nkubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_flashbackpolicies.yaml\n\n```\n\n> Installs the KFlashbackConfig and FlashbackPolicy CRDs into your cluster.",
+        "commands": [
+          "kubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_kflashbackconfigs.yaml",
+          "kubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_flashbackpolicies.yaml"
+        ]
+      },
+      {
+        "title": "Create the kflashback namespace and RBAC",
+        "description": "Set up the namespace, service account, and RBAC rules that the kflashback controller needs.\n\n```bash\n\nkubectl create namespace kflashback-system --dry-run=client -o yaml | kubectl apply -f -\n\nkubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/service_account.yaml -n kflashback-system\n\nkubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role.yaml\n\nkubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role_binding.yaml\n\n```\n\n> Creates the namespace and grants the controller permission to watch cluster resources.",
+        "commands": [
+          "kubectl create namespace kflashback-system --dry-run=client -o yaml | kubectl apply -f -",
+          "kubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/service_account.yaml -n kflashback-system",
+          "kubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role.yaml",
+          "kubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role_binding.yaml"
+        ]
+      },
+      {
+        "title": "Deploy the kflashback controller",
+        "description": "Deploy the kflashback operator. The controller watches for FlashbackPolicy resources and begins tracking the specified Kubernetes resources.\n\n```bash\n\nkubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/manager/deployment.yaml -n kflashback-system\n\n```\n\n> Deploys the kflashback controller from the latest container image.",
+        "commands": [
+          "kubectl apply -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/manager/deployment.yaml -n kflashback-system"
+        ]
+      },
+      {
+        "title": "Create a KFlashbackConfig",
+        "description": "Configure the kflashback instance with SQLite storage and default server ports.\n\n```bash\n\nkubectl apply -f - <<EOF\napiVersion: flashback.io/v1alpha1\nkind: KFlashbackConfig\nmetadata:\n  name: kflashback\n  namespace: kflashback-system\nspec:\n  storage:\n    backend: sqlite\n    dsn: /data/kflashback.db\n  server:\n    apiAddress: \":9090\"\n    healthAddress: \":8081\"\n  controller:\n    leaderElection: true\n    reconcileInterval: \"5m\"\nEOF\n\n```\n\n> Configures kflashback with SQLite (lightweight, no external DB needed).",
+        "commands": [
+          "kubectl apply -f - <<EOF\napiVersion: flashback.io/v1alpha1\nkind: KFlashbackConfig\nmetadata:\n  name: kflashback\n  namespace: kflashback-system\nspec:\n  storage:\n    backend: sqlite\n    dsn: /data/kflashback.db\n  server:\n    apiAddress: \":9090\"\n    healthAddress: \":8081\"\n  controller:\n    leaderElection: true\n    reconcileInterval: \"5m\"\nEOF"
+        ]
+      },
+      {
+        "title": "Create a FlashbackPolicy to track workloads",
+        "description": "Define which Kubernetes resources kflashback should track. This sample policy tracks Deployments, StatefulSets, DaemonSets, and Services.\n\n```bash\n\nkubectl apply -f - <<EOF\napiVersion: flashback.io/v1alpha1\nkind: FlashbackPolicy\nmetadata:\n  name: track-workloads\n  namespace: kflashback-system\nspec:\n  resources:\n    - apiVersion: apps/v1\n      kind: Deployment\n      excludeNamespaces:\n        - kube-system\n        - kube-public\n    - apiVersion: apps/v1\n      kind: StatefulSet\n      excludeNamespaces:\n        - kube-system\n    - apiVersion: apps/v1\n      kind: DaemonSet\n      excludeNamespaces:\n        - kube-system\n    - apiVersion: v1\n      kind: Service\n      excludeNamespaces:\n        - kube-system\n        - kube-public\n  retention:\n    maxAge: \"720h\"\n    maxRevisions: 500\n  storage:\n    snapshotEvery: 20\n    compressSnapshots: true\n  tracking:\n    creations: true\n    updates: true\n    deletions: true\n  paused: false\nEOF\n\n```\n\n> Tracks all workload changes (create/update/delete) with 30-day retention.",
+        "commands": [
+          "kubectl apply -f - <<EOF\napiVersion: flashback.io/v1alpha1\nkind: FlashbackPolicy\nmetadata:\n  name: track-workloads\n  namespace: kflashback-system\nspec:\n  resources:\n    - apiVersion: apps/v1\n      kind: Deployment\n      excludeNamespaces:\n        - kube-system\n        - kube-public\n    - apiVersion: apps/v1\n      kind: StatefulSet\n      excludeNamespaces:\n        - kube-system\n    - apiVersion: apps/v1\n      kind: DaemonSet\n      excludeNamespaces:\n        - kube-system\n    - apiVersion: v1\n      kind: Service\n      excludeNamespaces:\n        - kube-system\n        - kube-public\n  retention:\n    maxAge: \"720h\"\n    maxRevisions: 500\n  storage:\n    snapshotEvery: 20\n    compressSnapshots: true\n  tracking:\n    creations: true\n    updates: true\n    deletions: true\n  paused: false\nEOF"
+        ]
+      },
+      {
+        "title": "Verify kflashback is running",
+        "description": "Check that the controller pod is running and the CRDs are registered.\n\n```bash\n\nkubectl get pods -n kflashback-system\n\nkubectl get kflashbackconfigs -n kflashback-system\n\nkubectl get flashbackpolicies -n kflashback-system\n\n```\n\n> You should see the controller pod in Running state and both custom resources listed.",
+        "commands": [
+          "kubectl get pods -n kflashback-system",
+          "kubectl get kflashbackconfigs -n kflashback-system",
+          "kubectl get flashbackpolicies -n kflashback-system"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall kflashback",
+        "description": "Remove kflashback from your cluster. This deletes all tracked history data.\n\n```bash\n\nkubectl delete flashbackpolicies --all -n kflashback-system\n\nkubectl delete kflashbackconfigs --all -n kflashback-system\n\nkubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/manager/deployment.yaml -n kflashback-system\n\nkubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role_binding.yaml\n\nkubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role.yaml\n\nkubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/service_account.yaml -n kflashback-system\n\nkubectl delete namespace kflashback-system\n\nkubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_flashbackpolicies.yaml\n\nkubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_kflashbackconfigs.yaml\n\n```\n\n> Removes all kflashback resources, RBAC, CRDs, and namespace.",
+        "commands": [
+          "kubectl delete flashbackpolicies --all -n kflashback-system",
+          "kubectl delete kflashbackconfigs --all -n kflashback-system",
+          "kubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/manager/deployment.yaml -n kflashback-system",
+          "kubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role_binding.yaml",
+          "kubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/role.yaml",
+          "kubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/rbac/service_account.yaml -n kflashback-system",
+          "kubectl delete namespace kflashback-system",
+          "kubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_flashbackpolicies.yaml",
+          "kubectl delete -f https://raw.githubusercontent.com/prashanthjos/kflashback/main/config/crd/flashback.io_kflashbackconfigs.yaml"
+        ]
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Controller pod is in ImagePullBackOff",
+        "description": "**Cause:** The GHCR container image may not be publicly accessible (known issue #3 on the kflashback repo).\n\n**Fix:**\nBuild and push the image locally:\n```bash\ngit clone https://github.com/prashanthjos/kflashback.git\ncd kflashback\nmake docker-build IMG=kflashback:local\nkind load docker-image kflashback:local  # if using kind\n```\nThen update the deployment to use `kflashback:local` with `imagePullPolicy: Never`."
+      },
+      {
+        "title": "CRD validation errors on apply",
+        "description": "**Cause:** Kubernetes version may be too old for the CRD schema.\n\n**Fix:**\nkflashback requires Kubernetes 1.25+. Check your version with `kubectl version` and upgrade if needed."
+      },
+      {
+        "title": "No history being recorded",
+        "description": "**Cause:** The FlashbackPolicy may not match any resources, or the controller may not have RBAC to watch them.\n\n**Fix:**\nCheck controller logs: `kubectl logs -n kflashback-system -l app=kflashback`. Verify the policy's resource kinds and namespace filters match your workloads."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds guided install missions for two projects:

### k0rdent (594⭐, k0rdent org, Apache 2.0)
Kubernetes cluster lifecycle manager — super control plane for deploying and managing clusters at scale via GitOps. Featured on [CNCF blog](https://www.cncf.io/blog/2026/04/17/k3s-on-on-prem-infrastructures-the-gitops-way-writing-a-custom-k0rdent-template-from-scratch/).
- **Install**: Helm chart from OCI registry (ghcr.io/k0rdent/kcm v1.8.0)
- **Steps**: Management cluster setup → Helm install → verify → configure credentials → create child cluster
- **Includes**: Upgrade, uninstall, troubleshooting

### kflashback (9⭐, personal repo, Apache 2.0)
Kubernetes resource history tracker with AI-powered insights (natural language queries, anomaly detection). Supports Ollama/OpenAI/Anthropic.
- **Install**: Kustomize/raw manifests (no Helm chart yet)
- **Steps**: CRDs → namespace + RBAC → controller → config CR → tracking policy → verify
- **Includes**: Uninstall, troubleshooting (GHCR image visibility, etc.)