### PR TITLE
🌱 volcano: scheduling with update from v1.2.0 to v1.4.0

### DIFF
--- a/fixes/cncf-generated/volcano/volcano-1775-scheduling-with-update-from-v1-2-0-to-v1-4-0.json
+++ b/fixes/cncf-generated/volcano/volcano-1775-scheduling-with-update-from-v1-2-0-to-v1-4-0.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "volcano-1775-scheduling-with-update-from-v1-2-0-to-v1-4-0",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "volcano: scheduling with update from v1.2.0 to v1.4.0",
+    "description": "scheduling with update from v1.2.0 to v1.4.0. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify volcano troubleshoot symptoms",
+        "description": "Check for the issue in your volcano deployment:\n```bash\nkubectl get pods -n volcano -l app.kubernetes.io/name=volcano\nkubectl logs -l app.kubernetes.io/name=volcano -n volcano --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review volcano configuration",
+        "description": "Inspect the relevant volcano configuration:\n```bash\nkubectl get all -n volcano -l app.kubernetes.io/name=volcano\nkubectl get configmap -n volcano -l app.kubernetes.io/part-of=volcano\n```\n**What happened**:\n\nvolcano update from 1.2.0 to 1.4.0. With the newest version if there are not enough resources `PodGroup`s are kept in `Pending` phase and cluster autoscaler does not trigger to provision more resources."
+      },
+      {
+        "title": "Apply the fix for scheduling with update from v1.2.0 to v1.4.0",
+        "description": "#1672 introduced fine-grained Reasons to give users more context about why scheduling did not succeed. However, this breaks compatibility with cluster autoscalers like Karpenter, which rely on the reason being set to `Unschedulable` to trigger scale-up, and the more fine-grained reason `Undetermined` causes the autoscaler to skip the pod.\n\nThis PR removes this reason to fix support for cluster autoscalers.\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Confirm scheduling with update from v1.2.0 to v1.4.0 is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=volcano -n volcano --tail=50 --since=5m\nkubectl get events -n volcano --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "#1672 introduced fine-grained Reasons to give users more context about why scheduling did not succeed. However, this breaks compatibility with cluster autoscalers like Karpenter, which rely on the reason being set to `Unschedulable` to trigger scale-up, and the more fine-grained reason `Undetermined` causes the autoscaler to skip the pod.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "volcano",
+      "incubating",
+      "orchestration",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "volcano"
+    ],
+    "targetResourceKinds": [
+      "Pod"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/volcano-sh/volcano/issues/1775",
+      "repo": "https://github.com/volcano-sh/volcano",
+      "pr": "https://github.com/volcano-sh/volcano/pull/2602"
+    },
+    "reactions": 1,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with volcano installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:47:20.557Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: volcano — scheduling with update from v1.2.0 to v1.4.0

**Type:** troubleshoot | **Source:** https://github.com/volcano-sh/volcano/issues/1775 (1 reactions)
**Fix PR:** https://github.com/volcano-sh/volcano/pull/2602
**File:** `fixes/cncf-generated/volcano/volcano-1775-scheduling-with-update-from-v1-2-0-to-v1-4-0.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*