### PR TITLE
🌱 grpc: Python/Core: Error parsing http status code - `401` converted to `UNKNOWN:

### DIFF
--- a/fixes/cncf-generated/grpc/grpc-33935-python-core-error-parsing-http-status-code-401-converted-to-unknown-s.json
+++ b/fixes/cncf-generated/grpc/grpc-33935-python-core-error-parsing-http-status-code-401-converted-to-unknown-s.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "grpc-33935-python-core-error-parsing-http-status-code-401-converted-to-unknown-s",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "grpc: Python/Core: Error parsing http status code - `401` converted to `UNKNOWN: Stream removed`",
+    "description": "Python/Core: Error parsing http status code - `401` converted to `UNKNOWN: Stream removed`. This issue affects 11+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify grpc troubleshoot symptoms",
+        "description": "Check for the issue in your grpc setup:\ngRPC library — check your language-specific package (e.g., pip show grpcio, npm ls @grpc/grpc-js)\nLook for error: `invalid value key=content-type value=text/html`"
+      },
+      {
+        "title": "Review grpc configuration",
+        "description": "Review the relevant grpc configuration:\n### What version of gRPC and what language are you using?\ngRPC v1.56.2\nPython\n\n### What operating system (Linux, Windows,...) and version?\nMac (client)\nLinux (server)\n\n### What runtime / compiler are you using (e.g."
+      },
+      {
+        "title": "Apply the fix for Python/Core: Error parsing http status code - `401`…",
+        "description": "ok,  pointed out that it is not the parsing of the http status code - 401 that is problematic. It is the `content-type` value that is causing parsing errors.\n\nIf you look at the logs - \n```\nE0728 2016.829609000 8093441536 hpack_parser.cc:1218]              Error parsing metadata: error=invalid\n```yaml\nE0728 20:36:16.829609000 8093441536 hpack_parser.cc:1218]              Error parsing metadata: error=invalid value key=content-type value=text/html\nTraceback (most recent call last):\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/client.py\", line 27, in <module>\n    main()\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/client.py\", line 22, in main\n    response = stub.Echo(request)\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/.venv/lib/python3.10/site-packages/grpc/_channel.py\", line 946, in __call__\n    return _end_unary_re\n```"
+      },
+      {
+        "title": "Confirm Python/Core: Error parsing http status code -… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest grpc to confirm the issue is resolved.\nConfirm that `invalid value key=content-type value=text/html` no longer appears."
+      }
+    ],
+    "resolution": {
+      "summary": "ok,  pointed out that it is not the parsing of the http status code - 401 that is problematic. It is the `content-type` value that is causing parsing errors.",
+      "codeSnippets": [
+        "E0728 20:36:16.829609000 8093441536 hpack_parser.cc:1218]              Error parsing metadata: error=invalid value key=content-type value=text/html\nTraceback (most recent call last):\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/client.py\", line 27, in <module>\n    main()\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/client.py\", line 22, in main\n    response = stub.Echo(request)\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/.venv/lib/python3.10/site-packages/grpc/_channel.py\", line 946, in __call__\n    return _end_unary_response_blocking(state, call, False, None)\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/.venv/lib/python3.10/site-packages/grpc/_channel.py\", line 849, in _end_unary_response_b",
+        "E0728 19:54:05.103107000 8093441536 hpack_parser.cc:991]               Error parsing 'content-type' metadata: invalid value\nTraceback (most recent call last):\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/client.py\", line 27, in <module>\n    main()\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/client.py\", line 22, in main\n    response = stub.Echo(request)\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/.venv/lib/python3.10/site-packages/grpc/_channel.py\", line 1030, in __call__\n    return _end_unary_response_blocking(state, call, False, None)\n  File \"/Users/jeev/Workspace/repos/personal/grpc-regression-mre/echo/.venv/lib/python3.10/site-packages/grpc/_channel.py\", line 910, in _end_unary_response_blocking\n    raise _Inac",
+        "E0728 20:36:16.829609000 8093441536 hpack_parser.cc:1218]              Error parsing metadata: error=invalid value key=content-type value=text/html"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "grpc",
+      "incubating",
+      "networking",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "grpc"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/grpc/grpc/issues/33935",
+      "repo": "https://github.com/grpc/grpc"
+    },
+    "reactions": 11,
+    "comments": 29,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "protoc"
+    ],
+    "description": "gRPC library — check your language-specific package (e.g., pip show grpcio, npm ls @grpc/grpc-js)"
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:43:48.573Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: grpc — Python/Core: Error parsing http status code - `401` converted to `UNKNOWN: Stream removed`

**Type:** troubleshoot | **Source:** https://github.com/grpc/grpc/issues/33935 (11 reactions)
**File:** `fixes/cncf-generated/grpc/grpc-33935-python-core-error-parsing-http-status-code-401-converted-to-unknown-s.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*