### PR TITLE
🌱 caddy: Unable to issue IP address certificate with Let's Encrypt `shortlived` ACME

### DIFF
--- a/fixes/cncf-generated/caddy/caddy-7399-unable-to-issue-ip-address-certificate-with-let-s-encrypt-shortlived-.json
+++ b/fixes/cncf-generated/caddy/caddy-7399-unable-to-issue-ip-address-certificate-with-let-s-encrypt-shortlived-.json
@@ -1,0 +1,79 @@
+{
+  "version": "kc-mission-v1",
+  "name": "caddy-7399-unable-to-issue-ip-address-certificate-with-let-s-encrypt-shortlived-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "caddy: Unable to issue IP address certificate with Let's Encrypt `shortlived` ACME profile",
+    "description": "Unable to issue IP address certificate with Let's Encrypt `shortlived` ACME profile. This issue affects 8+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify caddy troubleshoot symptoms",
+        "description": "Check for the issue in your caddy installation:\n```bash\ncaddy version\ncaddy validate --config /etc/caddy/Caddyfile\n```\nLook for errors or warnings that may indicate the issue."
+      },
+      {
+        "title": "Review caddy configuration",
+        "description": "Review the relevant caddy configuration:\n### Issue Details\n\nGreetings,\n\n[Let's encrypt has rolled out IP address Identifiers for shortlived certificates to General"
+      },
+      {
+        "title": "Apply the fix for Unable to issue IP address certificate with Let's Encrypt…",
+        "description": "As of 5 months ago the code was updated to allow LE for issuing IP certs:\n\n```go\n\tpublicCAsAndIPCerts := map[string]bool{ // map of public CAs to whether they support IP certificates (last updated: Q1 2024)\n\t\t\"api.letsencrypt.org\": true,  //\n```yaml\nThen the IP address configuration:\n```"
+      },
+      {
+        "title": "Upgrade caddy to include the fix",
+        "description": "If the fix is included in a newer release, upgrade caddy:\n```bash\n# Check current version\ncaddy version\n# Follow the project's upgrade guide at https://github.com/caddyserver/caddy\n```"
+      },
+      {
+        "title": "Confirm Unable to issue IP address certificate with Let's… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest caddy to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "As of 5 months ago the code was updated to allow LE for issuing IP certs:\n\n```go\n\tpublicCAsAndIPCerts := map[string]bool{ // map of public CAs to whether they support IP certificates (last updated: Q1 2024)\n\t\t\"api.letsencrypt.org\": true,  // https://letsencrypt.org/2025/07/01/issuing-our-first-ip-address-certificate/\n\t\t\"acme.zerossl.com\":    false, // only supported via their API, not ACME",
+      "codeSnippets": [
+        "Then the IP address configuration:",
+        "Seems upgrading caddy manually with `caddy upgrade` fixed the issue for Ipv4 IP Identifiers. \n\nHowever, for IPv6, I get the following:",
+        "Its seems like 'tls-alpn-01' challenge types successful authorized, but 'http-01' not.\nCaddyfile:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "caddy",
+      "community",
+      "web-server",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "caddy"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/caddyserver/caddy/issues/7399",
+      "repo": "https://github.com/caddyserver/caddy"
+    },
+    "reactions": 8,
+    "comments": 17,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "caddy"
+    ],
+    "description": "A working caddy installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-04-26T07:07:14.995Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: caddy — Unable to issue IP address certificate with Let's Encrypt `shortlived` ACME profile

**Type:** troubleshoot | **Source:** https://github.com/caddyserver/caddy/issues/7399 (8 reactions)
**File:** `fixes/cncf-generated/caddy/caddy-7399-unable-to-issue-ip-address-certificate-with-let-s-encrypt-shortlived-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*