### PR TITLE
✨ Add 18 install missions for uncovered CNCF projects

### DIFF
--- a/fixes/platform-install/install-agones.json
+++ b/fixes/platform-install/install-agones.json
@@ -1,0 +1,64 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-agones",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "agones"
+  ],
+  "mission": {
+    "title": "Install and Configure Agones",
+    "description": "Agones is a CNCF platform for hosting, running, and scaling dedicated multiplayer game servers on Kubernetes. It provides GameServer and Fleet custom resources for managing the full lifecycle of game server instances.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Add the Agones Helm repository",
+        "description": "Add the official Agones Helm chart repository.\n\n```bash\nhelm repo add agones https://agones.dev/chart/stable\nhelm repo update\n```",
+        "commands": [
+          "helm repo add agones https://agones.dev/chart/stable",
+          "helm repo update"
+        ]
+      },
+      {
+        "title": "Install Agones using Helm",
+        "description": "Install Agones into a dedicated namespace.\n\n```bash\nhelm install agones agones/agones --namespace agones-system --create-namespace\n```",
+        "commands": [
+          "helm install agones agones/agones --namespace agones-system --create-namespace"
+        ]
+      },
+      {
+        "title": "Verify Agones pods are running",
+        "description": "Check that the Agones controller and related pods are running.\n\n```bash\nkubectl get pods -n agones-system\n```\n\n> You should see agones-controller, agones-allocator, and agones-ping pods in Running state.",
+        "commands": [
+          "kubectl get pods -n agones-system"
+        ]
+      },
+      {
+        "title": "Create a test GameServer",
+        "description": "Deploy a simple UDP game server to verify Agones is working.\n\n```bash\nkubectl apply -f https://raw.githubusercontent.com/agones-dev/agones/release-1.57.0/examples/simple-game-server/gameserver.yaml\n```",
+        "commands": [
+          "kubectl apply -f https://raw.githubusercontent.com/agones-dev/agones/release-1.57.0/examples/simple-game-server/gameserver.yaml"
+        ]
+      },
+      {
+        "title": "Verify GameServer is ready",
+        "description": "Check the GameServer reached Ready state.\n\n```bash\nkubectl get gameservers\n```\n\n> The STATUS should show Ready with an assigned port.",
+        "commands": [
+          "kubectl get gameservers"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Agones",
+        "description": "Remove Agones from your cluster.\n\n```bash\nhelm uninstall agones -n agones-system\n```",
+        "commands": [
+          "helm uninstall agones -n agones-system"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-athenz.json
+++ b/fixes/platform-install/install-athenz.json
@@ -1,0 +1,57 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-athenz",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "athenz"
+  ],
+  "mission": {
+    "title": "Install and Configure Athenz",
+    "description": "Athenz is a CNCF platform for X.509 certificate-based service authentication and fine-grained role-based access control (RBAC) in dynamic infrastructures, with mTLS and OAuth2 token support.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 20,
+    "steps": [
+      {
+        "title": "Clone the Athenz repository",
+        "description": "Clone the Athenz project.\n\n```bash\ngit clone https://github.com/AthenZ/athenz.git\ncd athenz\n```",
+        "commands": [
+          "git clone https://github.com/AthenZ/athenz.git",
+          "cd athenz"
+        ]
+      },
+      {
+        "title": "Start Athenz with Docker",
+        "description": "Run Athenz using Docker containers.\n\n```bash\ndocker compose up -d\n```\n\n> This starts ZMS (management), ZTS (token), and the UI components.",
+        "commands": [
+          "docker compose up -d"
+        ]
+      },
+      {
+        "title": "Verify services are running",
+        "description": "Check that the Athenz services are healthy.\n\n```bash\ndocker compose ps\n```\n\n> You should see ZMS, ZTS, and UI containers in running state.",
+        "commands": [
+          "docker compose ps"
+        ]
+      },
+      {
+        "title": "Access the Athenz UI",
+        "description": "Open the Athenz management console.\n\n```bash\ncurl -k https://localhost:9443/athenz\n```\n\n> The Athenz UI is available at https://localhost:9443.",
+        "commands": [
+          "curl -k https://localhost:9443/athenz"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Athenz",
+        "description": "Stop and remove Athenz containers.\n\n```bash\ndocker compose down\n```",
+        "commands": [
+          "docker compose down"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-cedar.json
+++ b/fixes/platform-install/install-cedar.json
@@ -1,0 +1,49 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-cedar",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "cedar"
+  ],
+  "mission": {
+    "title": "Install and Configure Cedar",
+    "description": "Cedar is a CNCF policy language and evaluation engine for writing and enforcing authorization policies. It provides a Rust library and CLI for defining fine-grained, analyzable access control rules.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install Cedar CLI via Cargo",
+        "description": "Install the Cedar policy CLI tool.\n\n```bash\ncargo install cedar-policy-cli\n```\n\n> Requires Rust/Cargo installed.",
+        "commands": [
+          "cargo install cedar-policy-cli"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Check the Cedar CLI is available.\n\n```bash\ncedar --version\n```",
+        "commands": [
+          "cedar --version"
+        ]
+      },
+      {
+        "title": "Test with a sample policy",
+        "description": "Create and evaluate a simple Cedar policy.\n\n```bash\necho 'permit(principal, action, resource)\nwhen { principal == User::\"alice\" };' > policy.cedar\ncedar validate --policies policy.cedar --schema schema.cedarschema\n```\n\n> Cedar policies use a human-readable syntax for authorization rules.",
+        "commands": [
+          "echo 'permit(principal, action, resource) when { principal == User::\"alice\" };' > policy.cedar"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Cedar",
+        "description": "Remove Cedar CLI.\n\n```bash\ncargo uninstall cedar-policy-cli\n```",
+        "commands": [
+          "cargo uninstall cedar-policy-cli"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-cloudnativepg.json
+++ b/fixes/platform-install/install-cloudnativepg.json
@@ -1,0 +1,64 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-cloudnativepg",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "cloudnativepg"
+  ],
+  "mission": {
+    "title": "Install and Configure CloudNativePG",
+    "description": "CloudNativePG is a CNCF Kubernetes operator for managing PostgreSQL databases with automated deployment, high-availability failover, scaling, and backup management directly through Kubernetes APIs.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Add the CloudNativePG Helm repository",
+        "description": "Add the official CloudNativePG Helm chart repository.\n\n```bash\nhelm repo add cnpg https://cloudnative-pg.github.io/charts\nhelm repo update\n```",
+        "commands": [
+          "helm repo add cnpg https://cloudnative-pg.github.io/charts",
+          "helm repo update"
+        ]
+      },
+      {
+        "title": "Install CloudNativePG operator",
+        "description": "Install the CloudNativePG operator into a dedicated namespace.\n\n```bash\nhelm install cnpg cnpg/cloudnative-pg --namespace cnpg-system --create-namespace\n```",
+        "commands": [
+          "helm install cnpg cnpg/cloudnative-pg --namespace cnpg-system --create-namespace"
+        ]
+      },
+      {
+        "title": "Verify operator is running",
+        "description": "Check that the CloudNativePG operator pod is running.\n\n```bash\nkubectl get pods -n cnpg-system\n```\n\n> You should see the cloudnative-pg controller manager pod in Running state.",
+        "commands": [
+          "kubectl get pods -n cnpg-system"
+        ]
+      },
+      {
+        "title": "Create a PostgreSQL cluster",
+        "description": "Deploy a 3-instance PostgreSQL cluster to verify the operator works.\n\n```bash\nkubectl apply -f - <<EOF\napiVersion: postgresql.cnpg.io/v1\nkind: Cluster\nmetadata:\n  name: my-postgresql\nspec:\n  instances: 3\n  storage:\n    size: 1Gi\nEOF\n```",
+        "commands": [
+          "kubectl apply -f - <<EOF\napiVersion: postgresql.cnpg.io/v1\nkind: Cluster\nmetadata:\n  name: my-postgresql\nspec:\n  instances: 3\n  storage:\n    size: 1Gi\nEOF"
+        ]
+      },
+      {
+        "title": "Verify PostgreSQL cluster is ready",
+        "description": "Check the cluster status.\n\n```bash\nkubectl get clusters\n```\n\n> The cluster should show 3 ready instances.",
+        "commands": [
+          "kubectl get clusters"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall CloudNativePG",
+        "description": "Remove the operator from your cluster.\n\n```bash\nhelm uninstall cnpg -n cnpg-system\n```",
+        "commands": [
+          "helm uninstall cnpg -n cnpg-system"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-hexa.json
+++ b/fixes/platform-install/install-hexa.json
@@ -1,0 +1,57 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-hexa",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "hexa"
+  ],
+  "mission": {
+    "title": "Install and Configure Hexa Policy Orchestrator",
+    "description": "Hexa is a CNCF policy orchestrator that provides unified access control across platforms by converting between IDQL (a universal policy format) and platform-specific policy formats including OPA, Azure RBAC, and Google IAP.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Clone the Hexa repository",
+        "description": "Clone the Hexa Policy Orchestrator repo.\n\n```bash\ngit clone https://github.com/hexa-org/policy-orchestrator.git\ncd policy-orchestrator\n```",
+        "commands": [
+          "git clone https://github.com/hexa-org/policy-orchestrator.git",
+          "cd policy-orchestrator"
+        ]
+      },
+      {
+        "title": "Start infrastructure services",
+        "description": "Start the required Keycloak and PostgreSQL services.\n\n```bash\ndocker compose -f demo/docker-compose.shared.yml up -d\n```",
+        "commands": [
+          "docker compose -f demo/docker-compose.shared.yml up -d"
+        ]
+      },
+      {
+        "title": "Start Hexa services",
+        "description": "Start the Hexa orchestrator and admin UI.\n\n```bash\ncd demo && docker compose up -d\n```",
+        "commands": [
+          "cd demo && docker compose up -d"
+        ]
+      },
+      {
+        "title": "Verify services are running",
+        "description": "Check all containers are healthy.\n\n```bash\ndocker compose ps\n```\n\n> You should see the orchestrator, admin UI, Keycloak, and PostgreSQL containers running.",
+        "commands": [
+          "docker compose ps"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Hexa",
+        "description": "Stop and remove all Hexa containers.\n\n```bash\ncd demo && docker compose down\ndocker compose -f docker-compose.shared.yml down\n```",
+        "commands": [
+          "cd demo && docker compose down"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-higress.json
+++ b/fixes/platform-install/install-higress.json
@@ -1,0 +1,57 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-higress",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "higress"
+  ],
+  "mission": {
+    "title": "Install and Configure Higress",
+    "description": "Higress is a CNCF cloud-native API gateway built on Istio and Envoy, supporting AI gateway capabilities, multiple protocols, and WebAssembly plugin extensibility. It functions as a Kubernetes ingress controller and Gateway API implementation.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Add the Higress Helm repository",
+        "description": "Add the official Higress Helm chart repository.\n\n```bash\nhelm repo add higress https://higress.io/helm-charts\nhelm repo update\n```",
+        "commands": [
+          "helm repo add higress https://higress.io/helm-charts",
+          "helm repo update"
+        ]
+      },
+      {
+        "title": "Install Higress using Helm",
+        "description": "Install Higress into a dedicated namespace.\n\n```bash\nhelm install higress higress/higress --namespace higress-system --create-namespace\n```",
+        "commands": [
+          "helm install higress higress/higress --namespace higress-system --create-namespace"
+        ]
+      },
+      {
+        "title": "Verify Higress pods are running",
+        "description": "Check that the Higress gateway and controller pods are running.\n\n```bash\nkubectl get pods -n higress-system\n```\n\n> You should see higress-gateway and higress-controller pods in Running state.",
+        "commands": [
+          "kubectl get pods -n higress-system"
+        ]
+      },
+      {
+        "title": "Verify Higress ingress class",
+        "description": "Confirm the Higress IngressClass was created.\n\n```bash\nkubectl get ingressclass\n```\n\n> You should see a 'higress' ingress class.",
+        "commands": [
+          "kubectl get ingressclass"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Higress",
+        "description": "Remove Higress from your cluster.\n\n```bash\nhelm uninstall higress -n higress-system\n```",
+        "commands": [
+          "helm uninstall higress -n higress-system"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-in-toto.json
+++ b/fixes/platform-install/install-in-toto.json
@@ -1,0 +1,50 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-in-toto",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "in-toto"
+  ],
+  "mission": {
+    "title": "Install and Configure in-toto",
+    "description": "in-toto is a CNCF graduated framework that protects software supply chain integrity by verifying that each step was performed by authorized personnel, collecting evidence as link metadata, and validating the complete chain.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install in-toto via pip",
+        "description": "Install the in-toto Python package.\n\n```bash\npip install in-toto\n```\n\n> Requires Python 3.8+.",
+        "commands": [
+          "pip install in-toto"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Confirm the in-toto CLI tools are available.\n\n```bash\nin-toto-run --version\nin-toto-verify --version\n```",
+        "commands": [
+          "in-toto-run --version",
+          "in-toto-verify --version"
+        ]
+      },
+      {
+        "title": "Generate signing keys",
+        "description": "Create a key pair for signing supply chain steps.\n\n```bash\npython3 -c \"from securesystemslib.interface import generate_ed25519_keypair; generate_ed25519_keypair('my-key')\"\n```\n\n> This creates my-key (private) and my-key.pub (public) files.",
+        "commands": [
+          "python3 -c \"from securesystemslib.interface import generate_ed25519_keypair; generate_ed25519_keypair('my-key')\""
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall in-toto",
+        "description": "Remove in-toto.\n\n```bash\npip uninstall in-toto -y\n```",
+        "commands": [
+          "pip uninstall in-toto -y"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-k0rdent.json
+++ b/fixes/platform-install/install-k0rdent.json
@@ -1,15 +1,17 @@
 {
   "version": "kc-mission-v1",
-  "name": "platform-k0rdent",
+  "name": "install-k0rdent",
   "missionClass": "install",
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "metadata": {
-    "cncfProjects": ["k0rdent"]
+    "cncfProjects": [
+      "k0rdent"
+    ]
   },
   "mission": {
     "title": "Install and Configure k0rdent (Kubernetes Cluster Lifecycle Manager)",
-    "description": "k0rdent is an open-source platform for deploying and managing Kubernetes clusters at scale. It functions as a super control plane, orchestrating multiple Kubernetes clusters across on-premises, cloud, and hybrid environments using a declarative GitOps approach. Built on Cluster API (CAPI), it supports infrastructure providers like AWS, Azure, vSphere, and bare metal. k0rdent provides centralized lifecycle management — provisioning, configuration, updates, and observability — from a single management cluster.",
+    "description": "k0rdent is an open-source platform for deploying and managing Kubernetes clusters at scale. It functions as a super control plane, orchestrating multiple Kubernetes clusters across on-premises, cloud, and hybrid environments using a declarative GitOps approach. Built on Cluster API (CAPI), it supports infrastructure providers like AWS, Azure, vSphere, and bare metal. k0rdent provides centralized lifecycle management \u2014 provisioning, configuration, updates, and observability \u2014 from a single management cluster.",
     "type": "deploy",
     "status": "completed",
     "estimatedMinutes": 15,
@@ -46,14 +48,14 @@
       },
       {
         "title": "Configure infrastructure credentials (example: AWS)",
-        "description": "To provision child clusters, k0rdent needs credentials for your infrastructure provider. This example shows AWS — adapt for Azure, vSphere, or other providers.\n\n```bash\n\nkubectl create secret generic aws-credentials -n kcm-system --from-literal=AccessKeyID=$AWS_ACCESS_KEY_ID --from-literal=SecretAccessKey=$AWS_SECRET_ACCESS_KEY\n\n```\n\n> Replace with your actual credentials. See [k0rdent docs](https://docs.k0rdent.io/latest/admin/installation/prepare-mgmt-cluster/) for provider-specific setup including Azure, vSphere, and bare metal.",
+        "description": "To provision child clusters, k0rdent needs credentials for your infrastructure provider. This example shows AWS \u2014 adapt for Azure, vSphere, or other providers.\n\n```bash\n\nkubectl create secret generic aws-credentials -n kcm-system --from-literal=AccessKeyID=$AWS_ACCESS_KEY_ID --from-literal=SecretAccessKey=$AWS_SECRET_ACCESS_KEY\n\n```\n\n> Replace with your actual credentials. See [k0rdent docs](https://docs.k0rdent.io/latest/admin/installation/prepare-mgmt-cluster/) for provider-specific setup including Azure, vSphere, and bare metal.",
         "commands": [
           "kubectl create secret generic aws-credentials -n kcm-system --from-literal=AccessKeyID=$AWS_ACCESS_KEY_ID --from-literal=SecretAccessKey=$AWS_SECRET_ACCESS_KEY"
         ]
       },
       {
         "title": "Create a child cluster (example)",
-        "description": "Deploy a managed child cluster using a k0rdent ClusterDeployment. This example creates a basic cluster — customize the template and parameters for your environment.\n\n```bash\n\nkubectl apply -f - <<EOF\napiVersion: k0rdent.mirantis.com/v1alpha1\nkind: ClusterDeployment\nmetadata:\n  name: my-child-cluster\n  namespace: kcm-system\nspec:\n  template: aws-standalone-cp-0-1-8\n  credential: aws-credentials\n  config:\n    region: us-east-1\n    controlPlane:\n      instanceType: t3.medium\n    worker:\n      instanceType: t3.medium\n      replicas: 2\nEOF\n\n```\n\n> This provisions a 2-worker Kubernetes cluster on AWS. Monitor progress with `kubectl get clusterdeployment -n kcm-system -w`.",
+        "description": "Deploy a managed child cluster using a k0rdent ClusterDeployment. This example creates a basic cluster \u2014 customize the template and parameters for your environment.\n\n```bash\n\nkubectl apply -f - <<EOF\napiVersion: k0rdent.mirantis.com/v1alpha1\nkind: ClusterDeployment\nmetadata:\n  name: my-child-cluster\n  namespace: kcm-system\nspec:\n  template: aws-standalone-cp-0-1-8\n  credential: aws-credentials\n  config:\n    region: us-east-1\n    controlPlane:\n      instanceType: t3.medium\n    worker:\n      instanceType: t3.medium\n      replicas: 2\nEOF\n\n```\n\n> This provisions a 2-worker Kubernetes cluster on AWS. Monitor progress with `kubectl get clusterdeployment -n kcm-system -w`.",
         "commands": [
           "kubectl apply -f - <<EOF\napiVersion: k0rdent.mirantis.com/v1alpha1\nkind: ClusterDeployment\nmetadata:\n  name: my-child-cluster\n  namespace: kcm-system\nspec:\n  template: aws-standalone-cp-0-1-8\n  credential: aws-credentials\n  config:\n    region: us-east-1\n    controlPlane:\n      instanceType: t3.medium\n    worker:\n      instanceType: t3.medium\n      replicas: 2\nEOF"
         ]

--- a/fixes/platform-install/install-kflashback.json
+++ b/fixes/platform-install/install-kflashback.json
@@ -1,15 +1,17 @@
 {
   "version": "kc-mission-v1",
-  "name": "platform-kflashback",
+  "name": "install-kflashback",
   "missionClass": "install",
   "author": "KubeStellar Bot",
   "authorGithub": "kubestellar",
   "metadata": {
-    "cncfProjects": ["kflashback"]
+    "cncfProjects": [
+      "kflashback"
+    ]
   },
   "mission": {
     "title": "Install and Configure kflashback (Kubernetes Resource History)",
-    "description": "kflashback is a Kubernetes operator that tracks resource history — every create, update, and delete — with revision diffs, AI-powered insights, and anomaly detection. It records a complete audit trail of your cluster's state over time with configurable retention policies. Supports local LLMs (Ollama) or cloud providers (OpenAI, Anthropic) for natural-language queries like \"What changed in the last hour?\" and automatic anomaly detection.",
+    "description": "kflashback is a Kubernetes operator that tracks resource history \u2014 every create, update, and delete \u2014 with revision diffs, AI-powered insights, and anomaly detection. It records a complete audit trail of your cluster's state over time with configurable retention policies. Supports local LLMs (Ollama) or cloud providers (OpenAI, Anthropic) for natural-language queries like \"What changed in the last hour?\" and automatic anomaly detection.",
     "type": "deploy",
     "status": "completed",
     "estimatedMinutes": 10,

--- a/fixes/platform-install/install-kube-burner.json
+++ b/fixes/platform-install/install-kube-burner.json
@@ -1,0 +1,49 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-kube-burner",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "kube-burner"
+  ],
+  "mission": {
+    "title": "Install and Configure Kube-burner",
+    "description": "Kube-burner is a CNCF Kubernetes performance and scale testing tool that creates, deletes, and patches resources at scale, collects Prometheus metrics, and alerts on performance regressions.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install kube-burner",
+        "description": "Download and install the kube-burner binary.\n\n```bash\ncurl -sLS https://raw.githubusercontent.com/kube-burner/kube-burner/refs/heads/main/hack/install.sh | sh\n```\n\n> Installs to ~/.local/bin/kube-burner by default. Set INSTALL_DIR for custom path.",
+        "commands": [
+          "curl -sLS https://raw.githubusercontent.com/kube-burner/kube-burner/refs/heads/main/hack/install.sh | sh"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Check kube-burner is installed.\n\n```bash\nkube-burner version\n```",
+        "commands": [
+          "kube-burner version"
+        ]
+      },
+      {
+        "title": "Run a sample workload",
+        "description": "Run a basic cluster-density test against your cluster.\n\n```bash\nkube-burner init -c https://raw.githubusercontent.com/kube-burner/kube-burner/main/examples/workloads/cfg_cluster-density_pod_serving.yml\n```\n\n> Ensure your kubeconfig is configured for the target cluster.",
+        "commands": [
+          "kube-burner init -c https://raw.githubusercontent.com/kube-burner/kube-burner/main/examples/workloads/cfg_cluster-density_pod_serving.yml"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall kube-burner",
+        "description": "Remove kube-burner.\n\n```bash\nrm ~/.local/bin/kube-burner\n```",
+        "commands": [
+          "rm ~/.local/bin/kube-burner"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-nmstate.json
+++ b/fixes/platform-install/install-nmstate.json
@@ -1,0 +1,49 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-nmstate",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "nmstate"
+  ],
+  "mission": {
+    "title": "Install and Configure NMstate",
+    "description": "NMstate is a CNCF declarative network management API for Linux hosts. It provides a Python library (libnmstate), Rust crate, and CLI tools (nmstatectl) for managing network configurations declaratively.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install NMstate via package manager",
+        "description": "Install NMstate using your system package manager.\n\n```bash\n# Fedora/RHEL\nsudo dnf install nmstate\n\n# Or via pip\npip install libnmstate\n```",
+        "commands": [
+          "sudo dnf install nmstate"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Check the NMstate CLI is available.\n\n```bash\nnmstatectl version\n```",
+        "commands": [
+          "nmstatectl version"
+        ]
+      },
+      {
+        "title": "Show current network state",
+        "description": "Display the current declarative network state.\n\n```bash\nnmstatectl show\n```\n\n> This outputs the full network configuration in YAML format.",
+        "commands": [
+          "nmstatectl show"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall NMstate",
+        "description": "Remove NMstate.\n\n```bash\nsudo dnf remove nmstate\n# Or: pip uninstall libnmstate -y\n```",
+        "commands": [
+          "sudo dnf remove nmstate"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-opa.json
+++ b/fixes/platform-install/install-opa.json
@@ -1,0 +1,60 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-opa",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "opa"
+  ],
+  "mission": {
+    "title": "Install and Configure Open Policy Agent (OPA)",
+    "description": "OPA is a CNCF graduated general-purpose policy engine that enables unified, context-aware policy enforcement across the cloud-native stack. It uses the Rego policy language for writing and evaluating policies.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install OPA binary",
+        "description": "Download and install the OPA binary.\n\n```bash\n# macOS\nbrew install opa\n\n# Linux\ncurl -L -o opa https://openpolicyagent.org/downloads/v1.15.2/opa_linux_amd64_static\nchmod 755 opa\nsudo mv opa /usr/local/bin/\n```",
+        "commands": [
+          "curl -L -o opa https://openpolicyagent.org/downloads/v1.15.2/opa_linux_amd64_static",
+          "chmod 755 opa",
+          "sudo mv opa /usr/local/bin/"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Check OPA is installed correctly.\n\n```bash\nopa version\n```",
+        "commands": [
+          "opa version"
+        ]
+      },
+      {
+        "title": "Run OPA as a server",
+        "description": "Start OPA as a policy decision service.\n\n```bash\nopa run --server &\ncurl localhost:8181/v1/data\n```\n\n> OPA listens on port 8181 and responds to policy queries via REST API.",
+        "commands": [
+          "opa run --server",
+          "curl localhost:8181/v1/data"
+        ]
+      },
+      {
+        "title": "Test with a sample policy",
+        "description": "Create and evaluate a simple Rego policy.\n\n```bash\necho 'package example\ndefault allow := false\nallow if input.user == \"admin\"' > policy.rego\necho '{\"user\": \"admin\"}' | opa eval -d policy.rego -i /dev/stdin 'data.example.allow'\n```",
+        "commands": [
+          "echo 'package example\ndefault allow := false\nallow if input.user == \"admin\"' > policy.rego",
+          "echo '{\"user\": \"admin\"}' | opa eval -d policy.rego -i /dev/stdin 'data.example.allow'"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall OPA",
+        "description": "Remove OPA.\n\n```bash\n# macOS\nbrew uninstall opa\n\n# Linux\nsudo rm /usr/local/bin/opa\n```",
+        "commands": [
+          "sudo rm /usr/local/bin/opa"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-openchoreo.json
+++ b/fixes/platform-install/install-openchoreo.json
@@ -1,0 +1,57 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-openchoreo",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "openchoreo"
+  ],
+  "mission": {
+    "title": "Install and Configure OpenChoreo",
+    "description": "OpenChoreo is a CNCF open-source internal developer platform for Kubernetes providing higher-level abstractions, a Backstage-powered developer portal, integrated CI/CD, GitOps workflows, and observability.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 20,
+    "steps": [
+      {
+        "title": "Add the OpenChoreo Helm repository",
+        "description": "Add the official OpenChoreo Helm chart repository.\n\n```bash\nhelm repo add openchoreo https://charts.openchoreo.dev\nhelm repo update\n```",
+        "commands": [
+          "helm repo add openchoreo https://charts.openchoreo.dev",
+          "helm repo update"
+        ]
+      },
+      {
+        "title": "Install OpenChoreo using Helm",
+        "description": "Install OpenChoreo into a dedicated namespace.\n\n```bash\nhelm install openchoreo openchoreo/openchoreo --namespace openchoreo-system --create-namespace\n```",
+        "commands": [
+          "helm install openchoreo openchoreo/openchoreo --namespace openchoreo-system --create-namespace"
+        ]
+      },
+      {
+        "title": "Verify OpenChoreo pods are running",
+        "description": "Check that all OpenChoreo components are running.\n\n```bash\nkubectl get pods -n openchoreo-system\n```\n\n> You should see the control plane, data plane, and portal pods in Running state.",
+        "commands": [
+          "kubectl get pods -n openchoreo-system"
+        ]
+      },
+      {
+        "title": "Access the developer portal",
+        "description": "Port-forward to access the Backstage-powered developer portal.\n\n```bash\nkubectl port-forward svc/openchoreo-portal -n openchoreo-system 3000:3000\n```\n\n> Open http://localhost:3000 to access the developer portal.",
+        "commands": [
+          "kubectl port-forward svc/openchoreo-portal -n openchoreo-system 3000:3000"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall OpenChoreo",
+        "description": "Remove OpenChoreo from your cluster.\n\n```bash\nhelm uninstall openchoreo -n openchoreo-system\n```",
+        "commands": [
+          "helm uninstall openchoreo -n openchoreo-system"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-openeverest.json
+++ b/fixes/platform-install/install-openeverest.json
@@ -1,0 +1,58 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-openeverest",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "openeverest"
+  ],
+  "mission": {
+    "title": "Install and Configure OpenEverest",
+    "description": "OpenEverest (formerly Percona Everest) is a CNCF open-source cloud-native database platform for deploying, scaling, and managing PostgreSQL, MySQL, and MongoDB on Kubernetes with a web UI and CLI.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 20,
+    "steps": [
+      {
+        "title": "Download the everestctl CLI",
+        "description": "Download the OpenEverest CLI for your platform.\n\n```bash\ncurl -sSL -o everestctl https://github.com/openeverest/openeverest/releases/latest/download/everestctl-linux-amd64\nchmod +x everestctl\nsudo mv everestctl /usr/local/bin/\n```",
+        "commands": [
+          "curl -sSL -o everestctl https://github.com/openeverest/openeverest/releases/latest/download/everestctl-linux-amd64",
+          "chmod +x everestctl",
+          "sudo mv everestctl /usr/local/bin/"
+        ]
+      },
+      {
+        "title": "Install OpenEverest on your cluster",
+        "description": "Use everestctl to install all components.\n\n```bash\neverestctl install\n```\n\n> This installs the Everest operator, database operators, and web UI into the everest-system namespace.",
+        "commands": [
+          "everestctl install"
+        ]
+      },
+      {
+        "title": "Retrieve admin credentials",
+        "description": "Get the initial admin password.\n\n```bash\nkubectl get secret everest-accounts -n everest-system -o jsonpath='{.data.users\\.yaml}' | base64 --decode\n```",
+        "commands": [
+          "kubectl get secret everest-accounts -n everest-system -o jsonpath='{.data.users\\.yaml}' | base64 --decode"
+        ]
+      },
+      {
+        "title": "Access the web UI",
+        "description": "Port-forward to access the Everest dashboard.\n\n```bash\nkubectl port-forward svc/everest -n everest-system 8080:8080\n```\n\n> Open http://localhost:8080 and log in with the admin credentials.",
+        "commands": [
+          "kubectl port-forward svc/everest -n everest-system 8080:8080"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall OpenEverest",
+        "description": "Remove OpenEverest from your cluster.\n\n```bash\neverestctl uninstall\n```",
+        "commands": [
+          "everestctl uninstall"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-serverless-devs.json
+++ b/fixes/platform-install/install-serverless-devs.json
@@ -1,0 +1,49 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-serverless-devs",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "serverless-devs"
+  ],
+  "mission": {
+    "title": "Install and Configure Serverless Devs",
+    "description": "Serverless Devs is a CNCF open-source serverless developer platform providing a unified CLI for building, deploying, and operating serverless applications across multiple cloud platforms.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install Serverless Devs via npm",
+        "description": "Install the Serverless Devs CLI globally.\n\n```bash\nnpm install -g @serverless-devs/s\n```\n\n> Requires Node.js 14+.",
+        "commands": [
+          "npm install -g @serverless-devs/s"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Check the CLI is available.\n\n```bash\ns --version\n```",
+        "commands": [
+          "s --version"
+        ]
+      },
+      {
+        "title": "Initialize a project",
+        "description": "Create a new serverless project from a template.\n\n```bash\ns init\n```\n\n> Follow the interactive prompts to select a template and configure your project.",
+        "commands": [
+          "s init"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Serverless Devs",
+        "description": "Remove Serverless Devs.\n\n```bash\nnpm uninstall -g @serverless-devs/s\n```",
+        "commands": [
+          "npm uninstall -g @serverless-devs/s"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-shipwright.json
+++ b/fixes/platform-install/install-shipwright.json
@@ -1,0 +1,63 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-shipwright",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "shipwright"
+  ],
+  "mission": {
+    "title": "Install and Configure Shipwright",
+    "description": "Shipwright is a CNCF extensible framework for building container images on Kubernetes. It supports multiple build strategies (Kaniko, Buildpacks, BuildKit, Buildah) and integrates with Tekton Pipelines.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 20,
+    "steps": [
+      {
+        "title": "Install Tekton Pipelines (prerequisite)",
+        "description": "Shipwright requires Tekton Pipelines. Install it first.\n\n```bash\nkubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.65.2/release.yaml\n```\n\n> Wait for Tekton pods to be ready before proceeding.",
+        "commands": [
+          "kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.65.2/release.yaml"
+        ]
+      },
+      {
+        "title": "Wait for Tekton to be ready",
+        "description": "Verify Tekton Pipelines pods are running.\n\n```bash\nkubectl get pods -n tekton-pipelines --watch\n```\n\n> Wait until all pods show Running status.",
+        "commands": [
+          "kubectl get pods -n tekton-pipelines"
+        ]
+      },
+      {
+        "title": "Install Shipwright Build",
+        "description": "Install the Shipwright build controller.\n\n```bash\nkubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.19.2/release.yaml --server-side\n```",
+        "commands": [
+          "kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.19.2/release.yaml --server-side"
+        ]
+      },
+      {
+        "title": "Install build strategies",
+        "description": "Install the sample build strategies (Kaniko, Buildpacks, etc.).\n\n```bash\nkubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.19.2/sample-strategies.yaml --server-side\n```",
+        "commands": [
+          "kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.19.2/sample-strategies.yaml --server-side"
+        ]
+      },
+      {
+        "title": "Verify Shipwright is running",
+        "description": "Check the Shipwright build controller is running.\n\n```bash\nkubectl get pods -n shipwright-build\n```\n\n> You should see the shipwright-build-controller pod in Running state.",
+        "commands": [
+          "kubectl get pods -n shipwright-build"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Shipwright",
+        "description": "Remove Shipwright from your cluster.\n\n```bash\nkubectl delete --filename https://github.com/shipwright-io/build/releases/download/v0.19.2/release.yaml\n```",
+        "commands": [
+          "kubectl delete --filename https://github.com/shipwright-io/build/releases/download/v0.19.2/release.yaml"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-tinkerbell.json
+++ b/fixes/platform-install/install-tinkerbell.json
@@ -1,0 +1,57 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-tinkerbell",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "tinkerbell"
+  ],
+  "mission": {
+    "title": "Install and Configure Tinkerbell",
+    "description": "Tinkerbell is a CNCF bare metal provisioning engine with workflow capabilities, supporting BMC interactions, DHCP, and hardware auto-discovery. Deploy it to Kubernetes via Helm to automate bare metal server provisioning.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 20,
+    "steps": [
+      {
+        "title": "Add the Tinkerbell Helm repository",
+        "description": "Add the official Tinkerbell Helm chart repository.\n\n```bash\nhelm repo add tinkerbell https://tinkerbell.github.io/charts\nhelm repo update\n```",
+        "commands": [
+          "helm repo add tinkerbell https://tinkerbell.github.io/charts",
+          "helm repo update"
+        ]
+      },
+      {
+        "title": "Install Tinkerbell using Helm",
+        "description": "Install Tinkerbell into a dedicated namespace.\n\n```bash\nhelm install tinkerbell tinkerbell/tinkerbell --namespace tinkerbell --create-namespace --version 0.23.0\n```\n\n> Adjust --version to match your desired release.",
+        "commands": [
+          "helm install tinkerbell tinkerbell/tinkerbell --namespace tinkerbell --create-namespace --version 0.23.0"
+        ]
+      },
+      {
+        "title": "Verify Tinkerbell pods are running",
+        "description": "Check that all Tinkerbell components are running.\n\n```bash\nkubectl get pods -n tinkerbell\n```\n\n> You should see tink-server, tink-controller, boots (DHCP), and hegel pods.",
+        "commands": [
+          "kubectl get pods -n tinkerbell"
+        ]
+      },
+      {
+        "title": "Verify Tinkerbell CRDs",
+        "description": "Confirm the Tinkerbell custom resource definitions were installed.\n\n```bash\nkubectl get crds | grep tinkerbell\n```\n\n> You should see Hardware, Template, and Workflow CRDs.",
+        "commands": [
+          "kubectl get crds | grep tinkerbell"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall Tinkerbell",
+        "description": "Remove Tinkerbell from your cluster.\n\n```bash\nhelm uninstall tinkerbell -n tinkerbell\n```",
+        "commands": [
+          "helm uninstall tinkerbell -n tinkerbell"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-tuf.json
+++ b/fixes/platform-install/install-tuf.json
@@ -1,0 +1,49 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-tuf",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "tuf"
+  ],
+  "mission": {
+    "title": "Install and Configure The Update Framework (TUF)",
+    "description": "TUF (The Update Framework) is a CNCF graduated specification and Python reference implementation for securing software update systems against key compromise and other attacks.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "title": "Install python-tuf via pip",
+        "description": "Install the TUF Python reference implementation.\n\n```bash\npip install tuf\n```\n\n> Requires Python 3.9+.",
+        "commands": [
+          "pip install tuf"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Confirm TUF is installed.\n\n```bash\npython3 -c \"import tuf; print(tuf.__version__)\"\n```",
+        "commands": [
+          "python3 -c \"import tuf; print(tuf.__version__)\""
+        ]
+      },
+      {
+        "title": "Initialize a TUF repository",
+        "description": "Create a basic TUF repository structure for testing.\n\n```bash\npython3 -c \"\nfrom tuf.api.metadata import Root, Timestamp, Snapshot, Targets\nprint('TUF metadata classes loaded successfully')\n\"\n```\n\n> TUF provides Python APIs for creating and managing update metadata.",
+        "commands": [
+          "python3 -c \"from tuf.api.metadata import Root, Timestamp, Snapshot, Targets; print('TUF metadata classes loaded successfully')\""
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall TUF",
+        "description": "Remove python-tuf.\n\n```bash\npip uninstall tuf -y\n```",
+        "commands": [
+          "pip uninstall tuf -y"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-youki.json
+++ b/fixes/platform-install/install-youki.json
@@ -1,0 +1,51 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-youki",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "youki"
+  ],
+  "mission": {
+    "title": "Install and Configure youki",
+    "description": "youki is a CNCF container runtime implementation in Rust, providing a low-memory-footprint alternative to runc. It implements the OCI Runtime Spec and can be used as a drop-in replacement for runc with Docker or containerd.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Download youki binary",
+        "description": "Download the pre-built youki binary for Linux.\n\n```bash\ncurl -sSL -o youki https://github.com/youki-dev/youki/releases/download/v0.6.0/youki_v0_6_0_linux_amd64\nchmod +x youki\nsudo mv youki /usr/local/bin/\n```\n\n> Requires Linux with kernel 5.3+.",
+        "commands": [
+          "curl -sSL -o youki https://github.com/youki-dev/youki/releases/download/v0.6.0/youki_v0_6_0_linux_amd64",
+          "chmod +x youki",
+          "sudo mv youki /usr/local/bin/"
+        ]
+      },
+      {
+        "title": "Verify installation",
+        "description": "Check youki version.\n\n```bash\nyouki --version\n```",
+        "commands": [
+          "youki --version"
+        ]
+      },
+      {
+        "title": "Configure Docker to use youki",
+        "description": "Register youki as a Docker runtime.\n\n```bash\nsudo dockerd --experimental --add-runtime=\"youki=/usr/local/bin/youki\" &\ndocker run --runtime=youki hello-world\n```\n\n> youki can also be configured in /etc/docker/daemon.json.",
+        "commands": [
+          "docker run --runtime=youki hello-world"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall youki",
+        "description": "Remove youki binary.\n\n```bash\nsudo rm /usr/local/bin/youki\n```",
+        "commands": [
+          "sudo rm /usr/local/bin/youki"
+        ]
+      }
+    ]
+  }
+}

--- a/fixes/platform-install/install-zot.json
+++ b/fixes/platform-install/install-zot.json
@@ -1,0 +1,58 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-zot",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "cncfProjects": [
+    "zot"
+  ],
+  "mission": {
+    "title": "Install and Configure zot",
+    "description": "zot is a CNCF production-ready, vendor-neutral OCI-native container image registry. It provides a minimal, performant registry that supports OCI image and artifact specs with built-in search, deduplication, and signing.",
+    "type": "deploy",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "title": "Deploy zot to Kubernetes",
+        "description": "Deploy a minimal zot registry using kubectl.\n\n```bash\nkubectl create namespace zot\nkubectl apply -n zot -f https://raw.githubusercontent.com/project-zot/zot/main/examples/k8s/deployment.yaml\n```",
+        "commands": [
+          "kubectl create namespace zot",
+          "kubectl apply -n zot -f https://raw.githubusercontent.com/project-zot/zot/main/examples/k8s/deployment.yaml"
+        ]
+      },
+      {
+        "title": "Expose zot service",
+        "description": "Create a service to expose the zot registry.\n\n```bash\nkubectl expose deployment zot -n zot --port=5000 --target-port=5000 --type=ClusterIP\n```",
+        "commands": [
+          "kubectl expose deployment zot -n zot --port=5000 --target-port=5000 --type=ClusterIP"
+        ]
+      },
+      {
+        "title": "Verify zot is running",
+        "description": "Check the zot pod is running.\n\n```bash\nkubectl get pods -n zot\n```\n\n> You should see the zot pod in Running state.",
+        "commands": [
+          "kubectl get pods -n zot"
+        ]
+      },
+      {
+        "title": "Test the registry",
+        "description": "Port-forward and test the zot registry API.\n\n```bash\nkubectl port-forward svc/zot -n zot 5000:5000 &\ncurl http://localhost:5000/v2/_catalog\n```",
+        "commands": [
+          "kubectl port-forward svc/zot -n zot 5000:5000",
+          "curl http://localhost:5000/v2/_catalog"
+        ]
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Uninstall zot",
+        "description": "Remove zot from your cluster.\n\n```bash\nkubectl delete namespace zot\n```",
+        "commands": [
+          "kubectl delete namespace zot"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds install missions for 18 CNCF projects that had no coverage, bringing total CNCF outreach coverage to ~220/225 (98%).

### Helm-based (6)
- **Tinkerbell** v0.23.0 — bare metal provisioning
- **Agones** v1.57.0 — game server hosting
- **Higress** v2.2.1 — API gateway (Istio/Envoy)
- **CloudNativePG** v1.29.0 — PostgreSQL operator
- **OpenEverest** v1.14.0 — multi-DB platform
- **OpenChoreo** v1.0.0 — developer platform

### kubectl-based (2)
- **Shipwright** v0.19.2 — container image builds (requires Tekton)
- **zot** v2.1.16 — OCI image registry

### pip-based (3)
- **in-toto** v3.0.0 — supply chain security (graduated)
- **TUF** v6.0.0 — update framework (graduated)
- **NMstate** v2.2.60 — declarative network management

### Binary/CLI (4)
- **OPA** v1.15.2 — policy engine (graduated)
- **Cedar** v4.9.1 — authorization policy language
- **Kube-burner** v2.6.1 — K8s performance testing
- **Serverless Devs** v3.1.10 — serverless CLI

### Docker-based (2)
- **Hexa** v0.5.0 — policy orchestrator
- **Athenz** v1.12.39 — service auth platform

### Runtime (1)
- **youki** v0.6.0 — Rust container runtime

### Skipped (4 non-installable)
- composefs, bootc (Linux-only utilities)
- OpenGitOps (specification, no software)
- CNI (Go library/specification)

### Also fixes
- `name` field mismatch in k0rdent and kflashback missions