### PR TITLE
🌱 hami: VRAM usage is shown differently on between node and pod

### DIFF
--- a/fixes/cncf-generated/hami/hami-409-vram-usage-is-shown-differently-on-between-node-and-pod.json
+++ b/fixes/cncf-generated/hami/hami-409-vram-usage-is-shown-differently-on-between-node-and-pod.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "hami-409-vram-usage-is-shown-differently-on-between-node-and-pod",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "hami: VRAM usage is shown differently on between node and pod",
+    "description": "VRAM usage is shown differently on between node and pod. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current hami deployment",
+        "description": "Verify your hami version and configuration:\n```bash\nkubectl get pods -n hami -l app.kubernetes.io/name=hami\nhelm list -n hami 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working hami installation."
+      },
+      {
+        "title": "Review hami configuration",
+        "description": "Inspect the relevant hami configuration:\n```bash\nkubectl get all -n hami -l app.kubernetes.io/name=hami\nkubectl get configmap -n hami -l app.kubernetes.io/part-of=hami\n```\n### 1. Issue or feature description\nI used `nvidia-smi` to list the usage of gpu memory of pods and I encountered weird situation that the usage of process is shown differently on between node and pod."
+      },
+      {
+        "title": "Apply the fix for VRAM usage is shown differently on between node and pod",
+        "description": "This issue still exists, we will further debug and fix it\n```yaml\n# in node\n+---------------------------------------------------------------------------------------+\n| NVIDIA-SMI 535.154.05             Driver Version: 535.154.05   CUDA Version: 12.2     |\n|-----------------------------------------+----------------------+----------------------+\n| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |\n| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |\n|                                         |                      |               MIG M. |\n|=========================================+=======\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n hami -l app.kubernetes.io/name=hami\nkubectl get events -n hami --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"VRAM usage is shown differently on between node and pod\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "This issue still exists, we will further debug and fix it",
+      "codeSnippets": [
+        "# in node\n+---------------------------------------------------------------------------------------+\n| NVIDIA-SMI 535.154.05             Driver Version: 535.154.05   CUDA Version: 12.2     |\n|-----------------------------------------+----------------------+----------------------+\n| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |\n| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |\n|                                         |                      |               MIG M. |\n|=========================================+======================+======================|\n...\n+-----------------------------------------+----------------------+----------------------+\n|   5  NVIDIA A100-SXM4-80GB          On  | 00000000:98:00.0 Off |",
+        "# in pod (container)\n[HAMI-core Info(231:139933826504512:hook.c:300)]: loaded nvml libraries\n[HAMI-core Msg(231:139933826504512:libvgpu.c:836)]: Initializing.....\n[HAMI-core Info(231:139933826504512:hook.c:238)]: Start hijacking\n[HAMI-core Info(231:139933826504512:hook.c:267)]: loaded_cuda_libraries\n[HAMI-core Info(231:139933826504512:multiprocess_memory_limit.c:122)]: put_device_info finished 1\n[HAMI-core Info(231:139933826504512:multiprocess_memory_limit.c:103)]: device core util limit set to 0, which means no limit: CUDA_DEVICE_SM_LIMIT=0\n[HAMI-core Info(231:139933826504512:device.c:102)]: driver version=12020\nThu Aug  1 02:23:24 2024       \n+---------------------------------------------------------------------------------------+\n| NVIDIA-SMI 535.104.05             Driver Version: 535.1",
+        "# in node\n...\n    FB Memory Usage\n        Total                             : 81920 MiB\n        Reserved                          : 691 MiB\n        Used                              : 871 MiB\n        Free                              : 80357 MiB\n...\n    Processes\n        GPU instance ID                   : N/A\n        Compute instance ID               : N/A\n        Process ID                        : 141453\n            Type                          : C\n            Name                          : python3\n            Used GPU Memory               : 862 MiB"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "hami",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "hami"
+    ],
+    "targetResourceKinds": [
+      "Pod"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/Project-HAMi/HAMi/issues/409",
+      "repo": "https://github.com/Project-HAMi/HAMi"
+    },
+    "reactions": 3,
+    "comments": 14,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with hami installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-28T07:09:11.067Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: hami — VRAM usage is shown differently on between node and pod

**Type:** feature | **Source:** https://github.com/Project-HAMi/HAMi/issues/409 (3 reactions)
**File:** `fixes/cncf-generated/hami/hami-409-vram-usage-is-shown-differently-on-between-node-and-pod.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*