### PR TITLE
🌱 container-network-interface-cni-: converting plugin result to wrong config version results in regression 

### DIFF
--- a/fixes/cncf-generated/container-network-interface-cni-/container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver.json
+++ b/fixes/cncf-generated/container-network-interface-cni-/container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "container-network-interface-cni-: converting plugin result to wrong config version results in regression ",
+    "description": "converting plugin result to wrong config version results in regression . Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current container-network-interface-cni- deployment",
+        "description": "Verify your container-network-interface-cni- version and configuration:\n```bash\nkubectl get pods -n container-network-interface-cni- -l app.kubernetes.io/name=container-network-interface-cni-\nhelm list -n container-network-interface-cni- 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working container-network-interface-cni- installation."
+      },
+      {
+        "title": "Review container-network-interface-cni- configuration",
+        "description": "Inspect the relevant container-network-interface-cni- configuration:\n```bash\nkubectl get all -n container-network-interface-cni- -l app.kubernetes.io/name=container-network-interface-cni-\nkubectl get configmap -n container-network-interface-cni- -l app.kubernetes.io/part-of=container-network-interface-cni-\n```\nhttps://github.com/weaveworks/weave/issues/3936\nhttps://github.com/containerd/containerd/issues/6921\n\n drafted a prototype fix:\nhttps://github.com/fuweid/containerd/commit/8c5607ca4edae3bfd21a15f7d3f9db2d17fee0f0"
+      },
+      {
+        "title": "Apply the fix for converting plugin result to wrong config version results in…",
+        "description": "The CNI Spec requires plugins to return a CNIVersion in the Result\nthat is the same as the CNIVersion of the incoming CNI config.\n\nEmpty CNIVersions are specified to map to 0.1.0 (since the first\nCNI spec didn't have versioning) and libcni handles that automatically.\n\nUnfortunately some versions of Weave don't do that and depend on\na libcni <= 0.8 quirk that used the netconf version if the result\nversion was empty. This is technically a libcni regression, though\nthe plugin itself is violating\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Upgrade container-network-interface-cni- to include the fix",
+        "description": "If the fix is included in a newer release, upgrade container-network-interface-cni-:\n```bash\nhelm repo update\nhelm upgrade container-network-interface-cni- container-network-interface-cni-/container-network-interface-cni- --namespace container-network-interface-cni-\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n container-network-interface-cni-\nhelm list -n container-network-interface-cni-\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n container-network-interface-cni- -l app.kubernetes.io/name=container-network-interface-cni-\nkubectl get events -n container-network-interface-cni- --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"converting plugin result to wrong config version results in…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "The CNI Spec requires plugins to return a CNIVersion in the Result\nthat is the same as the CNIVersion of the incoming CNI config.\n\nEmpty CNIVersions are specified to map to 0.1.0 (since the first\nCNI spec didn't have versioning) and libcni handles that automatically.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "container-network-interface-cni-",
+      "incubating",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "container-network-interface-cni-"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/containernetworking/cni/issues/895",
+      "repo": "https://github.com/containernetworking/cni",
+      "pr": "https://github.com/containernetworking/cni/pull/896"
+    },
+    "reactions": 0,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with container-network-interface-cni- installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-29T06:53:45.597Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/solutions/cncf-generated/container-network-interface-cni-/container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver.json
+++ b/solutions/cncf-generated/container-network-interface-cni-/container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver",
+  "missionClass": "solution",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "container-network-interface-cni-: converting plugin result to wrong config version results in regression ",
+    "description": "converting plugin result to wrong config version results in regression . Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current container-network-interface-cni- deployment",
+        "description": "Verify your container-network-interface-cni- version and configuration:\n```bash\nkubectl get pods -n container-network-interface-cni- -l app.kubernetes.io/name=container-network-interface-cni-\nhelm list -n container-network-interface-cni- 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working container-network-interface-cni- installation."
+      },
+      {
+        "title": "Review container-network-interface-cni- configuration",
+        "description": "Inspect the relevant container-network-interface-cni- configuration:\n```bash\nkubectl get all -n container-network-interface-cni- -l app.kubernetes.io/name=container-network-interface-cni-\nkubectl get configmap -n container-network-interface-cni- -l app.kubernetes.io/part-of=container-network-interface-cni-\n```\nhttps://github.com/weaveworks/weave/issues/3936\nhttps://github.com/containerd/containerd/issues/6921\n\n drafted a prototype fix:\nhttps://github.com/fuweid/containerd/commit/8c5607ca4edae3bfd21a15f7d3f9db2d17fee0f0"
+      },
+      {
+        "title": "Apply the fix for converting plugin result to wrong config version results in…",
+        "description": "The CNI Spec requires plugins to return a CNIVersion in the Result\nthat is the same as the CNIVersion of the incoming CNI config.\n\nEmpty CNIVersions are specified to map to 0.1.0 (since the first\nCNI spec didn't have versioning) and libcni handles that automatically.\n\nUnfortunately some versions of Weave don't do that and depend on\na libcni <= 0.8 quirk that used the netconf version if the result\nversion was empty. This is technically a libcni regression, though\nthe plugin itself is violating\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Upgrade container-network-interface-cni- to include the fix",
+        "description": "If the fix is included in a newer release, upgrade container-network-interface-cni-:\n```bash\nhelm repo update\nhelm upgrade container-network-interface-cni- container-network-interface-cni-/container-network-interface-cni- --namespace container-network-interface-cni-\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n container-network-interface-cni-\nhelm list -n container-network-interface-cni-\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n container-network-interface-cni- -l app.kubernetes.io/name=container-network-interface-cni-\nkubectl get events -n container-network-interface-cni- --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"converting plugin result to wrong config version results in…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "The CNI Spec requires plugins to return a CNIVersion in the Result\nthat is the same as the CNIVersion of the incoming CNI config.\n\nEmpty CNIVersions are specified to map to 0.1.0 (since the first\nCNI spec didn't have versioning) and libcni handles that automatically.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "container-network-interface-cni-",
+      "incubating",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "container-network-interface-cni-"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/containernetworking/cni/issues/895",
+      "repo": "https://github.com/containernetworking/cni",
+      "pr": "https://github.com/containernetworking/cni/pull/896"
+    },
+    "reactions": 0,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with container-network-interface-cni- installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-03-16T06:37:17.888Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: container-network-interface-cni- — converting plugin result to wrong config version results in regression 

**Type:** feature | **Source:** https://github.com/containernetworking/cni/issues/895 (0 reactions)
**Fix PR:** https://github.com/containernetworking/cni/pull/896
**File:** `fixes/cncf-generated/container-network-interface-cni-/container-network-interface-cni-895-converting-plugin-result-to-wrong-config-ver.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*