### PR TITLE
🌱 litellm: Why does OTel tracing require `litellm[proxy]`?

### DIFF
--- a/fixes/cncf-generated/litellm/litellm-13081-why-does-otel-tracing-require-litellm-proxy.json
+++ b/fixes/cncf-generated/litellm/litellm-13081-why-does-otel-tracing-require-litellm-proxy.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "litellm-13081-why-does-otel-tracing-require-litellm-proxy",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "litellm: Why does OTel tracing require `litellm[proxy]`?",
+    "description": "Why does OTel tracing require `litellm[proxy]`?. Requested by 21+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current litellm deployment",
+        "description": "Verify your litellm version and configuration:\n```bash\nkubectl get pods -n litellm -l app.kubernetes.io/name=litellm\nhelm list -n litellm 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working litellm installation."
+      },
+      {
+        "title": "Review litellm configuration",
+        "description": "Inspect the relevant litellm configuration:\n```bash\nkubectl get all -n litellm -l app.kubernetes.io/name=litellm\nkubectl get configmap -n litellm -l app.kubernetes.io/part-of=litellm\n```\nI'd like to use OpenTelemetry tracing with LiteLLM. But this causes an error:\n\n```\nImportError: Missing dependency No module named 'backoff'."
+      },
+      {
+        "title": "Apply the fix for Why does OTel tracing require `litellm[proxy]`?",
+        "description": "Apply the configuration change to resolve the issue:\n```yaml\nImportError: Missing dependency No module named 'backoff'. Run `pip install 'litellm[proxy]'`\nERROR    LiteLLM:litellm_logging.py:3416 [Non-Blocking Error] Error initializing custom logger: Missing dependency No module named 'backoff'. Run `pip install 'litellm[proxy]'`\nTraceback (most recent call last):\n  File \"/.venv/lib/python3.12/site-packages/litellm/proxy/proxy_server.py\", line 74, in <module>\n    import backoff\nModuleNotFoundError: No module named 'backoff'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/.venv/lib/python3\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n litellm -l app.kubernetes.io/name=litellm\nkubectl get events -n litellm --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Why does OTel tracing require `litellm[proxy]`?\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "See the source issue for the community-verified solution: https://github.com/BerriAI/litellm/issues/13081",
+      "codeSnippets": [
+        "ImportError: Missing dependency No module named 'backoff'. Run `pip install 'litellm[proxy]'`\nERROR    LiteLLM:litellm_logging.py:3416 [Non-Blocking Error] Error initializing custom logger: Missing dependency No module named 'backoff'. Run `pip install 'litellm[proxy]'`\nTraceback (most recent call last):\n  File \"/.venv/lib/python3.12/site-packages/litellm/proxy/proxy_server.py\", line 74, in <module>\n    import backoff\nModuleNotFoundError: No module named 'backoff'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/litellm_logging.py\", line 3225, in _init_custom_logger_compatible_class\n    **_get_custom_logger_settings_from_proxy_server(\n      ^^^^^^^^^^^^^^^^^^^^^^^^",
+        "LiteLLM:WARNING: opentelemetry.py:190 - Proxy Server is not installed. Skipping OpenTelemetry initialization."
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "litellm",
+      "community",
+      "llm-gateway",
+      "feature"
+    ],
+    "cncfProjects": [
+      "litellm"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/BerriAI/litellm/issues/13081",
+      "repo": "https://github.com/BerriAI/litellm"
+    },
+    "reactions": 21,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with litellm installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-04-29T07:15:09.393Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: litellm — Why does OTel tracing require `litellm[proxy]`?

**Type:** feature | **Source:** https://github.com/BerriAI/litellm/issues/13081 (21 reactions)
**File:** `fixes/cncf-generated/litellm/litellm-13081-why-does-otel-tracing-require-litellm-proxy.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*