### PR TITLE
🌱 flux: Flux CLI tool doesn't respect context namespace

### DIFF
--- a/fixes/cncf-generated/flux/flux-3453-flux-cli-tool-doesn-t-respect-context-namespace.json
+++ b/fixes/cncf-generated/flux/flux-3453-flux-cli-tool-doesn-t-respect-context-namespace.json
@@ -1,0 +1,79 @@
+{
+  "version": "kc-mission-v1",
+  "name": "flux-3453-flux-cli-tool-doesn-t-respect-context-namespace",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "flux: Flux CLI tool doesn't respect context namespace",
+    "description": "Flux CLI tool doesn't respect context namespace. Requested by 6+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current flux deployment",
+        "description": "Verify your flux version and configuration:\n```bash\nkubectl get pods -n flux -l app.kubernetes.io/name=flux\nhelm list -n flux 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working flux installation."
+      },
+      {
+        "title": "Review flux configuration",
+        "description": "Inspect the relevant flux configuration:\n```bash\nkubectl get all -n flux -l app.kubernetes.io/name=flux\nkubectl get configmap -n flux -l app.kubernetes.io/part-of=flux\n```\n### Describe the bug\n\nSay a Kubeconfig has the following block:\n\n```\ncontexts:\n- context:\n    cluster: cluster\n    namespace: services\n    user: user\n  name: cluster\ncurrent-context: cluster\n```\n\nWhen you run flux commands it will not target the"
+      },
+      {
+        "title": "Apply the fix for Flux CLI tool doesn't respect context namespace",
+        "description": "I agree with this report in principle, however I'd like to note as a point of information that this is not a regression. This is how `flux` CLI has always worked. You can use the `FLUX_SYSTEM_NAMESPACE` environment variable to set `flux` CLI to work in a different namespace, but, generally, it is\n```yaml\ncontexts:\n- context:\n    cluster: cluster\n    namespace: services\n    user: user\n  name: cluster\ncurrent-context: cluster\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n flux -l app.kubernetes.io/name=flux\nkubectl get events -n flux --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Flux CLI tool doesn't respect context namespace\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "I agree with this report in principle, however I'd like to note as a point of information that this is not a regression. This is how `flux` CLI has always worked.",
+      "codeSnippets": [
+        "contexts:\n- context:\n    cluster: cluster\n    namespace: services\n    user: user\n  name: cluster\ncurrent-context: cluster",
+        "namespace: services\nhelmrelease: service",
+        "namespace: services\nhelmrelease: service"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "flux",
+      "graduated",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "flux"
+    ],
+    "targetResourceKinds": [
+      "Namespace",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/fluxcd/flux2/issues/3453",
+      "repo": "https://github.com/fluxcd/flux2"
+    },
+    "reactions": 6,
+    "comments": 14,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with flux installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-01T06:56:10.358Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: flux — Flux CLI tool doesn't respect context namespace

**Type:** feature | **Source:** https://github.com/fluxcd/flux2/issues/3453 (6 reactions)
**File:** `fixes/cncf-generated/flux/flux-3453-flux-cli-tool-doesn-t-respect-context-namespace.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*