### PR TITLE
🌱 caddy: Move CI process to GitHub Actions and add CD pipelines

### DIFF
--- a/fixes/cncf-generated/caddy/caddy-2931-move-ci-process-to-github-actions-and-add-cd-pipelines.json
+++ b/fixes/cncf-generated/caddy/caddy-2931-move-ci-process-to-github-actions-and-add-cd-pipelines.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "caddy-2931-move-ci-process-to-github-actions-and-add-cd-pipelines",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "caddy: Move CI process to GitHub Actions and add CD pipelines",
+    "description": "Move CI process to GitHub Actions and add CD pipelines. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current caddy setup",
+        "description": "Verify your caddy version and configuration:\n```bash\ncaddy version\n```\nThis feature requires a working caddy installation."
+      },
+      {
+        "title": "Review caddy configuration",
+        "description": "Review the relevant caddy configuration:\nHello,\n\nas discussed over Twitter: https://twitter.com/mholt6/status/1203790630880600065 my idea would be to introduce [GoReleaser](https://goreleaser.com/) into the project. Currently as far as I've seen for CI is Azure Pipelines in use."
+      },
+      {
+        "title": "Apply the fix for Move CI process to GitHub Actions and add CD pipelines",
+        "description": "Now that we've switched to GitHub Actions, next step -- at some point -- is to make releases at new tags, at least on the GitHub Releases page, if possible! I think that'd be pretty helpful. Right now v2 releases take about an hour or two to get right, and it's kinda tedious.\n```yaml\nroot@eea4381d15b1:/# apt install caddy\nReading package lists... Done\nBuilding dependency tree       \nReading state information... Done\nE: Unable to locate package caddy\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected.\nConfirm the feature described in \"Move CI process to GitHub Actions and add CD pipelines\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Now that we've switched to GitHub Actions, next step -- at some point -- is to make releases at new tags, at least on the GitHub Releases page, if possible! I think that'd be pretty helpful. Right now v2 releases take about an hour or two to get right, and it's kinda tedious.",
+      "codeSnippets": [
+        "root@eea4381d15b1:/# apt install caddy\nReading package lists... Done\nBuilding dependency tree       \nReading state information... Done\nE: Unable to locate package caddy"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "caddy",
+      "community",
+      "web-server",
+      "feature"
+    ],
+    "cncfProjects": [
+      "caddy"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/caddyserver/caddy/issues/2931",
+      "repo": "https://github.com/caddyserver/caddy"
+    },
+    "reactions": 4,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "caddy"
+    ],
+    "description": "A working caddy installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-05-08T07:09:15.990Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: caddy — Move CI process to GitHub Actions and add CD pipelines

**Type:** feature | **Source:** https://github.com/caddyserver/caddy/issues/2931 (4 reactions)
**File:** `fixes/cncf-generated/caddy/caddy-2931-move-ci-process-to-github-actions-and-add-cd-pipelines.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*