### PR TITLE
🌱 open-policy-agent-opa-: Add support for rule-level tracing

### DIFF
--- a/fixes/cncf-generated/open-policy-agent-opa-/open-policy-agent-opa-2089-add-support-for-rule-level-tracing.json
+++ b/fixes/cncf-generated/open-policy-agent-opa-/open-policy-agent-opa-2089-add-support-for-rule-level-tracing.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "open-policy-agent-opa-2089-add-support-for-rule-level-tracing",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "open-policy-agent-opa-: Add support for rule-level tracing",
+    "description": "Add support for rule-level tracing. Requested by 11+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current open-policy-agent-opa- deployment",
+        "description": "Verify your open-policy-agent-opa- version and configuration:\n```bash\nkubectl get pods -n open-policy-agent-opa- -l app.kubernetes.io/name=open-policy-agent-opa-\nhelm list -n open-policy-agent-opa- 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working open-policy-agent-opa- installation."
+      },
+      {
+        "title": "Review open-policy-agent-opa- configuration",
+        "description": "Inspect the relevant open-policy-agent-opa- configuration:\n```bash\nkubectl get all -n open-policy-agent-opa- -l app.kubernetes.io/name=open-policy-agent-opa-\nkubectl get configmap -n open-policy-agent-opa- -l app.kubernetes.io/part-of=open-policy-agent-opa-\n```\nIt would be nice to have a cheap, efficient rule-level tracer that could be enabled in more situations than the current tracing implementation allows."
+      },
+      {
+        "title": "Apply the fix for Add support for rule-level tracing",
+        "description": "Rules can now be annotated with a metadata `id` field. When `decision_logs.evaluated_rules` is enabled in the configuration, the IDs of successfully evaluated rules are included in decision log events. Additionally, the Data API supports a `?rules` query parameter to include evaluated rule IDs directly in the response payload.\n\n```rego\n# METADATA\n# id: allow-admin\nallow if input.role == \"admin\"\n```\n\nModules containing `id` annotations will have metadata parsing enabled automatically.\n\n----\nI'll\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n open-policy-agent-opa- -l app.kubernetes.io/name=open-policy-agent-opa-\nkubectl get events -n open-policy-agent-opa- --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Add support for rule-level tracing\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Rules can now be annotated with a metadata `id` field. When `decision_logs.evaluated_rules` is enabled in the configuration, the IDs of successfully evaluated rules are included in decision log events. Additionally, the Data API supports a `?rules` query parameter to include evaluated rule IDs directly in the response payload.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "open-policy-agent-opa-",
+      "graduated",
+      "security",
+      "feature"
+    ],
+    "cncfProjects": [
+      "open-policy-agent-opa-"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/open-policy-agent/opa/issues/2089",
+      "repo": "https://github.com/open-policy-agent/opa",
+      "pr": "https://github.com/open-policy-agent/opa/pull/8606"
+    },
+    "reactions": 11,
+    "comments": 8,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with open-policy-agent-opa- installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-07T07:06:27.054Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: open-policy-agent-opa- — Add support for rule-level tracing

**Type:** feature | **Source:** https://github.com/open-policy-agent/opa/issues/2089 (11 reactions)
**Fix PR:** https://github.com/open-policy-agent/opa/pull/8606
**File:** `fixes/cncf-generated/open-policy-agent-opa-/open-policy-agent-opa-2089-add-support-for-rule-level-tracing.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*