### PR TITLE
Add install missions for Tetragon, APISIX, and KubeRay

### DIFF
--- a/fixes/cncf-install/install-apisix.json
+++ b/fixes/cncf-install/install-apisix.json
@@ -1,0 +1,146 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-apisix",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Apache APISIX on Kubernetes",
+    "description": "Apache APISIX is a dynamic, real-time, high-performance API gateway. It provides traffic management features including load balancing, dynamic upstream, canary release, circuit breaking, authentication, and observability. APISIX can handle north-south traffic as well as east-west traffic between services and can also run as a Kubernetes ingress controller.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the APISIX Helm repository",
+        "description": "Add the official Apache APISIX Helm chart repository to your Helm configuration.\n```bash\nhelm repo add apisix https://apache.github.io/apisix-helm-chart\nhelm repo update\n```"
+      },
+      {
+        "title": "Install APISIX using Helm",
+        "description": "Install APISIX in a new namespace called 'ingress-apisix' using the upstream chart. The chart bundles etcd as a dependency for APISIX's configuration store.\n```bash\nhelm install apisix apisix/apisix --version 2.13.0 --namespace ingress-apisix --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the APISIX and etcd pods are running successfully.\n```bash\nkubectl get pods --namespace ingress-apisix\n```"
+      },
+      {
+        "title": "Check the gateway service",
+        "description": "Confirm the APISIX gateway Service has been created. By default it is of type LoadBalancer.\n```bash\nkubectl get svc apisix-gateway --namespace ingress-apisix\n```"
+      },
+      {
+        "title": "Access the Admin API",
+        "description": "Set up port forwarding to reach the APISIX Admin API from your local machine. The chart ships with a default admin key that you should rotate before using in production.\n```bash\nkubectl port-forward -n ingress-apisix svc/apisix-admin 9180:9180\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the APISIX release from the 'ingress-apisix' namespace.\n```bash\nhelm uninstall apisix --namespace ingress-apisix\n```"
+      },
+      {
+        "title": "Clean up persistent resources",
+        "description": "The bundled etcd runs as a StatefulSet with persistent volume claims. Delete them so the storage is released.\n```bash\nkubectl delete pvc --all --namespace ingress-apisix\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'ingress-apisix' namespace and verify it has been removed.\n```bash\nkubectl delete namespace ingress-apisix\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the current Helm values before upgrading so you can restore any custom configuration if needed.\n```bash\nhelm get values apisix --namespace ingress-apisix > apisix-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the APISIX Helm repository to pick up the latest chart version.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade APISIX",
+        "description": "Upgrade the release to the next chart version. Chart 2.14.0 ships APISIX 3.16.0, a minor version bump from 3.15.0 in chart 2.13.0.\n```bash\nhelm upgrade apisix apisix/apisix --namespace ingress-apisix --version 2.14.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the APISIX pods are running the new version.\n```bash\nkubectl get pods --namespace ingress-apisix\nkubectl get pods -n ingress-apisix -l app.kubernetes.io/name=apisix -o jsonpath='{.items[*].spec.containers[*].image}'\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "APISIX pods stuck waiting for etcd",
+        "description": "If the APISIX pods stay in Init or CrashLoopBackOff, check the etcd pods first. APISIX will not start until etcd is reachable and healthy.\n```bash\nkubectl get pods -n ingress-apisix -l app.kubernetes.io/name=etcd\nkubectl logs -n ingress-apisix -l app.kubernetes.io/name=etcd --tail=100\n```"
+      },
+      {
+        "title": "Admin API returning 401",
+        "description": "APISIX requires the X-API-KEY header for Admin API requests. The default key is defined in the chart values under 'apisix.admin.credentials.admin'. Confirm the key you are using matches the one in the cluster.\n```bash\nkubectl get -n ingress-apisix secret apisix -o jsonpath='{.data}'\nhelm get values apisix --namespace ingress-apisix\n```"
+      },
+      {
+        "title": "Gateway service stuck in Pending",
+        "description": "If the apisix-gateway Service stays Pending, your cluster may not have a LoadBalancer provider. Either install one (MetalLB on bare metal) or override the service type.\n```bash\nkubectl describe svc apisix-gateway -n ingress-apisix\nhelm upgrade apisix apisix/apisix --namespace ingress-apisix --set service.type=NodePort\n```"
+      },
+      {
+        "title": "Routes not taking effect",
+        "description": "If routes configured through the Admin API are not being served, check the APISIX worker logs for syntax or plugin errors.\n```bash\nkubectl logs -n ingress-apisix -l app.kubernetes.io/name=apisix --tail=200\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of APISIX will show both the APISIX and etcd pods running in the 'ingress-apisix' namespace, an apisix-gateway Service reachable on its external IP or NodePort, and an Admin API accepting requests with the configured X-API-KEY. You can then register upstream services and routes through the Admin API or the ingress controller.",
+      "codeSnippets": [
+        "helm repo add apisix https://apache.github.io/apisix-helm-chart\nhelm repo update",
+        "helm install apisix apisix/apisix --version 2.13.0 --namespace ingress-apisix --create-namespace",
+        "kubectl get pods --namespace ingress-apisix",
+        "kubectl get svc apisix-gateway --namespace ingress-apisix",
+        "kubectl port-forward -n ingress-apisix svc/apisix-admin 9180:9180"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "networking",
+      "graduated"
+    ],
+    "cncfProjects": [
+      "apisix"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "StatefulSet",
+      "Service",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "graduated",
+    "projectVersion": "v3.16.0",
+    "containerImages": [
+      "apache/apisix:3.16.0-debian"
+    ],
+    "sourceUrls": {
+      "docs": "https://apisix.apache.org/docs/",
+      "repo": "https://github.com/apache/apisix",
+      "helm": "https://apache.github.io/apisix-helm-chart"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. The chart bundles etcd by default, so a StorageClass must be available in the cluster for the etcd PersistentVolumeClaims."
+  },
+  "security": {
+    "scannedAt": "2026-05-13T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/fixes/cncf-install/install-apisix.json
+++ b/fixes/cncf-install/install-apisix.json
@@ -98,7 +98,7 @@
       "configuration",
       "cncf",
       "networking",
-      "graduated"
+      "incubating"
     ],
     "cncfProjects": [
       "apisix"
@@ -117,7 +117,7 @@
     "installMethods": [
       "helm"
     ],
-    "maturity": "graduated",
+    "maturity": "incubating",
     "projectVersion": "v3.16.0",
     "containerImages": [
       "apache/apisix:3.16.0-debian"

--- a/fixes/cncf-install/install-kuberay.json
+++ b/fixes/cncf-install/install-kuberay.json
@@ -1,0 +1,145 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-kuberay",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure KubeRay on Kubernetes",
+    "description": "KubeRay is a Kubernetes operator for running Ray clusters, jobs, and services. It manages the lifecycle of distributed Ray workloads for machine learning, hyperparameter tuning, reinforcement learning, and model serving. Installing the KubeRay operator lets platform teams run Ray on Kubernetes as first-class RayCluster, RayJob, and RayService resources.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the KubeRay Helm repository",
+        "description": "Add the official KubeRay Helm chart repository to your Helm configuration.\n```bash\nhelm repo add kuberay https://ray-project.github.io/kuberay-helm/\nhelm repo update\n```"
+      },
+      {
+        "title": "Install the KubeRay operator",
+        "description": "Install the operator into a new namespace called 'kuberay-operator'. The chart also installs the RayCluster, RayJob, and RayService CRDs.\n```bash\nhelm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 --namespace kuberay-operator --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the operator pod is running and the CRDs were installed.\n```bash\nkubectl get pods -n kuberay-operator\nkubectl get crd | grep ray.io\n```"
+      },
+      {
+        "title": "Deploy a sample RayCluster",
+        "description": "Use the companion ray-cluster chart to spin up a small cluster in the default namespace and confirm the operator reconciles it.\n```bash\nhelm install raycluster kuberay/ray-cluster --version 1.6.0\nkubectl get rayclusters\n```"
+      },
+      {
+        "title": "Access the Ray dashboard",
+        "description": "Port-forward the head service to reach the Ray dashboard from your local machine.\n```bash\nkubectl port-forward svc/raycluster-kuberay-head-svc 8265:8265\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the sample RayCluster",
+        "description": "Uninstall the sample ray-cluster release first so the operator can clean up the underlying head and worker pods.\n```bash\nhelm uninstall raycluster\n```"
+      },
+      {
+        "title": "Remove the KubeRay operator",
+        "description": "Uninstall the operator from the 'kuberay-operator' namespace.\n```bash\nhelm uninstall kuberay-operator --namespace kuberay-operator\n```"
+      },
+      {
+        "title": "Clean up CRDs and namespace",
+        "description": "Delete the Ray CRDs and the operator namespace to finish cleaning up. Removing the CRDs deletes any remaining RayCluster, RayJob, and RayService resources across the cluster.\n```bash\nkubectl delete crd rayclusters.ray.io rayjobs.ray.io rayservices.ray.io\nkubectl delete namespace kuberay-operator\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the Helm values for the operator before upgrading.\n```bash\nhelm get values kuberay-operator --namespace kuberay-operator > kuberay-operator-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the KubeRay Helm repository to pick up the latest chart.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade the KubeRay operator",
+        "description": "Upgrade the release to the next chart version. The chart version tracks the KubeRay release, so this is also an application upgrade.\n```bash\nhelm upgrade kuberay-operator kuberay/kuberay-operator --namespace kuberay-operator --version 1.6.1\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the operator pod rolled out and is now running the new image.\n```bash\nkubectl get pods -n kuberay-operator\nkubectl get deployment kuberay-operator -n kuberay-operator -o jsonpath='{.spec.template.spec.containers[*].image}'\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator pod in CrashLoopBackOff",
+        "description": "If the operator pod will not start, the most common cause is conflicting CRDs from a previous install. Check the logs and the CRD state.\n```bash\nkubectl logs -n kuberay-operator deploy/kuberay-operator\nkubectl get crd | grep ray.io\n```"
+      },
+      {
+        "title": "RayCluster stuck with no head pod",
+        "description": "If a RayCluster is created but no head pod appears, confirm the operator is watching events and check for resource quota or scheduling issues.\n```bash\nkubectl describe raycluster <name>\nkubectl logs -n kuberay-operator deploy/kuberay-operator --tail=200\n```"
+      },
+      {
+        "title": "Worker pods not scaling",
+        "description": "If worker pods do not come up to match the RayCluster spec, check the resource requests against available node capacity.\n```bash\nkubectl get pods -l ray.io/cluster=<cluster-name>\nkubectl describe pod <worker-pod-name>\n```"
+      },
+      {
+        "title": "Dashboard not reachable",
+        "description": "If the port-forward command succeeds but the dashboard does not load, the head pod may still be initializing the Ray processes. Check the head pod logs.\n```bash\nkubectl logs -l ray.io/node-type=head --tail=200\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of KubeRay will show the operator pod running in 'kuberay-operator', the Ray CRDs registered on the cluster, and a sample RayCluster reconciled into a running head pod plus worker pods. The Ray dashboard is reachable through port forwarding. From here you can submit RayJob and RayService resources against the running cluster.",
+      "codeSnippets": [
+        "helm repo add kuberay https://ray-project.github.io/kuberay-helm/\nhelm repo update",
+        "helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 --namespace kuberay-operator --create-namespace",
+        "kubectl get pods -n kuberay-operator",
+        "helm install raycluster kuberay/ray-cluster --version 1.6.0",
+        "kubectl port-forward svc/raycluster-kuberay-head-svc 8265:8265"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "ai-ml",
+      "sandbox"
+    ],
+    "cncfProjects": [
+      "kuberay"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "CustomResourceDefinition",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "sandbox",
+    "projectVersion": "v1.6.1",
+    "containerImages": [
+      "quay.io/kuberay/operator:v1.6.1"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.ray.io/en/latest/cluster/kubernetes/",
+      "repo": "https://github.com/ray-project/kuberay",
+      "helm": "https://ray-project.github.io/kuberay-helm/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.26",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. For non-trivial workloads the cluster should have enough CPU and memory for the Ray head and worker pods."
+  },
+  "security": {
+    "scannedAt": "2026-05-13T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/fixes/cncf-install/install-tetragon.json
+++ b/fixes/cncf-install/install-tetragon.json
@@ -98,7 +98,7 @@
       "configuration",
       "cncf",
       "security",
-      "graduated"
+      "sandbox"
     ],
     "cncfProjects": [
       "tetragon"
@@ -115,7 +115,7 @@
     "installMethods": [
       "helm"
     ],
-    "maturity": "graduated",
+    "maturity": "sandbox",
     "projectVersion": "v1.7.0",
     "containerImages": [
       "quay.io/cilium/tetragon:v1.7.0"

--- a/fixes/cncf-install/install-tetragon.json
+++ b/fixes/cncf-install/install-tetragon.json
@@ -1,0 +1,144 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-tetragon",
+  "missionClass": "install",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "Install and Configure Tetragon on Kubernetes",
+    "description": "Tetragon is an eBPF-based security observability and runtime enforcement tool from the Cilium project. It detects and can react to security-significant events such as process execution, system call activity, and network or file I/O, with Kubernetes-aware context. Installing Tetragon gives platform teams deep visibility into workload behavior at the kernel level.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Cilium Helm repository",
+        "description": "Tetragon is distributed through the Cilium Helm repository. Add it to your local Helm configuration.\n```bash\nhelm repo add cilium https://helm.cilium.io\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Tetragon using Helm",
+        "description": "Install Tetragon into the 'kube-system' namespace, which is the recommended location per the upstream docs.\n```bash\nhelm install tetragon cilium/tetragon --version 1.6.1 --namespace kube-system\n```"
+      },
+      {
+        "title": "Wait for the DaemonSet to roll out",
+        "description": "Tetragon deploys as a DaemonSet so every node gets an agent pod. Watch the rollout until all pods are ready.\n```bash\nkubectl rollout status -n kube-system ds/tetragon -w\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Confirm the Tetragon pods are running and the CRDs are registered.\n```bash\nkubectl get pods -n kube-system -l app.kubernetes.io/name=tetragon\nkubectl get crd | grep cilium.io\n```"
+      },
+      {
+        "title": "Observe process execution events",
+        "description": "Tail the export log on one of the agent pods to confirm events are being generated.\n```bash\nkubectl exec -n kube-system ds/tetragon -c export-stdout -- tail -f /var/run/cilium/tetragon/tetragon.log\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Tetragon Helm release from the 'kube-system' namespace.\n```bash\nhelm uninstall tetragon --namespace kube-system\n```"
+      },
+      {
+        "title": "Clean up tracing policies and CRDs",
+        "description": "Remove any TracingPolicy resources and the Tetragon CRDs that were installed.\n```bash\nkubectl delete tracingpolicies --all\nkubectl delete crd tracingpolicies.cilium.io tracingpoliciesnamespaced.cilium.io podinfo.cilium.io\n```"
+      },
+      {
+        "title": "Verify removal",
+        "description": "Confirm no Tetragon pods or DaemonSets remain in 'kube-system'.\n```bash\nkubectl get pods -n kube-system -l app.kubernetes.io/name=tetragon\nkubectl get ds -n kube-system tetragon\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the current Helm values and any tracing policies before upgrading.\n```bash\nhelm get values tetragon --namespace kube-system > tetragon-backup.yaml\nkubectl get tracingpolicies -o yaml > tracingpolicies-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the Cilium Helm repository to pick up the latest Tetragon chart.\n```bash\nhelm repo update\n```"
+      },
+      {
+        "title": "Upgrade Tetragon",
+        "description": "Upgrade the release to the next minor version. The chart version mirrors the application version for Tetragon.\n```bash\nhelm upgrade tetragon cilium/tetragon --namespace kube-system --version 1.7.0\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the DaemonSet rolled out and the new agent pods are running the expected image.\n```bash\nkubectl rollout status -n kube-system ds/tetragon -w\nkubectl get pods -n kube-system -l app.kubernetes.io/name=tetragon -o jsonpath='{.items[*].spec.containers[*].image}'\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Tetragon pods stuck in Init or CrashLoopBackOff",
+        "description": "Tetragon needs a recent kernel with BTF support. Check the agent logs for a kernel or BTF error before anything else.\n```bash\nkubectl logs -n kube-system ds/tetragon -c tetragon\n```\nOn kind clusters, make sure the host /proc is mounted into the node container as described in the Tetragon install-k8s guide."
+      },
+      {
+        "title": "No events appearing in the export log",
+        "description": "If the export-stdout container shows nothing, confirm the Tetragon process is healthy and that events are not being filtered out by the default kube-system exclusion.\n```bash\nkubectl logs -n kube-system ds/tetragon -c tetragon\nkubectl logs -n kube-system ds/tetragon -c export-stdout\n```"
+      },
+      {
+        "title": "TracingPolicy not taking effect",
+        "description": "If a custom TracingPolicy is not producing events, verify it was accepted and is loaded on the agents.\n```bash\nkubectl get tracingpolicies\nkubectl exec -n kube-system ds/tetragon -c tetragon -- tetra tracingpolicy list\n```"
+      },
+      {
+        "title": "High CPU or memory usage on an agent pod",
+        "description": "Noisy tracing policies can load the agent. Check which policies are active and consider scoping them to specific namespaces.\n```bash\nkubectl top pods -n kube-system -l app.kubernetes.io/name=tetragon\nkubectl get tracingpolicies\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful installation of Tetragon will show one agent pod per node in 'kube-system', the Tetragon CRDs registered on the cluster, and process execution events streaming through the export-stdout container. From here you can apply TracingPolicy resources to enforce custom runtime rules.",
+      "codeSnippets": [
+        "helm repo add cilium https://helm.cilium.io\nhelm repo update",
+        "helm install tetragon cilium/tetragon --version 1.6.1 --namespace kube-system",
+        "kubectl rollout status -n kube-system ds/tetragon -w",
+        "kubectl get pods -n kube-system -l app.kubernetes.io/name=tetragon",
+        "kubectl exec -n kube-system ds/tetragon -c export-stdout -- tail -f /var/run/cilium/tetragon/tetragon.log"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "security",
+      "graduated"
+    ],
+    "cncfProjects": [
+      "tetragon"
+    ],
+    "targetResourceKinds": [
+      "DaemonSet",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "maturity": "graduated",
+    "projectVersion": "v1.7.0",
+    "containerImages": [
+      "quay.io/cilium/tetragon:v1.7.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://tetragon.io/docs/",
+      "repo": "https://github.com/cilium/tetragon",
+      "helm": "https://helm.cilium.io"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running on Linux nodes with a kernel that supports eBPF and BTF, and have Helm and kubectl installed on your local machine. On kind clusters the host /proc filesystem must be mounted into the node container."
+  },
+  "security": {
+    "scannedAt": "2026-05-13T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## Description

Adds three new install missions, filling real gaps in `fixes/cncf-install/`:

- `install-tetragon.json` — eBPF runtime security from the Cilium project. Complements the existing Cilium mission.
- `install-apisix.json` — Apache APISIX, a CNCF Graduated API gateway.
- `install-kuberay.json` — KubeRay operator for running Ray on Kubernetes. Fits alongside KServe and Kubeflow.

Each mission includes steps, uninstall, upgrade, and troubleshooting sections, matching the structure used across existing missions like `install-prometheus.json` and `install-cortex.json`.

Lesson applied from the Thanos review (#2231): every chart version in the file was checked against its upstream `Chart.yaml`, and each upgrade step targets a newer version than install so it reflects a real version bump.

Version evidence:

| Mission | Install chart | Upgrade chart | appVersion | Image |
|---|---|---|---|---|
| Tetragon | 1.6.1 | 1.7.0 | v1.7.0 | `quay.io/cilium/tetragon:v1.7.0` |
| APISIX | 2.13.0 (appV 3.15.0) | 2.14.0 (appV 3.16.0) | v3.16.0 | `apache/apisix:3.16.0-debian` |
| KubeRay | 1.6.0 | 1.6.1 | v1.6.1 | `quay.io/kuberay/operator:v1.6.1` |

All versions verified against each project's upstream `Chart.yaml` on the corresponding release tag.

## Related Issue

No issue link. Gap fill after the Thanos mission merge. The remaining missing projects were diffed from `fixes/cncf-generated/` against `fixes/cncf-install/`, and these three were picked for maintenance quality and multi-cluster fit.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [x] I have signed off my commits (`git commit -s`)
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

## Additional Notes

Both CI checks passed locally against all three files:

- `node scripts/validate-schema.mjs` → Valid kc-mission-v1 (3/3)
- `node scripts/test-kb-quality-ci.mjs` → 100/100 across clarity, completeness, correctness, structure, and observability for each mission

`fixes/index.json` intentionally not committed. The build-index workflow regenerates and commits it on master after merge.

@clubanderson Please review it, Thank You.