### PR TITLE
🌱 inspektor-gadget: [RFE] Update GadgetInfo() rpc to avoid handling BTF/Wasm client-side

### DIFF
--- a/fixes/cncf-generated/inspektor-gadget/inspektor-gadget-2131-rfe-update-gadgetinfo-rpc-to-avoid-handling-btf-wasm-clien.json
+++ b/fixes/cncf-generated/inspektor-gadget/inspektor-gadget-2131-rfe-update-gadgetinfo-rpc-to-avoid-handling-btf-wasm-clien.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "inspektor-gadget-2131-rfe-update-gadgetinfo-rpc-to-avoid-handling-btf-wasm-clien",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "inspektor-gadget: [RFE] Update GadgetInfo() rpc to avoid handling BTF/Wasm client-side",
+    "description": "[RFE] Update GadgetInfo() rpc to avoid handling BTF/Wasm client-side. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current inspektor-gadget deployment",
+        "description": "Verify your inspektor-gadget version and configuration:\n```bash\nkubectl get pods -n inspektor-gadget -l app.kubernetes.io/name=inspektor-gadget\nhelm list -n inspektor-gadget 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working inspektor-gadget installation."
+      },
+      {
+        "title": "Review inspektor-gadget configuration",
+        "description": "Inspect the relevant inspektor-gadget configuration:\n```bash\nkubectl get all -n inspektor-gadget -l app.kubernetes.io/name=inspektor-gadget\nkubectl get configmap -n inspektor-gadget -l app.kubernetes.io/part-of=inspektor-gadget\n```\n## Current situation\n\nI would like to revisit the design decision in this commit:\n\nhttps://github.com/inspektor-gadget/inspektor-gadget/pull/2015/commits/8b513e713340f35f9b301af6914542d3f6f8abf1\n\nCurrently, in the client/server architecture, the"
+      },
+      {
+        "title": "Apply the fix for [RFE] Update GadgetInfo() rpc to avoid handling BTF/Wasm…",
+        "description": "# image build: add wasm\n\nThis PR adds the possibility to add a wasm module in a gadget image.\n\nThere are no changes in the CLI flags. This can be used by adding an entry in `build.yaml`:\n```\nwasm: program.go\n```\n\nThe following file types are supported:\n* `*.wasm`: pre-compiled wasm module\n* `*.go`:\n```yaml\ntype GadgetInfo struct {\n\tGadgetDefinition *GadgetDefinition\n\tProgContent      []byte\n}\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n inspektor-gadget -l app.kubernetes.io/name=inspektor-gadget\nkubectl get events -n inspektor-gadget --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[RFE] Update GadgetInfo() rpc to avoid handling BTF/Wasm…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "# image build: add wasm\n\nThis PR adds the possibility to add a wasm module in a gadget image.\n\nThere are no changes in the CLI flags. This can be used by adding an entry in `build.yaml`:\n```\nwasm: program.go\n```\n\nThe following file types are supported:\n* `*.wasm`: pre-compiled wasm module\n* `*.go`: Inspektor Gadget will compile it with tinygo\n\nThe wasm module is not executed.",
+      "codeSnippets": [
+        "type GadgetInfo struct {\n\tGadgetDefinition *GadgetDefinition\n\tProgContent      []byte\n}",
+        "wasm: program.go",
+        "docker build -f Dockerfiles/ebpf-builder.Dockerfile -t ghcr.io/inspektor-gadget/ebpf-builder:alban_wasm2 .\nsudo -E ig image build --builder-image=ghcr.io/inspektor-gadget/ebpf-builder:alban_wasm2 -t ghcr.io/inspektor-gadget/gadget/trace_dns:test gadgets/trace_dns/\nsudo -E ig run ghcr.io/inspektor-gadget/gadget/trace_dns:test"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "inspektor-gadget",
+      "sandbox",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "inspektor-gadget"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/inspektor-gadget/inspektor-gadget/issues/2131",
+      "repo": "https://github.com/inspektor-gadget/inspektor-gadget",
+      "pr": "https://github.com/inspektor-gadget/inspektor-gadget/pull/2127"
+    },
+    "reactions": 2,
+    "comments": 11,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with inspektor-gadget installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:54:25.574Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: inspektor-gadget — [RFE] Update GadgetInfo() rpc to avoid handling BTF/Wasm client-side

**Type:** feature | **Source:** https://github.com/inspektor-gadget/inspektor-gadget/issues/2131 (2 reactions)
**Fix PR:** https://github.com/inspektor-gadget/inspektor-gadget/pull/2127
**File:** `fixes/cncf-generated/inspektor-gadget/inspektor-gadget-2131-rfe-update-gadgetinfo-rpc-to-avoid-handling-btf-wasm-clien.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*