### PR TITLE
🌱 cri-o: CRI-O 1.30.7 / 1.31.2: writing file devices.allow: Operation not permitted

### DIFF
--- a/fixes/cncf-generated/cri-o/cri-o-8743-cri-o-1-30-7-1-31-2-writing-file-devices-allow-operation-not-permitte.json
+++ b/fixes/cncf-generated/cri-o/cri-o-8743-cri-o-1-30-7-1-31-2-writing-file-devices-allow-operation-not-permitte.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "cri-o-8743-cri-o-1-30-7-1-31-2-writing-file-devices-allow-operation-not-permitte",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "cri-o: CRI-O 1.30.7 / 1.31.2: writing file devices.allow: Operation not permitted",
+    "description": "CRI-O 1.30.7 / 1.31.2: writing file devices.allow: Operation not permitted. Users encounter: \"writing file devices.allow: Operation not permitted`\".",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify cri-o troubleshoot symptoms",
+        "description": "Check for the issue in your cri-o deployment:\n```bash\nkubectl get pods -n cri-o -l app.kubernetes.io/name=cri-o\nkubectl logs -l app.kubernetes.io/name=cri-o -n cri-o --tail=100 | grep -i error\n```\nLook for error: `writing file devices.allow: Operation not permitted``"
+      },
+      {
+        "title": "Review cri-o configuration",
+        "description": "Inspect the relevant cri-o configuration:\n```bash\nkubectl get all -n cri-o -l app.kubernetes.io/name=cri-o\nkubectl get configmap -n cri-o -l app.kubernetes.io/part-of=cri-o\n```\n### What happened?\n\nUpgrade from CRI-O 1.30.6 to 1.30.7 causes error for kubelet and containers are not starting:\n`\"Container creation error: writing file devices.allow: Operation not permitted`\n\nAs a temporary workaround downgrading CRI-O back to"
+      },
+      {
+        "title": "Apply the fix for CRI-O 1.30.7 / 1.31.2: writing file devices.allow:…",
+        "description": "Hm, we may regressed something between v1.30.6 and v1.30.7: https://github.com/cri-o/cri-o/compare/v1.30.6...v1.30.7\n\nI'm not sure if that commit is related: https://github.com/cri-o/cri-o/commit/34f2834aeb20d0ca887fec8ff2c05fbcefd80390\n```yaml\n</details>\n\n\n### OS version\n\n<details>\n```"
+      },
+      {
+        "title": "Confirm CRI-O 1.30.7 / 1.31.2: writing file… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=cri-o -n cri-o --tail=50 --since=5m\nkubectl get events -n cri-o --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that `writing file devices.allow: Operation not permitted`` no longer appears in logs."
+      }
+    ],
+    "resolution": {
+      "summary": "Hm, we may regressed something between v1.30.6 and v1.30.7: https://github.com/cri-o/cri-o/compare/v1.30.6...v1.30.7\n\nI'm not sure if that commit is related: https://github.com/cri-o/cri-o/commit/34f2834aeb20d0ca887fec8ff2c05fbcefd80390",
+      "codeSnippets": [
+        "</details>\n\n\n### OS version\n\n<details>",
+        "</details>\n\n\n### Additional environment details (AWS, VirtualBox, physical, etc.)\n\n<details>\nVirtual machine\n</details>\n\n\nHm, we may regressed something between v1.30.6 and v1.30.7: https://github.com/cri-o/cri-o/compare/v1.30.6...v1.30.7\n\nI'm not sure if that commit is related: https://github.com/cri-o/cri-o/commit/34f2834aeb20d0ca887fec8ff2c05fbcefd80390\n\n:thinking: \nJust tested and there seems to be same issue also with latest v1.31.2...\nwhat's the pod spec @opipenbe ?\nsame problem\nfrom repo https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main/rpm/ don't work version **cri-o-1.32.0~dev-150500.54.1.x86_64**\nfrom repo https://pkgs.k8s.io/addons:/cri-o:/stable:/v1.30/rpm/ don't work version **1.30.7-150500.1.1**\nversion **1.30.6-150500.1.1** from https://pkgs.k8s.io/addons:/cri-o:/stable:/v"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "cri-o",
+      "graduated",
+      "runtime",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "cri-o"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/cri-o/cri-o/issues/8743",
+      "repo": "https://github.com/cri-o/cri-o"
+    },
+    "reactions": 2,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with cri-o installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:42:56.086Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: cri-o — CRI-O 1.30.7 / 1.31.2: writing file devices.allow: Operation not permitted

**Type:** troubleshoot | **Source:** https://github.com/cri-o/cri-o/issues/8743 (2 reactions)
**File:** `fixes/cncf-generated/cri-o/cri-o-8743-cri-o-1-30-7-1-31-2-writing-file-devices-allow-operation-not-permitte.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*