### PR TITLE
🌱 containerd: failed to create containerd container: error unpacking image: content digest

### DIFF
--- a/fixes/cncf-generated/containerd/containerd-3401-failed-to-create-containerd-container-error-unpacking-image-cont.json
+++ b/fixes/cncf-generated/containerd/containerd-3401-failed-to-create-containerd-container-error-unpacking-image-cont.json
@@ -1,0 +1,80 @@
+{
+  "version": "kc-mission-v1",
+  "name": "containerd-3401-failed-to-create-containerd-container-error-unpacking-image-cont",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "containerd: failed to create containerd container: error unpacking image: content digest sha256:16*: not found\"",
+    "description": "failed to create containerd container: error unpacking image: content digest sha256:16*: not found\". This issue affects 7+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify containerd troubleshoot symptoms",
+        "description": "Check for the issue in your containerd deployment:\n```bash\nkubectl get pods -n containerd -l app.kubernetes.io/name=containerd\nkubectl logs -l app.kubernetes.io/name=containerd -n containerd --tail=100 | grep -i error\n```\nLook for error: `\"failed to create containerd container: error unpacking image: content digest sha256:1657edafda9d973766b6ba5a748da3c9570`"
+      },
+      {
+        "title": "Review containerd configuration",
+        "description": "Inspect the relevant containerd configuration:\n```bash\nkubectl get all -n containerd -l app.kubernetes.io/name=containerd\nkubectl get configmap -n containerd -l app.kubernetes.io/part-of=containerd\n```\nDue to a bug in docker https://github.com/moby/moby/issues/36789, when we repeat doing \n```\n     docker tag image:v1 image:latest\n     docker push image:latest\n```\n."
+      },
+      {
+        "title": "Apply the fix for failed to create containerd container: error unpacking…",
+        "description": "I have another idea about how to fix this. See https://github.com/containerd/containerd/issues/3401\n\nBackground https://github.com/containerd/containerd/issues/3401\n```yaml\ndocker tag image:v1 image:latest\n     docker push image:latest\n```"
+      },
+      {
+        "title": "Confirm failed to create containerd container: error… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=containerd -n containerd --tail=50 --since=5m\nkubectl get events -n containerd --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that `\"failed to create containerd container: error unpacking image: content digest sha256:1657edafda9d973766b6ba5a748da3c9570` no longer appears in logs."
+      }
+    ],
+    "resolution": {
+      "summary": "I have another idea about how to fix this. See https://github.com/containerd/containerd/issues/3401\n\nBackground https://github.com/containerd/containerd/issues/3401",
+      "codeSnippets": [
+        "docker tag image:v1 image:latest\n     docker push image:latest",
+        "*/fesu/tess-build-jenkins                latest                     sha256:349c662bc29fd98a608a5da773afd50b068a8f624b142c2df3060aa5626783fc   95eaa6e8aae1        12 days\n*/fesu/tess-build-jenkins                latest                     sha256:54a37661a521c4f69832b11ea76fd062fe67c6182382a2d291c93fd6eecb47f7   95eaa6e8aae1        12 days",
+        "if oldExist {\n\t\tif oldID == img.ID {\n\t\t\treturn nil\n\t\t}\n       *\n}"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "containerd",
+      "graduated",
+      "runtime",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "containerd"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Namespace",
+      "Service"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/containerd/containerd/issues/3401",
+      "repo": "https://github.com/containerd/containerd"
+    },
+    "reactions": 7,
+    "comments": 6,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with containerd installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:42:10.221Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: containerd — failed to create containerd container: error unpacking image: content digest sha256:16*: not found"

**Type:** troubleshoot | **Source:** https://github.com/containerd/containerd/issues/3401 (7 reactions)
**File:** `fixes/cncf-generated/containerd/containerd-3401-failed-to-create-containerd-container-error-unpacking-image-cont.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*