### PR TITLE
🌱 woodpecker-ci: Allow notification plugins to notify about the pipeline status

### DIFF
--- a/fixes/cncf-generated/woodpecker-ci/woodpecker-ci-4337-allow-notification-plugins-to-notify-about-the-pipeline-statu.json
+++ b/fixes/cncf-generated/woodpecker-ci/woodpecker-ci-4337-allow-notification-plugins-to-notify-about-the-pipeline-statu.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "woodpecker-ci-4337-allow-notification-plugins-to-notify-about-the-pipeline-statu",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "woodpecker-ci: Allow notification plugins to notify about the pipeline status",
+    "description": "Allow notification plugins to notify about the pipeline status. This issue affects 9+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify woodpecker-ci troubleshoot symptoms",
+        "description": "Check for the issue in your woodpecker-ci deployment:\n```bash\nkubectl get pods -n woodpecker-ci -l app.kubernetes.io/name=woodpecker-ci\nkubectl logs -l app.kubernetes.io/name=woodpecker-ci -n woodpecker-ci --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review woodpecker-ci configuration",
+        "description": "Inspect the relevant woodpecker-ci configuration:\n```bash\nkubectl get all -n woodpecker-ci -l app.kubernetes.io/name=woodpecker-ci\nkubectl get configmap -n woodpecker-ci -l app.kubernetes.io/part-of=woodpecker-ci\n```\n### Clear and concise description of the problem\n\nThe env var `CI_PIPELINE_STATUS` war broken already and has always reported `success` but was now removed completely in https://github.com/woodpecker-ci/woodpecker/pull/3846\n\nRight now, I don't see"
+      },
+      {
+        "title": "Apply the fix for Allow notification plugins to notify about the pipeline…",
+        "description": "remove some environment variables who are either the same value or make no sense to exist in the first place:\n\nCI_STEP_STATUS\nCI_STEP_FINISHED\nCI_PIPELINE_STATUS\nCI_PIPELINE_FINISHED\nCI_COMMIT_URL\n```yaml\nsteps:\n   - name: slack\n     image: plugins/slack\n     settings:\n       channel: dev\n     when:\n       - status: [ success, failure ]\n```"
+      },
+      {
+        "title": "Confirm Allow notification plugins to notify about the… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=woodpecker-ci -n woodpecker-ci --tail=50 --since=5m\nkubectl get events -n woodpecker-ci --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "remove some environment variables who are either the same value or make no sense to exist in the first place:\n\nCI_STEP_STATUS\nCI_STEP_FINISHED\nCI_PIPELINE_STATUS\nCI_PIPELINE_FINISHED\nCI_COMMIT_URL",
+      "codeSnippets": [
+        "steps:\n   - name: slack\n     image: plugins/slack\n     settings:\n       channel: dev\n     when:\n       - status: [ success, failure ]",
+        "steps:\n   - name: notify\n     image: debian:stable-slim\n     commands:\n       - echo notifying\nruns_on: [ success, failure ]",
+        "steps:\n   - name: slack\n     image: plugins/slack\n     settings:\n       channel: dev\n     when:\n       - status: [ success, failure ]"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "woodpecker-ci",
+      "community",
+      "ci-cd",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "woodpecker-ci"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/woodpecker-ci/woodpecker/issues/4337",
+      "repo": "https://github.com/woodpecker-ci/woodpecker",
+      "pr": "https://github.com/woodpecker-ci/woodpecker/pull/3846"
+    },
+    "reactions": 9,
+    "comments": 31,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with woodpecker-ci installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-02T07:09:47.435Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: woodpecker-ci — Allow notification plugins to notify about the pipeline status

**Type:** troubleshoot | **Source:** https://github.com/woodpecker-ci/woodpecker/issues/4337 (9 reactions)
**Fix PR:** https://github.com/woodpecker-ci/woodpecker/pull/3846
**File:** `fixes/cncf-generated/woodpecker-ci/woodpecker-ci-4337-allow-notification-plugins-to-notify-about-the-pipeline-statu.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*