### PR TITLE
🌱 prometheus: Stop removing __name__ from results: prevent `vector cannot contain metrics

### DIFF
--- a/fixes/cncf-generated/prometheus/prometheus-11397-stop-removing-name-from-results-prevent-vector-cannot-contain-m.json
+++ b/fixes/cncf-generated/prometheus/prometheus-11397-stop-removing-name-from-results-prevent-vector-cannot-contain-m.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "prometheus-11397-stop-removing-name-from-results-prevent-vector-cannot-contain-m",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "prometheus: Stop removing __name__ from results: prevent `vector cannot contain metrics with the same labelset`",
+    "description": "Stop removing __name__ from results: prevent `vector cannot contain metrics with the same labelset`. This issue affects 9+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify prometheus troubleshoot symptoms",
+        "description": "Check for the issue in your prometheus deployment:\n```bash\nkubectl get pods -n prometheus -l app.kubernetes.io/name=prometheus\nkubectl logs -l app.kubernetes.io/name=prometheus -n prometheus --tail=100 | grep -i error\n```\nLook for error: `ranges only allowed for vector selectors`. But by switching to a subquery, `count_over_time` no longer counting the DPM`"
+      },
+      {
+        "title": "Review prometheus configuration",
+        "description": "Inspect the relevant prometheus configuration:\n```bash\nkubectl get all -n prometheus -l app.kubernetes.io/name=prometheus\nkubectl get configmap -n prometheus -l app.kubernetes.io/part-of=prometheus\n```\nThis issue was previously named as:\n\n## Problem / Use-Case\n\nAs an Admin/Manager/Operator of a Prometheus instance one use-case is to understand, then manage-down the usage on the instance and the cost of running it."
+      },
+      {
+        "title": "Apply the fix for Stop removing __name__ from results: prevent `vector cannot…",
+        "description": "Inspired by this issue, I had added an agenda item for the dev-summit many months ago. However, it wasn't discussed so far as other agenda items were deemed more pressing.\n\nThis makes it hard to go forward with any of the more invasive approaches. However, as already discussed in the dev-summit agenda item (search for \"Revisit metric name removal during PromQL evaluation\" in the [dev summit document](https://docs.google.com/document/d/11LC3wJcVk00l8w5P3oLQ-m3Y37iom6INAMEu2ZAGIIE/edit?pli=1),\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Confirm Stop removing __name__ from results: prevent… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=prometheus -n prometheus --tail=50 --since=5m\nkubectl get events -n prometheus --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that `ranges only allowed for vector selectors`. But by switching to a subquery, `count_over_time` no longer counting the DPM` no longer appears in logs."
+      }
+    ],
+    "resolution": {
+      "summary": "Inspired by this issue, I had added an agenda item for the dev-summit many months ago. However, it wasn't discussed so far as other agenda items were deemed more pressing.\n\nThis makes it hard to go forward with any of the more invasive approaches.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "prometheus",
+      "graduated",
+      "observability",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "prometheus"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/prometheus/prometheus/issues/11397",
+      "repo": "https://github.com/prometheus/prometheus"
+    },
+    "reactions": 9,
+    "comments": 27,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with prometheus installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-29T06:56:37.190Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: prometheus — Stop removing __name__ from results: prevent `vector cannot contain metrics with the same labelset`

**Type:** troubleshoot | **Source:** https://github.com/prometheus/prometheus/issues/11397 (9 reactions)
**File:** `fixes/cncf-generated/prometheus/prometheus-11397-stop-removing-name-from-results-prevent-vector-cannot-contain-m.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*