### PR TITLE
🌱 meshery: [Docs] Copy-to-clipboard for CLI commands

### DIFF
--- a/fixes/cncf-generated/meshery/meshery-1269-docs-copy-to-clipboard-for-cli-commands.json
+++ b/fixes/cncf-generated/meshery/meshery-1269-docs-copy-to-clipboard-for-cli-commands.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "meshery-1269-docs-copy-to-clipboard-for-cli-commands",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "meshery: [Docs] Copy-to-clipboard for CLI commands",
+    "description": "[Docs] Copy-to-clipboard for CLI commands. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current meshery deployment",
+        "description": "Verify your meshery version and configuration:\n```bash\nkubectl get pods -n meshery -l app.kubernetes.io/name=meshery\nhelm list -n meshery 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working meshery installation."
+      },
+      {
+        "title": "Review meshery configuration",
+        "description": "Inspect the relevant meshery configuration:\n```bash\nkubectl get all -n meshery -l app.kubernetes.io/name=meshery\nkubectl get configmap -n meshery -l app.kubernetes.io/part-of=meshery\n```\n**Current State:**\nCLI commands included in the Meshery documentation have to be highlighted and copied by the reader. Sometimes the reader will accidentally include the `$` in what they copy and paste to their terminal."
+      },
+      {
+        "title": "Apply the fix for [Docs] Copy-to-clipboard for CLI commands",
+        "description": "Yes,  you are right. Sorry, I didn't check the link properly which you shared in the previous comment. I don't think we want to do the change in the markdown file, but the structure of the site is in a way that makes it a bit difficult to workaround. \nSo, you can check if we could do that like adding a separate file or we will have to do something in the markdown itself.\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n meshery -l app.kubernetes.io/name=meshery\nkubectl get events -n meshery --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[Docs] Copy-to-clipboard for CLI commands\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Yes,  you are right. Sorry, I didn't check the link properly which you shared in the previous comment. I don't think we want to do the change in the markdown file, but the structure of the site is in a way that makes it a bit difficult to workaround. \nSo, you can check if we could do that like adding a separate file or we will have to do something in the markdown itself.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "meshery",
+      "sandbox",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "meshery"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/meshery/meshery/issues/1269",
+      "repo": "https://github.com/meshery/meshery",
+      "pr": "https://github.com/meshery/meshery/pull/1946"
+    },
+    "reactions": 1,
+    "comments": 14,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with meshery installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T06:56:07.476Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: meshery — [Docs] Copy-to-clipboard for CLI commands

**Type:** feature | **Source:** https://github.com/meshery/meshery/issues/1269 (1 reactions)
**Fix PR:** https://github.com/meshery/meshery/pull/1946
**File:** `fixes/cncf-generated/meshery/meshery-1269-docs-copy-to-clipboard-for-cli-commands.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*