### PR TITLE
🌱 wasmcloud: [FEATURE] Washboard should display assets that are managed by wadm

### DIFF
--- a/fixes/cncf-generated/wasmcloud/wasmcloud-844-feature-washboard-should-display-assets-that-are-managed-by-wadm.json
+++ b/fixes/cncf-generated/wasmcloud/wasmcloud-844-feature-washboard-should-display-assets-that-are-managed-by-wadm.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "wasmcloud-844-feature-washboard-should-display-assets-that-are-managed-by-wadm",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "wasmcloud: [FEATURE] Washboard should display assets that are managed by wadm",
+    "description": "[FEATURE] Washboard should display assets that are managed by wadm. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current wasmcloud deployment",
+        "description": "Verify your wasmcloud version and configuration:\n```bash\nkubectl get pods -n wasmcloud -l app.kubernetes.io/name=wasmcloud\nhelm list -n wasmcloud 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working wasmcloud installation."
+      },
+      {
+        "title": "Review wasmcloud configuration",
+        "description": "Inspect the relevant wasmcloud configuration:\n```bash\nkubectl get all -n wasmcloud -l app.kubernetes.io/name=wasmcloud\nkubectl get configmap -n wasmcloud -l app.kubernetes.io/part-of=wasmcloud\n```\nAs we develop wadm, I realized that there's not an easy way to determine if a resource is managed by wadm or not."
+      },
+      {
+        "title": "Apply the fix for [FEATURE] Washboard should display assets that are managed…",
+        "description": "## Feature or Problem\n\nSome of the resources are managed by wadm and it is not easy to know which one is manually created and which one is by wadm.\nObviously the feature flag part is part of the WIP only.\n\n## Related Issues\r\n\n## Release Information\n\n## Consumer Impact\n\n## Testing\n\nTesting might be interesting and I am waiting for your opinion as well.\n\nSteps:\n1. ```cd washboard-ui```\n2. ```make run-ui```\n3. Go to localhost:5173 (or as the output of the previous)\n4. Start multiple assets with\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n wasmcloud -l app.kubernetes.io/name=wasmcloud\nkubectl get events -n wasmcloud --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[FEATURE] Washboard should display assets that are managed…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "## Feature or Problem\n\nSome of the resources are managed by wadm and it is not easy to know which one is manually created and which one is by wadm.\nObviously the feature flag part is part of the WIP only.\n\n## Related Issues\r\n\n## Release Information\n\n## Consumer Impact\n\n## Testing\n\nTesting might be interesting and I am waiting for your opinion as well.\n\nSteps:\n1. ```cd washboard-ui```\n2.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "wasmcloud",
+      "incubating",
+      "runtime",
+      "feature"
+    ],
+    "cncfProjects": [
+      "wasmcloud"
+    ],
+    "targetResourceKinds": [
+      "Deployment"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/wasmCloud/wasmCloud/issues/844",
+      "repo": "https://github.com/wasmCloud/wasmCloud",
+      "pr": "https://github.com/wasmCloud/wasmCloud/pull/2447"
+    },
+    "reactions": 2,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with wasmcloud installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:47:47.907Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: wasmcloud — [FEATURE] Washboard should display assets that are managed by wadm

**Type:** feature | **Source:** https://github.com/wasmCloud/wasmCloud/issues/844 (2 reactions)
**Fix PR:** https://github.com/wasmCloud/wasmCloud/pull/2447
**File:** `fixes/cncf-generated/wasmcloud/wasmcloud-844-feature-washboard-should-display-assets-that-are-managed-by-wadm.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*