### PR TITLE
🌱 konveyor: `config/` and `Makefile` bundle variables are out of date

### DIFF
--- a/fixes/cncf-generated/konveyor/konveyor-201-config-and-makefile-bundle-variables-are-out-of-date.json
+++ b/fixes/cncf-generated/konveyor/konveyor-201-config-and-makefile-bundle-variables-are-out-of-date.json
@@ -1,0 +1,83 @@
+{
+  "version": "kc-mission-v1",
+  "name": "konveyor-201-config-and-makefile-bundle-variables-are-out-of-date",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "konveyor: `config/` and `Makefile` bundle variables are out of date",
+    "description": "`config/` and `Makefile` bundle variables are out of date. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current konveyor deployment",
+        "description": "Verify your konveyor version and configuration:\n```bash\nkubectl get pods -n konveyor -l app.kubernetes.io/name=konveyor\nhelm list -n konveyor 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working konveyor installation."
+      },
+      {
+        "title": "Review konveyor configuration",
+        "description": "Inspect the relevant konveyor configuration:\n```bash\nkubectl get all -n konveyor -l app.kubernetes.io/name=konveyor\nkubectl get configmap -n konveyor -l app.kubernetes.io/part-of=konveyor\n```\nIt appears that this repo has been modifying `bundle/` without modifying `config/`\n\nUpdates should be put into config/ first, and then run `make bundle` to generate an update `bundle/`\n\nFor example [see"
+      },
+      {
+        "title": "Apply the fix for `config/` and `Makefile` bundle variables are out of date",
+        "description": "👻 simplified tools/tackle-opdev.sh with `make bundle`\n `docker-build`, `bundle-build` fixes for docker where `--arch` is invalid\n\n `make deploy-olm` to run local unpublished changes from source installed with a new bundle.\n- replicate behavior of installing from OperatorHub giving you better idea\n```yaml\ndiff <(curl -s https://raw.githubusercontent.com/konveyor/tackle2-operator/main/bundle/manifests/konveyor-operator.clusterserviceversion.yaml | yq -P 'sort_keys(..)') <(curl -s https://raw.githubusercontent.com/kaovilai/tackle2-operator/configmakefile-update/bundle/manifests/konveyor-operator.clusterserviceversion.yaml | yq -P 'sort_keys(..)')\n```"
+      },
+      {
+        "title": "Upgrade konveyor to include the fix",
+        "description": "If the fix is included in a newer release, upgrade konveyor:\n```bash\nhelm repo update\nhelm upgrade konveyor konveyor/konveyor --namespace konveyor\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n konveyor\nhelm list -n konveyor\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n konveyor -l app.kubernetes.io/name=konveyor\nkubectl get events -n konveyor --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"`config/` and `Makefile` bundle variables are out of date\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "👻 simplified tools/tackle-opdev.sh with `make bundle`\n `docker-build`, `bundle-build` fixes for docker where `--arch` is invalid\n\n `make deploy-olm` to run local unpublished changes from source installed with a new bundle.",
+      "codeSnippets": [
+        "diff <(curl -s https://raw.githubusercontent.com/konveyor/tackle2-operator/main/bundle/manifests/konveyor-operator.clusterserviceversion.yaml | yq -P 'sort_keys(..)') <(curl -s https://raw.githubusercontent.com/kaovilai/tackle2-operator/configmakefile-update/bundle/manifests/konveyor-operator.clusterserviceversion.yaml | yq -P 'sort_keys(..)')",
+        "if c.useImageDigests {\n\t\tc.println(\"pinning image versions to digests instead of tags\")\n\t\tif err := c.pinImages(filepath.Join(c.outputDir, \"manifests\")); err != nil {\n\t\t\treturn err\n\t\t}\n\t}",
+        "bundle\n├── manifests\n│   ├── konveyor-operator.clusterserviceversion.yaml\n│   ├── tackle.konveyor.io_addons.yaml\n│   └── tackle.konveyor.io_tackles.yaml\n├── metadata\n│   └── annotations.yaml\n└── tests\n    └── scorecard\n        └── config.yaml"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "konveyor",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "konveyor"
+    ],
+    "targetResourceKinds": [
+      "Deployment"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/konveyor/operator/issues/201",
+      "repo": "https://github.com/konveyor/operator",
+      "pr": "https://github.com/konveyor/operator/pull/216"
+    },
+    "reactions": 0,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with konveyor installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:55:33.313Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: konveyor — `config/` and `Makefile` bundle variables are out of date

**Type:** feature | **Source:** https://github.com/konveyor/operator/issues/201 (0 reactions)
**Fix PR:** https://github.com/konveyor/operator/pull/216
**File:** `fixes/cncf-generated/konveyor/konveyor-201-config-and-makefile-bundle-variables-are-out-of-date.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*