### PR TITLE
🌱 knative: minScale should not apply to non-routable revisions

### DIFF
--- a/fixes/cncf-generated/knative/knative-4183-minscale-should-not-apply-to-non-routable-revisions.json
+++ b/fixes/cncf-generated/knative/knative-4183-minscale-should-not-apply-to-non-routable-revisions.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "knative-4183-minscale-should-not-apply-to-non-routable-revisions",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "knative: minScale should not apply to non-routable revisions",
+    "description": "minScale should not apply to non-routable revisions. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current knative deployment",
+        "description": "Verify your knative version and configuration:\n```bash\nkubectl get pods -n knative -l app.kubernetes.io/name=knative\nhelm list -n knative 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working knative installation."
+      },
+      {
+        "title": "Review knative configuration",
+        "description": "Inspect the relevant knative configuration:\n```bash\nkubectl get all -n knative -l app.kubernetes.io/name=knative\nkubectl get configmap -n knative -l app.kubernetes.io/part-of=knative\n```\nThis is a repost of #2720, except the request is that we actually actually fix the behavior and not just document that it works in a broken (unexpected) way."
+      },
+      {
+        "title": "Apply the fix for minScale should not apply to non-routable revisions",
+        "description": "* Ignore `minScale` annotation on `PodAutoscalers` if `Reachability` is `Ureachable`\n\n**Release Note**\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n knative -l app.kubernetes.io/name=knative\nkubectl get events -n knative --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"minScale should not apply to non-routable revisions\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "* Ignore `minScale` annotation on `PodAutoscalers` if `Reachability` is `Ureachable`\n\n**Release Note**",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "knative",
+      "graduated",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "knative"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/knative/serving/issues/4183",
+      "repo": "https://github.com/knative/serving",
+      "pr": "https://github.com/knative/serving/pull/4884"
+    },
+    "reactions": 3,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with knative installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:41:32.720Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: knative — minScale should not apply to non-routable revisions

**Type:** feature | **Source:** https://github.com/knative/serving/issues/4183 (3 reactions)
**Fix PR:** https://github.com/knative/serving/pull/4884
**File:** `fixes/cncf-generated/knative/knative-4183-minscale-should-not-apply-to-non-routable-revisions.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*