### PR TITLE
🌱 submariner: Add 1 HA Failure Scenario to E2E testing (POC)

### DIFF
--- a/fixes/cncf-generated/submariner/submariner-825-add-1-ha-failure-scenario-to-e2e-testing-poc.json
+++ b/fixes/cncf-generated/submariner/submariner-825-add-1-ha-failure-scenario-to-e2e-testing-poc.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "submariner-825-add-1-ha-failure-scenario-to-e2e-testing-poc",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "submariner: Add 1 HA Failure Scenario to E2E testing (POC)",
+    "description": "Add 1 HA Failure Scenario to E2E testing (POC). Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current submariner deployment",
+        "description": "Verify your submariner version and configuration:\n```bash\nkubectl get pods -n submariner -l app.kubernetes.io/name=submariner\nhelm list -n submariner 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working submariner installation."
+      },
+      {
+        "title": "Review submariner configuration",
+        "description": "Inspect the relevant submariner configuration:\n```bash\nkubectl get all -n submariner -l app.kubernetes.io/name=submariner\nkubectl get configmap -n submariner -l app.kubernetes.io/part-of=submariner\n```\nPurpose of this issue : \nTo automate - add to e2e (GO) a single HA failure test from the scenarios here : \nhttps://docs.google.com/spreadsheets/d/11MV7CZmt13D8D4WYJTaddzQxSrXFRrn3UG0LiQKFVwY/edit#gid=0\n\nMore specifically :\nscenario no."
+      },
+      {
+        "title": "Apply the fix for Add 1 HA Failure Scenario to E2E testing (POC)",
+        "description": "Yes, Scenario-1 and Scenario-7 are kind of covered in the current e2e redundancy tests where the connectivity is validated (not downtime). Also, I agree with what  mentioned. The amount of downtime largely depends on the environment as there are many factors involved that can impact the behavior. So such tests IMHO are more suitable as subctl tests (not as e2e). \n\nWell, we don't have to try each and every combination of Pod location. The e2e redundancy tests try out the following combinations\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n submariner -l app.kubernetes.io/name=submariner\nkubectl get events -n submariner --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Add 1 HA Failure Scenario to E2E testing (POC)\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Yes, Scenario-1 and Scenario-7 are kind of covered in the current e2e redundancy tests where the connectivity is validated (not downtime). Also, I agree with what  mentioned. The amount of downtime largely depends on the environment as there are many factors involved that can impact the behavior. So such tests IMHO are more suitable as subctl tests (not as e2e).",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "submariner",
+      "sandbox",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "submariner"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Node"
+    ],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/submariner-io/submariner/issues/825",
+      "repo": "https://github.com/submariner-io/submariner",
+      "pr": "https://github.com/submariner-io/submariner/pull/1084"
+    },
+    "reactions": 0,
+    "comments": 18,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with submariner installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T07:03:48.444Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: submariner — Add 1 HA Failure Scenario to E2E testing (POC)

**Type:** feature | **Source:** https://github.com/submariner-io/submariner/issues/825 (0 reactions)
**Fix PR:** https://github.com/submariner-io/submariner/pull/1084
**File:** `fixes/cncf-generated/submariner/submariner-825-add-1-ha-failure-scenario-to-e2e-testing-poc.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*