### PR TITLE
🌱 knative: Add option to enable/disable profiling of Knative Serving pods

### DIFF
--- a/fixes/cncf-generated/knative/knative-4982-add-option-to-enable-disable-profiling-of-knative-serving-pods.json
+++ b/fixes/cncf-generated/knative/knative-4982-add-option-to-enable-disable-profiling-of-knative-serving-pods.json
@@ -1,0 +1,80 @@
+{
+  "version": "kc-mission-v1",
+  "name": "knative-4982-add-option-to-enable-disable-profiling-of-knative-serving-pods",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "knative: Add option to enable/disable profiling of Knative Serving pods",
+    "description": "Add option to enable/disable profiling of Knative Serving pods. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current knative deployment",
+        "description": "Verify your knative version and configuration:\n```bash\nkubectl get pods -n knative -l app.kubernetes.io/name=knative\nhelm list -n knative 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working knative installation."
+      },
+      {
+        "title": "Review knative configuration",
+        "description": "Inspect the relevant knative configuration:\n```bash\nkubectl get all -n knative -l app.kubernetes.io/name=knative\nkubectl get configmap -n knative -l app.kubernetes.io/part-of=knative\n```\n## In what area(s)?\r\n\n## Describe the feature\n\nMake it possible to profile Knative Serving while it's running."
+      },
+      {
+        "title": "Apply the fix for Add option to enable/disable profiling of Knative Serving…",
+        "description": "* Introduce a new port 8008 where a web server will be listening and serving profiling data that are consumable by the pprof tool\n* Introduce profiling.enable flag in config-observability.yaml that will be either true or false. It will indicate whether it's possible to access the URLs that server\n```yaml\n2) Use port-forwarding to get access to Knative Serving pods\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n knative -l app.kubernetes.io/name=knative\nkubectl get events -n knative --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Add option to enable/disable profiling of Knative Serving…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "* Introduce a new port 8008 where a web server will be listening and serving profiling data that are consumable by the pprof tool\n* Introduce profiling.enable flag in config-observability.yaml that will be either true or false. It will indicate whether it's possible to access the URLs that server pprof-specific profiling data.",
+      "codeSnippets": [
+        "2) Use port-forwarding to get access to Knative Serving pods",
+        "3) Use either of these commands (detailed description at [url](https://golang.org/src/net/http/pprof/pprof.go)) to get/analyze pprof data:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "knative",
+      "graduated",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "knative"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Configmap",
+      "Namespace"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/knative/serving/issues/4982",
+      "repo": "https://github.com/knative/serving",
+      "pr": "https://github.com/knative/serving/pull/5083"
+    },
+    "reactions": 3,
+    "comments": 14,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with knative installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:41:24.733Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: knative — Add option to enable/disable profiling of Knative Serving pods

**Type:** feature | **Source:** https://github.com/knative/serving/issues/4982 (3 reactions)
**Fix PR:** https://github.com/knative/serving/pull/5083
**File:** `fixes/cncf-generated/knative/knative-4982-add-option-to-enable-disable-profiling-of-knative-serving-pods.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*