### PR TITLE
🌱 dapr: Enable GET for secret stores to dynamically fetch secrets

### DIFF
--- a/fixes/cncf-generated/dapr/dapr-1034-enable-get-for-secret-stores-to-dynamically-fetch-secrets.json
+++ b/fixes/cncf-generated/dapr/dapr-1034-enable-get-for-secret-stores-to-dynamically-fetch-secrets.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "dapr-1034-enable-get-for-secret-stores-to-dynamically-fetch-secrets",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "dapr: Enable GET for secret stores to dynamically fetch secrets",
+    "description": "Enable GET for secret stores to dynamically fetch secrets. Requested by 6+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current dapr deployment",
+        "description": "Verify your dapr version and configuration:\n```bash\nkubectl get pods -n dapr -l app.kubernetes.io/name=dapr\nhelm list -n dapr 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working dapr installation."
+      },
+      {
+        "title": "Review dapr configuration",
+        "description": "Inspect the relevant dapr configuration:\n```bash\nkubectl get all -n dapr -l app.kubernetes.io/name=dapr\nkubectl get configmap -n dapr -l app.kubernetes.io/part-of=dapr\n```\n## Current situation\n\nDapr already supports various [secret stores](https://github.com/dapr/components-contrib/blob/master/secretstores/Readme.md) for [referencing secrets inside Components spec.metadata"
+      },
+      {
+        "title": "Apply the fix for Enable GET for secret stores to dynamically fetch secrets",
+        "description": "Enabling GET for secret stores to dynamically fetch secrets as described in #1034. Current work just enables the http endpoint.\n```yaml\n#### URL Parameters\n\nParameter | Description\n--------- | -----------\ndaprPort | the Dapr port\nsecretstorename |\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n dapr -l app.kubernetes.io/name=dapr\nkubectl get events -n dapr --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Enable GET for secret stores to dynamically fetch secrets\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Enabling GET for secret stores to dynamically fetch secrets as described in #1034. Current work just enables the http endpoint.",
+      "codeSnippets": [
+        "#### URL Parameters\n\nParameter | Description\n--------- | -----------\ndaprPort | the Dapr port\nsecretstorename |"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "dapr",
+      "graduated",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "dapr"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Secret"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/dapr/dapr/issues/1034",
+      "repo": "https://github.com/dapr/dapr",
+      "pr": "https://github.com/dapr/dapr/pull/1059"
+    },
+    "reactions": 6,
+    "comments": 6,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with dapr installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:44:06.889Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: dapr — Enable GET for secret stores to dynamically fetch secrets

**Type:** feature | **Source:** https://github.com/dapr/dapr/issues/1034 (6 reactions)
**Fix PR:** https://github.com/dapr/dapr/pull/1059
**File:** `fixes/cncf-generated/dapr/dapr-1034-enable-get-for-secret-stores-to-dynamically-fetch-secrets.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*