### PR TITLE
🌱 kagenti: bug: MCP Inspector not connecting to weather tool

### DIFF
--- a/fixes/cncf-generated/kagenti/kagenti-72-bug-mcp-inspector-not-connecting-to-weather-tool.json
+++ b/fixes/cncf-generated/kagenti/kagenti-72-bug-mcp-inspector-not-connecting-to-weather-tool.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kagenti-72-bug-mcp-inspector-not-connecting-to-weather-tool",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kagenti: bug: MCP Inspector not connecting to weather tool",
+    "description": "bug: MCP Inspector not connecting to weather tool. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify kagenti troubleshoot symptoms",
+        "description": "Check for the issue in your kagenti deployment:\n```bash\nkubectl get pods -n kagenti -l app.kubernetes.io/name=kagenti\nkubectl logs -l app.kubernetes.io/name=kagenti -n kagenti --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review kagenti configuration",
+        "description": "Inspect the relevant kagenti configuration:\n```bash\nkubectl get all -n kagenti -l app.kubernetes.io/name=kagenti\nkubectl get configmap -n kagenti -l app.kubernetes.io/part-of=kagenti\n```\n### Describe the bug\n\nAfter importing weather tool and selecting \"Connect with MCP Inspector\", the inspector window opens. When I click \"Connect\" this error show up: Error Connecting to MCP Inspector Proxy - Check Console logs."
+      },
+      {
+        "title": "Apply the fix for bug: MCP Inspector not connecting to weather tool",
+        "description": "## Summary\n\n fix setting up mcp inspector proxy URL. Accounts for MCP_PROXY_FULL_ADDRESS being part of the [configuration](https://github.com/modelcontextprotocol/inspector?tab=readme-ov-file#configuration) and not an environment variable so it can only be set in the UI or passed as query parameter.\n```yaml\n- env:\n        - name: MCP_PROXY_FULL_ADDRESS\n          value: mcp-proxy.localtest.me\n        - name: DANGEROUSLY_OMIT_AUTH\n          value: \"true\"\n        - name: ALLOWED_ORIGINS\n          value: http://mcp-inspector.localtest.me:8080,*\n        - name: HOST\n          value: 0.0.0.0\n```"
+      },
+      {
+        "title": "Confirm bug: MCP Inspector not connecting to weather tool is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=kagenti -n kagenti --tail=50 --since=5m\nkubectl get events -n kagenti --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "## Summary\n\n fix setting up mcp inspector proxy URL. Accounts for MCP_PROXY_FULL_ADDRESS being part of the [configuration](https://github.com/modelcontextprotocol/inspector?tab=readme-ov-file#configuration) and not an environment variable so it can only be set in the UI or passed as query parameter.",
+      "codeSnippets": [
+        "- env:\n        - name: MCP_PROXY_FULL_ADDRESS\n          value: mcp-proxy.localtest.me\n        - name: DANGEROUSLY_OMIT_AUTH\n          value: \"true\"\n        - name: ALLOWED_ORIGINS\n          value: http://mcp-inspector.localtest.me:8080,*\n        - name: HOST\n          value: 0.0.0.0"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kagenti",
+      "community",
+      "ai-agents",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "kagenti"
+    ],
+    "targetResourceKinds": [
+      "Pod"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/kagenti/kagenti/issues/72",
+      "repo": "https://github.com/kagenti/kagenti",
+      "pr": "https://github.com/kagenti/kagenti/pull/262"
+    },
+    "reactions": 0,
+    "comments": 16,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kagenti installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T07:02:29.333Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kagenti — bug: MCP Inspector not connecting to weather tool

**Type:** troubleshoot | **Source:** https://github.com/kagenti/kagenti/issues/72 (0 reactions)
**Fix PR:** https://github.com/kagenti/kagenti/pull/262
**File:** `fixes/cncf-generated/kagenti/kagenti-72-bug-mcp-inspector-not-connecting-to-weather-tool.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*