### PR TITLE
🌱 pushgateway: Expose metrics metadata in HTTP API

### DIFF
--- a/fixes/cncf-generated/pushgateway/pushgateway-184-expose-metrics-metadata-in-http-api.json
+++ b/fixes/cncf-generated/pushgateway/pushgateway-184-expose-metrics-metadata-in-http-api.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "pushgateway-184-expose-metrics-metadata-in-http-api",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "pushgateway: Expose metrics metadata in HTTP API",
+    "description": "Expose metrics metadata in HTTP API. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current pushgateway deployment",
+        "description": "Verify your pushgateway version and configuration:\n```bash\nkubectl get pods -n pushgateway -l app.kubernetes.io/name=pushgateway\nhelm list -n pushgateway 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working pushgateway installation."
+      },
+      {
+        "title": "Review pushgateway configuration",
+        "description": "Inspect the relevant pushgateway configuration:\n```bash\nkubectl get all -n pushgateway -l app.kubernetes.io/name=pushgateway\nkubectl get configmap -n pushgateway -l app.kubernetes.io/part-of=pushgateway\n```\nThe way I understand it when interacting with a registered metric via pushgateway API (PUT, POST, DELET, etc.) you need to match grouping key exactly."
+      },
+      {
+        "title": "Apply the fix for Expose metrics metadata in HTTP API",
+        "description": "This PR relates to https://github.com/prometheus/pushgateway/issues/264\n\nI've created a POC so this PR would still be a working progress, I just wanted to get early feedback before keep moving forward, summary:\n\n- Added the new `--web.enable-admin-api` flag\n- Added the new `/-/wipe` route for the\n```yaml\n{\n  \"status\": \"success\",\n  \"data\": [\n    {\n      \"grouping_key\": \"7344000326925601179\",\n      \"labels\": {\"job\": \"some_job\", \"label1\": \"label1_value\"},\n      \"metrics\": {\n        \"some_metric_1\": {\n          \"type\": \"untyped\",\n          \"help\": \"\",\n          \"value\": \"3.14\",\n          \"labels\": {\"instance\": \"\", \"job\": \"some_job\", \"label1\": \"label1_value\"}\n        },\n        \"push_failure_time_seconds\": {\n          \"type\": \"gauge\",\n          \"help\": \"Last Unix time when changing this group in the Pushgateway failed.\",\n          \"value\": \"0\",\n          \"labels\": {\"instance\": \"\", \"job\": \"some_job\"\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n pushgateway -l app.kubernetes.io/name=pushgateway\nkubectl get events -n pushgateway --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Expose metrics metadata in HTTP API\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "This PR relates to https://github.com/prometheus/pushgateway/issues/264\n\nI've created a POC so this PR would still be a working progress, I just wanted to get early feedback before keep moving forward, summary:\n\n- Added the new `--web.enable-admin-api` flag\n- Added the new `/-/wipe` route for the `PUT` verb\n- I've created a new `WipePersistentFile` handler, this handler have a bunch of comments",
+      "codeSnippets": [
+        "{\n  \"status\": \"success\",\n  \"data\": [\n    {\n      \"grouping_key\": \"7344000326925601179\",\n      \"labels\": {\"job\": \"some_job\", \"label1\": \"label1_value\"},\n      \"metrics\": {\n        \"some_metric_1\": {\n          \"type\": \"untyped\",\n          \"help\": \"\",\n          \"value\": \"3.14\",\n          \"labels\": {\"instance\": \"\", \"job\": \"some_job\", \"label1\": \"label1_value\"}\n        },\n        \"push_failure_time_seconds\": {\n          \"type\": \"gauge\",\n          \"help\": \"Last Unix time when changing this group in the Pushgateway failed.\",\n          \"value\": \"0\",\n          \"labels\": {\"instance\": \"\", \"job\": \"some_job\", \"label1\": \"label1_value\"}\n        },\n        \"push_time_seconds\": {\n          \"type\": \"gauge\",\n          \"help\": \"Last Unix time when changing this group in the Pushgateway succeeded.\",\n          \"v",
+        "{\n  \"status\": \"error\",\n  \"errorType\": \"unknown_error\",\n  \"error\": \"unknown error\"\n}"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "pushgateway",
+      "graduated",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "pushgateway"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/prometheus/pushgateway/issues/184",
+      "repo": "https://github.com/prometheus/pushgateway",
+      "pr": "https://github.com/prometheus/pushgateway/pull/283"
+    },
+    "reactions": 0,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with pushgateway installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:45:34.690Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: pushgateway — Expose metrics metadata in HTTP API

**Type:** feature | **Source:** https://github.com/prometheus/pushgateway/issues/184 (0 reactions)
**Fix PR:** https://github.com/prometheus/pushgateway/pull/283
**File:** `fixes/cncf-generated/pushgateway/pushgateway-184-expose-metrics-metadata-in-http-api.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*