### PR TITLE
🌱 serverless-workflow: Rename output.from and output.to

### DIFF
--- a/fixes/cncf-generated/serverless-workflow/serverless-workflow-873-rename-output-from-and-output-to.json
+++ b/fixes/cncf-generated/serverless-workflow/serverless-workflow-873-rename-output-from-and-output-to.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "serverless-workflow-873-rename-output-from-and-output-to",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "serverless-workflow: Rename output.from and output.to",
+    "description": "Rename output.from and output.to. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current serverless-workflow deployment",
+        "description": "Verify your serverless-workflow version and configuration:\n```bash\nkubectl get pods -n serverless-workflow -l app.kubernetes.io/name=serverless-workflow\nhelm list -n serverless-workflow 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working serverless-workflow installation."
+      },
+      {
+        "title": "Review serverless-workflow configuration",
+        "description": "Inspect the relevant serverless-workflow configuration:\n```bash\nkubectl get all -n serverless-workflow -l app.kubernetes.io/name=serverless-workflow\nkubectl get configmap -n serverless-workflow -l app.kubernetes.io/part-of=serverless-workflow\n```\nOutput.from expression indicates the result of the task (and can be consumed by subsequent task) \nOutput.to expression indicates what should be the value of the context once the task is completed."
+      },
+      {
+        "title": "Apply the fix for Rename output.from and output.to",
+        "description": "Fix https://github.com/serverlessworkflow/specification/issues/873\noutput.from is renamed as output.as\noutput.to is renamed as export.as\n```yaml\noutput: \n    context: \n        set:\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n serverless-workflow -l app.kubernetes.io/name=serverless-workflow\nkubectl get events -n serverless-workflow --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Rename output.from and output.to\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Fix https://github.com/serverlessworkflow/specification/issues/873\noutput.from is renamed as output.as\noutput.to is renamed as export.as",
+      "codeSnippets": [
+        "output: \n    context: \n        set:",
+        "input:\n  from: ...\n  schema: ...\noutput:\n  to/as: ...\n  schema: ...\nexport:\n  to/as: ...\n  schema: ...",
+        "input:\n  from: ...\n  schema: ...\noutput:\n  to/as: ...\n  schema: ...\nexport: 'myexpression'"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "serverless-workflow",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "serverless-workflow"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/serverlessworkflow/specification/issues/873",
+      "repo": "https://github.com/serverlessworkflow/specification",
+      "pr": "https://github.com/serverlessworkflow/specification/pull/892"
+    },
+    "reactions": 2,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with serverless-workflow installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T07:00:50.641Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: serverless-workflow — Rename output.from and output.to

**Type:** feature | **Source:** https://github.com/serverlessworkflow/specification/issues/873 (2 reactions)
**Fix PR:** https://github.com/serverlessworkflow/specification/pull/892
**File:** `fixes/cncf-generated/serverless-workflow/serverless-workflow-873-rename-output-from-and-output-to.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*