### PR TITLE
🌱 longhorn: [FEATURE] Pause IO when raid1 bdev snapshotting

### DIFF
--- a/fixes/cncf-generated/longhorn/longhorn-5421-feature-pause-io-when-raid1-bdev-snapshotting.json
+++ b/fixes/cncf-generated/longhorn/longhorn-5421-feature-pause-io-when-raid1-bdev-snapshotting.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "longhorn-5421-feature-pause-io-when-raid1-bdev-snapshotting",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "longhorn: [FEATURE] Pause IO when raid1 bdev snapshotting",
+    "description": "[FEATURE] Pause IO when raid1 bdev snapshotting. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current longhorn deployment",
+        "description": "Verify your longhorn version and configuration:\n```bash\nkubectl get pods -n longhorn -l app.kubernetes.io/name=longhorn\nhelm list -n longhorn 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working longhorn installation."
+      },
+      {
+        "title": "Review longhorn configuration",
+        "description": "Inspect the relevant longhorn configuration:\n```bash\nkubectl get all -n longhorn -l app.kubernetes.io/name=longhorn\nkubectl get configmap -n longhorn -l app.kubernetes.io/part-of=longhorn\n```\n## Is your feature request related to a problem? Please describe (👍 if you like this request)\n\nTo ensure each volume snapshot consistent among the replicas of each longhorn bdev/volume, need to implement a mechanism to pause IO of the bdev and"
+      },
+      {
+        "title": "Apply the fix for [FEATURE] Pause IO when raid1 bdev snapshotting",
+        "description": "## Pre Ready-For-Testing Checklist\n\nThe reproduce steps/test steps are at:\n\nThe workaround is at:\n\nThe PR for the YAML change is at:\nThe PR for the chart change is at:\n\nThe PR is at\n\nArea\nIssues\n\nThe LEP PR is at\n\nThe UI issue/PR is at\n\nThe documentation issue/PR is at\n\nThe automation skeleton PR is at\nThe automation test case PR is at \nThe issue of automation test case implementation is at (please create by [the\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n longhorn -l app.kubernetes.io/name=longhorn\nkubectl get events -n longhorn --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[FEATURE] Pause IO when raid1 bdev snapshotting\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "## Pre Ready-For-Testing Checklist\n\nThe reproduce steps/test steps are at:\n\nThe workaround is at:\n\nThe PR for the YAML change is at:\nThe PR for the chart change is at:\n\nThe PR is at\n\nArea\nIssues\n\nThe LEP PR is at\n\nThe UI issue/PR is at\n\nThe documentation issue/PR is at\n\nThe automation skeleton PR is at\nThe automation test case PR is at \nThe issue of automation test case implementation is at",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "longhorn",
+      "incubating",
+      "storage",
+      "feature"
+    ],
+    "cncfProjects": [
+      "longhorn"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/longhorn/longhorn/issues/5421",
+      "repo": "https://github.com/longhorn/longhorn"
+    },
+    "reactions": 1,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with longhorn installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:47:43.428Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: longhorn — [FEATURE] Pause IO when raid1 bdev snapshotting

**Type:** feature | **Source:** https://github.com/longhorn/longhorn/issues/5421 (1 reactions)
**File:** `fixes/cncf-generated/longhorn/longhorn-5421-feature-pause-io-when-raid1-bdev-snapshotting.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*