### PR TITLE
🌱 kubevirt: download progress for image quay.io/kubevirtci/k8s-1.31 while building

### DIFF
--- a/fixes/cncf-generated/kubevirt/kubevirt-14242-download-progress-for-image-quay-io-kubevirtci-k8s-1-31-while-bui.json
+++ b/fixes/cncf-generated/kubevirt/kubevirt-14242-download-progress-for-image-quay-io-kubevirtci-k8s-1-31-while-bui.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kubevirt-14242-download-progress-for-image-quay-io-kubevirtci-k8s-1-31-while-bui",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kubevirt: download progress for image quay.io/kubevirtci/k8s-1.31 while building",
+    "description": "download progress for image quay.io/kubevirtci/k8s-1.31 while building. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current kubevirt deployment",
+        "description": "Verify your kubevirt version and configuration:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nhelm list -n kubevirt 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working kubevirt installation."
+      },
+      {
+        "title": "Review kubevirt configuration",
+        "description": "Inspect the relevant kubevirt configuration:\n```bash\nkubectl get all -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get configmap -n kubevirt -l app.kubernetes.io/part-of=kubevirt\n```\nhello, when I run `make cluster-up`, it downloads the `quay.io/kubevirtci/k8s-1.31` image."
+      },
+      {
+        "title": "Apply the fix for download progress for image quay.io/kubevirtci/k8s-1.31…",
+        "description": "Hi all, I am interested in working on this.  I see the following options for this:\n\n1. Copy line-by-line the output of the `cli.ImagePull` function to stdout, however this is going to be a lot of lines, as the image `quay.io/kubevirtci/k8s-1.3.1:2504071522-2880e252` is about 17GB large. The good\n```yaml\ntime=\"2025-03-14T14:00:38Z\" level=info msg=\"Using remote image quay.io/kubevirtci/k8s-1.31:2503070845-e6c41d6e\"\nDownloading ...............................................................................................................\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get events -n kubevirt --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"download progress for image quay.io/kubevirtci/k8s-1.31…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Hi all, I am interested in working on this.  I see the following options for this:\n\n1. Copy line-by-line the output of the `cli.ImagePull` function to stdout, however this is going to be a lot of lines, as the image `quay.io/kubevirtci/k8s-1.3.1:2504071522-2880e252` is about 17GB large. The good thing here is that the progress bars can be printed, but there are lots of lines in stdout.\n2.",
+      "codeSnippets": [
+        "time=\"2025-03-14T14:00:38Z\" level=info msg=\"Using remote image quay.io/kubevirtci/k8s-1.31:2503070845-e6c41d6e\"\nDownloading ..............................................................................................................."
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kubevirt",
+      "incubating",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "kubevirt"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/kubevirt/kubevirt/issues/14242",
+      "repo": "https://github.com/kubevirt/kubevirt"
+    },
+    "reactions": 3,
+    "comments": 18,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kubevirt installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-02T06:46:34.639Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kubevirt — download progress for image quay.io/kubevirtci/k8s-1.31 while building

**Type:** feature | **Source:** https://github.com/kubevirt/kubevirt/issues/14242 (3 reactions)
**File:** `fixes/cncf-generated/kubevirt/kubevirt-14242-download-progress-for-image-quay-io-kubevirtci-k8s-1-31-while-bui.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*