### PR TITLE
🌱 linkerd: Classify some gRPC status codes as non-errors

### DIFF
--- a/fixes/cncf-generated/linkerd/linkerd-3729-classify-some-grpc-status-codes-as-non-errors.json
+++ b/fixes/cncf-generated/linkerd/linkerd-3729-classify-some-grpc-status-codes-as-non-errors.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "linkerd-3729-classify-some-grpc-status-codes-as-non-errors",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "linkerd: Classify some gRPC status codes as non-errors",
+    "description": "Classify some gRPC status codes as non-errors. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify linkerd troubleshoot symptoms",
+        "description": "Check for the issue in your linkerd deployment:\n```bash\nkubectl get pods -n linkerd -l app.kubernetes.io/name=linkerd\nkubectl logs -l app.kubernetes.io/name=linkerd -n linkerd --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review linkerd configuration",
+        "description": "Inspect the relevant linkerd configuration:\n```bash\nkubectl get all -n linkerd -l app.kubernetes.io/name=linkerd\nkubectl get configmap -n linkerd -l app.kubernetes.io/part-of=linkerd\n```\n## Feature Request\n\n### What problem are you trying to solve?\n\nLinkerd classifies all gRPC status codes as errors, other than `OK`."
+      },
+      {
+        "title": "Apply the fix for Classify some gRPC status codes as non-errors",
+        "description": "I'd like to propose that only error codes 13-15 be considered failures. From [the docs](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md):\n\nName | Code | Description\n-- | -- | --\nINTERNAL | 13 | Internal errors. This means that some invariants expected by the  underlying system have been broken. This error code is reserved for  serious errors.\nUNAVAILABLE | 14 | The service is currently unavailable. This is most likely a  transient condition, which can be corrected by retrying with a\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Confirm Classify some gRPC status codes as non-errors is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=linkerd -n linkerd --tail=50 --since=5m\nkubectl get events -n linkerd --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "I'd like to propose that only error codes 13-15 be considered failures. From [the docs](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md):\n\nName | Code | Description\n-- | -- | --\nINTERNAL | 13 | Internal errors. This means that some invariants expected by the  underlying system have been broken. This error code is reserved for  serious errors.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "linkerd",
+      "graduated",
+      "networking",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "linkerd"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/linkerd/linkerd2/issues/3729",
+      "repo": "https://github.com/linkerd/linkerd2"
+    },
+    "reactions": 4,
+    "comments": 11,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with linkerd installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:43:16.865Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: linkerd — Classify some gRPC status codes as non-errors

**Type:** troubleshoot | **Source:** https://github.com/linkerd/linkerd2/issues/3729 (4 reactions)
**File:** `fixes/cncf-generated/linkerd/linkerd-3729-classify-some-grpc-status-codes-as-non-errors.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*