### PR TITLE
🌱 clusterpedia: Use Collection Resource to list all resources in a namespace

### DIFF
--- a/fixes/cncf-generated/clusterpedia/clusterpedia-169-use-collection-resource-to-list-all-resources-in-a-namespace.json
+++ b/fixes/cncf-generated/clusterpedia/clusterpedia-169-use-collection-resource-to-list-all-resources-in-a-namespace.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "clusterpedia-169-use-collection-resource-to-list-all-resources-in-a-namespace",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "clusterpedia: Use Collection Resource to list all resources in a namespace",
+    "description": "Use Collection Resource to list all resources in a namespace. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current clusterpedia deployment",
+        "description": "Verify your clusterpedia version and configuration:\n```bash\nkubectl get pods -n clusterpedia -l app.kubernetes.io/name=clusterpedia\nhelm list -n clusterpedia 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working clusterpedia installation."
+      },
+      {
+        "title": "Review clusterpedia configuration",
+        "description": "Inspect the relevant clusterpedia configuration:\n```bash\nkubectl get all -n clusterpedia -l app.kubernetes.io/name=clusterpedia\nkubectl get configmap -n clusterpedia -l app.kubernetes.io/part-of=clusterpedia\n```\n### What would you like to be added?\n\nUse Collection Resource to list all resources in a namespace\n\n### Why is this needed?\n\nUse Collection Resource to list all resources in a namespace"
+      },
+      {
+        "title": "Apply the fix for Use Collection Resource to list all resources in a namespace",
+        "description": "Apply the configuration change to resolve the issue:\n```yaml\n$ kubectl get collectionresources kuberesources\n\n$ kubectl get --raw \"/apis/clusterpedia.io/v1beta1/collectionresources/kuberesources?onlyMetadata=true\"\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n clusterpedia -l app.kubernetes.io/name=clusterpedia\nkubectl get events -n clusterpedia --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Use Collection Resource to list all resources in a namespace\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "See the fix PR for the community-verified solution: https://github.com/clusterpedia-io/clusterpedia/pull/186",
+      "codeSnippets": [
+        "$ kubectl get collectionresources kuberesources\n\n$ kubectl get --raw \"/apis/clusterpedia.io/v1beta1/collectionresources/kuberesources?onlyMetadata=true\"",
+        "$ kubectl get --raw \"/apis/clusterpedia.io/v1beta1/collectionresources/kuberesources?onlyMetadata=true&namespaces=default\" \n\n$ kubectl get --raw \"/apis/clusterpedia.io/v1beta1/collectionresources/kuberesources?onlyMetadata=true&namespaces=default,kube-system\""
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "clusterpedia",
+      "sandbox",
+      "orchestration",
+      "feature"
+    ],
+    "cncfProjects": [
+      "clusterpedia"
+    ],
+    "targetResourceKinds": [
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/clusterpedia-io/clusterpedia/issues/169",
+      "repo": "https://github.com/clusterpedia-io/clusterpedia",
+      "pr": "https://github.com/clusterpedia-io/clusterpedia/pull/186"
+    },
+    "reactions": 0,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with clusterpedia installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:48:02.256Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: clusterpedia — Use Collection Resource to list all resources in a namespace

**Type:** feature | **Source:** https://github.com/clusterpedia-io/clusterpedia/issues/169 (0 reactions)
**Fix PR:** https://github.com/clusterpedia-io/clusterpedia/pull/186
**File:** `fixes/cncf-generated/clusterpedia/clusterpedia-169-use-collection-resource-to-list-all-resources-in-a-namespace.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*