### PR TITLE
🌱 rook: docs: explain "too few PGs per OSD" warning

### DIFF
--- a/fixes/cncf-generated/rook/rook-1329-docs-explain-too-few-pgs-per-osd-warning.json
+++ b/fixes/cncf-generated/rook/rook-1329-docs-explain-too-few-pgs-per-osd-warning.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "rook-1329-docs-explain-too-few-pgs-per-osd-warning",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "rook: docs: explain \"too few PGs per OSD\" warning",
+    "description": "docs: explain \"too few PGs per OSD\" warning. Requested by 7+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current rook deployment",
+        "description": "Verify your rook version and configuration:\n```bash\nkubectl get pods -n rook -l app.kubernetes.io/name=rook\nhelm list -n rook 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working rook installation."
+      },
+      {
+        "title": "Review rook configuration",
+        "description": "Inspect the relevant rook configuration:\n```bash\nkubectl get all -n rook -l app.kubernetes.io/name=rook\nkubectl get configmap -n rook -l app.kubernetes.io/part-of=rook\n```\nIn a lot of scenarios, the ceph status will show something like `too few PGs per OSD (25 < min 30)`, which can be fairly benign."
+      },
+      {
+        "title": "Apply the fix for docs: explain \"too few PGs per OSD\" warning",
+        "description": "Update pg_num related documents.\nCommit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).\n- [o]\nAdd the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.\n- [o]\nAdd a flag to run tests for a specific storage provider. See [test\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Upgrade rook to include the fix",
+        "description": "If the fix is included in a newer release, upgrade rook:\n```bash\nhelm repo update\nhelm upgrade rook rook/rook --namespace rook\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n rook\nhelm list -n rook\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n rook -l app.kubernetes.io/name=rook\nkubectl get events -n rook --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"docs: explain \"too few PGs per OSD\" warning\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Update pg_num related documents.\nCommit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).\n- [o]\nAdd the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "rook",
+      "graduated",
+      "storage",
+      "feature"
+    ],
+    "cncfProjects": [
+      "rook"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/rook/rook/issues/1329",
+      "repo": "https://github.com/rook/rook",
+      "pr": "https://github.com/rook/rook/pull/5247"
+    },
+    "reactions": 7,
+    "comments": 8,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with rook installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:46:10.021Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: rook — docs: explain "too few PGs per OSD" warning

**Type:** feature | **Source:** https://github.com/rook/rook/issues/1329 (7 reactions)
**Fix PR:** https://github.com/rook/rook/pull/5247
**File:** `fixes/cncf-generated/rook/rook-1329-docs-explain-too-few-pgs-per-osd-warning.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*