### PR TITLE
🌱 n8n: installing community nodes get "spawn npm ENOENT" Issue in n8n on Windows

### DIFF
--- a/fixes/cncf-generated/n8n/n8n-22706-installing-community-nodes-get-spawn-npm-enoent-issue-in-n8n-on-window.json
+++ b/fixes/cncf-generated/n8n/n8n-22706-installing-community-nodes-get-spawn-npm-enoent-issue-in-n8n-on-window.json
@@ -1,0 +1,80 @@
+{
+  "version": "kc-mission-v1",
+  "name": "n8n-22706-installing-community-nodes-get-spawn-npm-enoent-issue-in-n8n-on-window",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "n8n: installing community nodes get \"spawn npm ENOENT\" Issue in n8n on Windows",
+    "description": "installing community nodes get \"spawn npm ENOENT\" Issue in n8n on Windows. Requested by 17+ users.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current n8n deployment",
+        "description": "Verify your n8n version and configuration:\n```bash\nkubectl get pods -n n8n -l app.kubernetes.io/name=n8n\nhelm list -n n8n 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working n8n installation."
+      },
+      {
+        "title": "Review n8n configuration",
+        "description": "Inspect the relevant n8n configuration:\n```bash\nkubectl get all -n n8n -l app.kubernetes.io/name=n8n\nkubectl get configmap -n n8n -l app.kubernetes.io/part-of=n8n\n```\n### Bug Description\n\nWhen installing community nodes in n8n under the Windows environment, the \"spawn npm ENOENT\" error often occurs. The core reason is that n8n does not adapt to Windows script suffix resolution when calling npm."
+      },
+      {
+        "title": "Apply the fix for installing community nodes get \"spawn npm ENOENT\" Issue in…",
+        "description": "I encountered the same issue on the current version (**n8n.9.4**) installed on Windows via `npx n8n`.\n\nThe solution was to add `shell: true` to the `asyncExecFile` options in the following\n```yaml\nerror Using Original file\nFailed to execute npm command\nError loading package \"n8n-nodes-kommo\" :Failed to execute npm command\nCause: spawn npm ENOENT\nResponseError: Error loading package \"n8n-nodes-kommo\" :Failed to execute npm command\nCause: spawn npm ENOENT\n    at CommunityPackagesController.installPackage (C:\\Users\\AC\\AppData\\Roaming\\npm\\node_modules\\n8n\\src\\modules\\community-packages\\community-packages.controller.ts:135:10)\n    at processTicksAndRejections (node:internal/process/task_queues:103:5)\n    at handler (C:\\Users\\AC\\AppData\\Roaming\\npm\\node_modules\\n8n\\src\\controller.registry.ts:\n```"
+      },
+      {
+        "title": "Upgrade n8n to include the fix",
+        "description": "If the fix is included in a newer release, upgrade n8n:\n```bash\nhelm repo update\nhelm upgrade n8n n8n/n8n --namespace n8n\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n n8n\nhelm list -n n8n\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n n8n -l app.kubernetes.io/name=n8n\nkubectl get events -n n8n --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"installing community nodes get \"spawn npm ENOENT\" Issue in…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "I encountered the same issue on the current version (**n8n.9.4**) installed on Windows via `npx n8n`.",
+      "codeSnippets": [
+        "error Using Original file\nFailed to execute npm command\nError loading package \"n8n-nodes-kommo\" :Failed to execute npm command\nCause: spawn npm ENOENT\nResponseError: Error loading package \"n8n-nodes-kommo\" :Failed to execute npm command\nCause: spawn npm ENOENT\n    at CommunityPackagesController.installPackage (C:\\Users\\AC\\AppData\\Roaming\\npm\\node_modules\\n8n\\src\\modules\\community-packages\\community-packages.controller.ts:135:10)\n    at processTicksAndRejections (node:internal/process/task_queues:103:5)\n    at handler (C:\\Users\\AC\\AppData\\Roaming\\npm\\node_modules\\n8n\\src\\controller.registry.ts:110:12)\n    at C:\\Users\\AC\\AppData\\Roaming\\npm\\node_modules\\n8n\\src\\response-helper.ts:161:17\n\n500 Error loading package \"n8n-nodes-kommo\" :Failed to execute npm command\nCause: spawn npm ENOENT\n\nError",
+        "**Change it to:**",
+        "npm lives at:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "n8n",
+      "community",
+      "workflow",
+      "deploy"
+    ],
+    "cncfProjects": [
+      "n8n"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "deploy"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/n8n-io/n8n/issues/22706",
+      "repo": "https://github.com/n8n-io/n8n"
+    },
+    "reactions": 17,
+    "comments": 29,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with n8n installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-24T07:07:55.460Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: n8n — installing community nodes get "spawn npm ENOENT" Issue in n8n on Windows

**Type:** deploy | **Source:** https://github.com/n8n-io/n8n/issues/22706 (17 reactions)
**File:** `fixes/cncf-generated/n8n/n8n-22706-installing-community-nodes-get-spawn-npm-enoent-issue-in-n8n-on-window.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*