### PR TITLE
🌱 k8sgpt: [Bug]: k8sgpt fails to start with "mkdir /.config: permission denied"

### DIFF
--- a/fixes/cncf-generated/k8sgpt/k8sgpt-440-bug-k8sgpt-fails-to-start-with-mkdir-config-permission-denied.json
+++ b/fixes/cncf-generated/k8sgpt/k8sgpt-440-bug-k8sgpt-fails-to-start-with-mkdir-config-permission-denied.json
@@ -1,0 +1,81 @@
+{
+  "version": "kc-mission-v1",
+  "name": "k8sgpt-440-bug-k8sgpt-fails-to-start-with-mkdir-config-permission-denied",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "k8sgpt: [Bug]: k8sgpt fails to start with \"mkdir /.config: permission denied\"",
+    "description": "[Bug]: k8sgpt fails to start with \"mkdir /.config: permission denied\". Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify k8sgpt troubleshoot symptoms",
+        "description": "Check for the issue in your k8sgpt deployment:\n```bash\nkubectl get pods -n k8sgpt -l app.kubernetes.io/name=k8sgpt\nkubectl logs -l app.kubernetes.io/name=k8sgpt -n k8sgpt --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review k8sgpt configuration",
+        "description": "Inspect the relevant k8sgpt configuration:\n```bash\nkubectl get all -n k8sgpt -l app.kubernetes.io/name=k8sgpt\nkubectl get configmap -n k8sgpt -l app.kubernetes.io/part-of=k8sgpt\n```\n- [X] I've searched for similar issues and couldn't find anything matching\n- [X] I've included steps to reproduce the behavior\n\n### Affected Components\n\n- [X] #470\n\n### K8sGPT Version\n\nv0.3.0\n\n### Kubernetes Version\n\nv1.24.0\n\n### Host OS and its"
+      },
+      {
+        "title": "Apply the fix for [Bug]: k8sgpt fails to start with \"mkdir /.config:…",
+        "description": "## 📑 Description\nwith this PR k8sgpt should also be able to run with an arbitrary uid. that is necessary especially in openshift environments because there by default the restricted-v2 SCC sets a uid in the securityContext. currently it depends on uid 65532 because k8sgpt wants to create a .config\n```yaml\nkubectl logs k8sgpt-deployment-877c6ddd9-2cx5z\nError: mkdir /.config: permission denied\n```"
+      },
+      {
+        "title": "Confirm [Bug]: k8sgpt fails to start with \"mkdir… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=k8sgpt -n k8sgpt --tail=50 --since=5m\nkubectl get events -n k8sgpt --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "## 📑 Description\nwith this PR k8sgpt should also be able to run with an arbitrary uid. that is necessary especially in openshift environments because there by default the restricted-v2 SCC sets a uid in the securityContext.",
+      "codeSnippets": [
+        "kubectl logs k8sgpt-deployment-877c6ddd9-2cx5z\nError: mkdir /.config: permission denied",
+        "securityContext:\n    fsGroup: 1000980000\n    seLinuxOptions:\n      level: s0:c31,c25\n    seccompProfile:\n      type: RuntimeDefault",
+        "securityContext:\n      allowPrivilegeEscalation: false\n      capabilities:\n        drop:\n        - ALL\n      runAsNonRoot: true\n      runAsUser: 1000980000"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "k8sgpt",
+      "sandbox",
+      "app-definition",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "k8sgpt"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Deployment",
+      "Secret"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/k8sgpt-ai/k8sgpt/issues/440",
+      "repo": "https://github.com/k8sgpt-ai/k8sgpt",
+      "pr": "https://github.com/k8sgpt-ai/k8sgpt/pull/454"
+    },
+    "reactions": 0,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with k8sgpt installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:56:04.800Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: k8sgpt — [Bug]: k8sgpt fails to start with "mkdir /.config: permission denied"

**Type:** troubleshoot | **Source:** https://github.com/k8sgpt-ai/k8sgpt/issues/440 (0 reactions)
**Fix PR:** https://github.com/k8sgpt-ai/k8sgpt/pull/454
**File:** `fixes/cncf-generated/k8sgpt/k8sgpt-440-bug-k8sgpt-fails-to-start-with-mkdir-config-permission-denied.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*