### PR TITLE
Fix quality-check CI working directory path

### DIFF
--- a/.github/workflows/kb-quality-enforcement.yml
+++ b/.github/workflows/kb-quality-enforcement.yml
@@ -43,5 +43,4 @@ jobs:
       - name: Run Quality Scorer
         if: steps.detect-files.outputs.files_changed == 'true'
         run: |
-          cd scripts
-          node test-kb-quality-ci.mjs $(cat ../changed_files.txt | tr '\n' ' ')
+          node scripts/test-kb-quality-ci.mjs $(cat changed_files.txt | tr '\n' ' ')


### PR DESCRIPTION
Fixes quality-check CI ENOENT failures affecting PRs #2105, #2106, #2107, #2108

## Problem
The `kb-quality-enforcement.yml` workflow was running the quality checker from the `scripts/` directory while the script tried to read files using repo-root-relative paths like `fixes/cncf-generated/...`, causing ENOENT errors.

## Solution
Changed the workflow to:
1. Run the script from the repo root: `node scripts/test-kb-quality-ci.mjs`
2. Access the changed files list from the repo root: `changed_files.txt`

This ensures file paths resolve correctly when the script reads them.