### PR TITLE
🌱 signoz: [web] access frontend from a different basepath than root

### DIFF
--- a/fixes/cncf-generated/signoz/signoz-357-web-access-frontend-from-a-different-basepath-than-root.json
+++ b/fixes/cncf-generated/signoz/signoz-357-web-access-frontend-from-a-different-basepath-than-root.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "signoz-357-web-access-frontend-from-a-different-basepath-than-root",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "signoz: [web] access frontend from a different basepath than root",
+    "description": "[web] access frontend from a different basepath than root. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current signoz deployment",
+        "description": "Verify your signoz version and configuration:\n```bash\nkubectl get pods -n signoz -l app.kubernetes.io/name=signoz\nhelm list -n signoz 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working signoz installation."
+      },
+      {
+        "title": "Review signoz configuration",
+        "description": "Inspect the relevant signoz configuration:\n```bash\nkubectl get all -n signoz -l app.kubernetes.io/name=signoz\nkubectl get configmap -n signoz -l app.kubernetes.io/part-of=signoz\n```\n## Is your feature request related to a problem?\n\nI'm behind an argo tunnel and traefik, and I need the frontend to be accessed from \"http://siteurl/admin/signoz\". Right now, this results in 404 errors."
+      },
+      {
+        "title": "Apply the fix for [web] access frontend from a different basepath than root",
+        "description": "Hi folks,\nBase path support is live in SigNoz **v0.121.0**. You can now serve SigNoz under any URL prefix.\n\nCheck out the [Serving SigNoz on an external URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) doc.\n\nPS: We've also been building\n```yaml\nsignoz-frontend:\n    image: signoz/frontend:0.4.3\n    container_name: frontend\n    depends_on:\n      - query-service\n    links:\n      - \"query-service\"\n    ports:\n      - \"3000:3000\"\n    volumes:\n      - ./signoz/nginx-config.conf:/etc/nginx/conf.d/default.conf\n    environment:\n      - BASE_PATH=/admin/signoz\n    labels:\n      - traefik.enable=true\n      - traefik.http.routers.signoz.rule=PathPrefix(`/admin/signoz`)\n      - traefik.http.services.signoz.loadbalancer.server.port=3000\n\n  traefik:\n    image: traefik:latest\n    ports:\n      - 80:80\n      - 8181:8080 #traefik dashboard\n    volumes:\n\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n signoz -l app.kubernetes.io/name=signoz\nkubectl get events -n signoz --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[web] access frontend from a different basepath than root\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Hi folks,\nBase path support is live in SigNoz **v0.121.0**. You can now serve SigNoz under any URL prefix.\n\nCheck out the [Serving SigNoz on an external URL](https://signoz.io/docs/manage/administrator-guide/configuration/serving-on-external-url/) doc.\n\nPS: We've also been building [Foundry](https://github.com/SigNoz/foundry), a unified install tool for SigNoz.",
+      "codeSnippets": [
+        "signoz-frontend:\n    image: signoz/frontend:0.4.3\n    container_name: frontend\n    depends_on:\n      - query-service\n    links:\n      - \"query-service\"\n    ports:\n      - \"3000:3000\"\n    volumes:\n      - ./signoz/nginx-config.conf:/etc/nginx/conf.d/default.conf\n    environment:\n      - BASE_PATH=/admin/signoz\n    labels:\n      - traefik.enable=true\n      - traefik.http.routers.signoz.rule=PathPrefix(`/admin/signoz`)\n      - traefik.http.services.signoz.loadbalancer.server.port=3000\n\n  traefik:\n    image: traefik:latest\n    ports:\n      - 80:80\n      - 8181:8080 #traefik dashboard\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock:ro\n    command:\n      - \"--log.level=ERROR\"\n      - \"--api=true\" #traefik dashboard\n      - \"--providers.docker=true\"\n      - \"--providers.docker.expo"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "signoz",
+      "community",
+      "apm",
+      "feature"
+    ],
+    "cncfProjects": [
+      "signoz"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/SigNoz/signoz/issues/357",
+      "repo": "https://github.com/SigNoz/signoz"
+    },
+    "reactions": 4,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with signoz installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-01T07:27:11.528Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: signoz — [web] access frontend from a different basepath than root

**Type:** feature | **Source:** https://github.com/SigNoz/signoz/issues/357 (4 reactions)
**File:** `fixes/cncf-generated/signoz/signoz-357-web-access-frontend-from-a-different-basepath-than-root.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*