### PR TITLE
🌱 ko: Add `pkg/v1/kind` for writing images to KinD

### DIFF
--- a/fixes/cncf-generated/ko/ko-149-add-pkg-v1-kind-for-writing-images-to-kind.json
+++ b/fixes/cncf-generated/ko/ko-149-add-pkg-v1-kind-for-writing-images-to-kind.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "ko-149-add-pkg-v1-kind-for-writing-images-to-kind",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "ko: Add `pkg/v1/kind` for writing images to KinD",
+    "description": "Add `pkg/v1/kind` for writing images to KinD. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current ko setup",
+        "description": "Verify your ko version and configuration:\n```bash\nko version\n```\nThis feature requires a working ko installation."
+      },
+      {
+        "title": "Review ko configuration",
+        "description": "Review the relevant ko configuration:\nI think we want something like:\nhttps://github.com/google/go-containerregistry/tree/master/pkg/v1/daemon\n\n... but to write it directly to KinD.\n\n for pointers on the best API."
+      },
+      {
+        "title": "Apply the fix for Add `pkg/v1/kind` for writing images to KinD",
+        "description": "It seems reasonable to me to have KinD folks (and any interested third parties) hack on this code in a separate repo, possibly in KinD's repo, using `v1.Image` etc interfaces, then contribute anything they settle on back to this repo when/if it's settled down.\n\nWe don't have much bandwidth to review changes and support code related to new technologies we're not familiar with, and there's no real reason KinD support has to live in this repo anyway AFAIK.\n\nIf you find there are changes you need\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected.\nConfirm the feature described in \"Add `pkg/v1/kind` for writing images to KinD\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "It seems reasonable to me to have KinD folks (and any interested third parties) hack on this code in a separate repo, possibly in KinD's repo, using `v1.Image` etc interfaces, then contribute anything they settle on back to this repo when/if it's settled down.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "ko",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "ko"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/ko-build/ko/issues/149",
+      "repo": "https://github.com/ko-build/ko"
+    },
+    "reactions": 1,
+    "comments": 23,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "ko",
+      "go"
+    ],
+    "description": "A working ko installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:55:13.288Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: ko — Add `pkg/v1/kind` for writing images to KinD

**Type:** feature | **Source:** https://github.com/ko-build/ko/issues/149 (1 reactions)
**File:** `fixes/cncf-generated/ko/ko-149-add-pkg-v1-kind-for-writing-images-to-kind.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*