### PR TITLE
🌱 submariner: Add dependency license scanning linting

### DIFF
--- a/fixes/cncf-generated/submariner/submariner-801-add-dependency-license-scanning-linting.json
+++ b/fixes/cncf-generated/submariner/submariner-801-add-dependency-license-scanning-linting.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "submariner-801-add-dependency-license-scanning-linting",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "submariner: Add dependency license scanning linting",
+    "description": "Add dependency license scanning linting. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current submariner deployment",
+        "description": "Verify your submariner version and configuration:\n```bash\nkubectl get pods -n submariner -l app.kubernetes.io/name=submariner\nhelm list -n submariner 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working submariner installation."
+      },
+      {
+        "title": "Review submariner configuration",
+        "description": "Inspect the relevant submariner configuration:\n```bash\nkubectl get all -n submariner -l app.kubernetes.io/name=submariner\nkubectl get configmap -n submariner -l app.kubernetes.io/part-of=submariner\n```\n**What would you like to be added**:\n\nLicense scanning paralleling the CNCF periodic license scanning, to make sure that all of our code and dependencies use a CNCF-approved license."
+      },
+      {
+        "title": "Apply the fix for Add dependency license scanning linting",
+        "description": "The [CNCF application process](https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A) says we need to follow [CNCF IP rules](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy), which in turn say:\n\nI guess that means we need to be confident that all of our dependencies use OSI-approved licenses.\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n submariner -l app.kubernetes.io/name=submariner\nkubectl get events -n submariner --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Add dependency license scanning linting\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "The [CNCF application process](https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A) says we need to follow [CNCF IP rules](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy), which in turn say:\n\nI guess that means we need to be confident that all of our dependencies use OSI-approved licenses.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "submariner",
+      "sandbox",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "submariner"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/submariner-io/submariner/issues/801",
+      "repo": "https://github.com/submariner-io/submariner"
+    },
+    "reactions": 0,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with submariner installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T07:03:40.585Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: submariner — Add dependency license scanning linting

**Type:** feature | **Source:** https://github.com/submariner-io/submariner/issues/801 (0 reactions)
**File:** `fixes/cncf-generated/submariner/submariner-801-add-dependency-license-scanning-linting.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*