### PR TITLE
🌱 crossplane: Deleting a provider should not delete all managed resources

### DIFF
--- a/fixes/cncf-generated/crossplane/crossplane-6001-deleting-a-provider-should-not-delete-all-managed-resources.json
+++ b/fixes/cncf-generated/crossplane/crossplane-6001-deleting-a-provider-should-not-delete-all-managed-resources.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "crossplane-6001-deleting-a-provider-should-not-delete-all-managed-resources",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "crossplane: Deleting a provider should not delete all managed resources",
+    "description": "Deleting a provider should not delete all managed resources. Requested by 17+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current crossplane deployment",
+        "description": "Verify your crossplane version and configuration:\n```bash\nkubectl get pods -n crossplane -l app.kubernetes.io/name=crossplane\nhelm list -n crossplane 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working crossplane installation."
+      },
+      {
+        "title": "Review crossplane configuration",
+        "description": "Inspect the relevant crossplane configuration:\n```bash\nkubectl get all -n crossplane -l app.kubernetes.io/name=crossplane\nkubectl get configmap -n crossplane -l app.kubernetes.io/part-of=crossplane\n```\n### What problem are you facing?\n\nWhen a provider is deleted it deletes all the managed resources."
+      },
+      {
+        "title": "Apply the fix for Deleting a provider should not delete all managed resources",
+        "description": "Hey  ! The ticket you shared captures a lot of what's going on in the situaion when things get stuck which is also something i was able to observe. However it states that:\n```\nAny MRs will be left in an orphaned, unreconciled, un-deletable state.\n```\n\nThis reads like MR's are not deleted when in fact i observed situations where they actually get deleted which is why i created this ticket. If we can add that behavior to the ticket you shared i think we can close this one. Thank you for the quick\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n crossplane -l app.kubernetes.io/name=crossplane\nkubectl get events -n crossplane --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Deleting a provider should not delete all managed resources\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Hey  ! The ticket you shared captures a lot of what's going on in the situaion when things get stuck which is also something i was able to observe. However it states that:\n```\nAny MRs will be left in an orphaned, unreconciled, un-deletable state.\n```\n\nThis reads like MR's are not deleted when in fact i observed situations where they actually get deleted which is why i created this ticket.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "crossplane",
+      "graduated",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "crossplane"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/crossplane/crossplane/issues/6001",
+      "repo": "https://github.com/crossplane/crossplane"
+    },
+    "reactions": 17,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with crossplane installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-09T06:47:41.883Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: crossplane — Deleting a provider should not delete all managed resources

**Type:** feature | **Source:** https://github.com/crossplane/crossplane/issues/6001 (17 reactions)
**File:** `fixes/cncf-generated/crossplane/crossplane-6001-deleting-a-provider-should-not-delete-all-managed-resources.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*