### PR TITLE
Fix Thanos install mission and correct author attribution

### DIFF
--- a/fixes/cncf-install/install-apisix.json
+++ b/fixes/cncf-install/install-apisix.json
@@ -2,8 +2,8 @@
   "version": "kc-mission-v1",
   "name": "install-apisix",
   "missionClass": "install",
-  "author": "KubeStellar Bot",
-  "authorGithub": "kubestellar",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
   "mission": {
     "title": "Install and Configure Apache APISIX on Kubernetes",
     "description": "Apache APISIX is a dynamic, real-time, high-performance API gateway. It provides traffic management features including load balancing, dynamic upstream, canary release, circuit breaking, authentication, and observability. APISIX can handle north-south traffic as well as east-west traffic between services and can also run as a Kubernetes ingress controller.",

--- a/fixes/cncf-install/install-kuberay.json
+++ b/fixes/cncf-install/install-kuberay.json
@@ -2,8 +2,8 @@
   "version": "kc-mission-v1",
   "name": "install-kuberay",
   "missionClass": "install",
-  "author": "KubeStellar Bot",
-  "authorGithub": "kubestellar",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
   "mission": {
     "title": "Install and Configure KubeRay on Kubernetes",
     "description": "KubeRay is a Kubernetes operator for running Ray clusters, jobs, and services. It manages the lifecycle of distributed Ray workloads for machine learning, hyperparameter tuning, reinforcement learning, and model serving. Installing the KubeRay operator lets platform teams run Ray on Kubernetes as first-class RayCluster, RayJob, and RayService resources.",

--- a/fixes/cncf-install/install-tetragon.json
+++ b/fixes/cncf-install/install-tetragon.json
@@ -2,8 +2,8 @@
   "version": "kc-mission-v1",
   "name": "install-tetragon",
   "missionClass": "install",
-  "author": "KubeStellar Bot",
-  "authorGithub": "kubestellar",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
   "mission": {
     "title": "Install and Configure Tetragon on Kubernetes",
     "description": "Tetragon is an eBPF-based security observability and runtime enforcement tool from the Cilium project. It detects and can react to security-significant events such as process execution, system call activity, and network or file I/O, with Kubernetes-aware context. Installing Tetragon gives platform teams deep visibility into workload behavior at the kernel level.",

--- a/fixes/cncf-install/install-thanos.json
+++ b/fixes/cncf-install/install-thanos.json
@@ -2,93 +2,114 @@
   "version": "kc-mission-v1",
   "name": "install-thanos",
   "missionClass": "install",
-  "author": "KubeStellar Bot",
-  "authorGithub": "kubestellar",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
   "mission": {
     "title": "Install and Configure Thanos on Kubernetes",
-    "description": "Thanos is a highly available metrics system that extends existing Prometheus deployments with long-term storage, global query view, and unlimited retention across multiple clusters. Installing Thanos allows platform teams to aggregate and query metrics from many Prometheus instances in a single, horizontally scalable system.",
+    "description": "Thanos is a highly available metrics system that extends existing Prometheus deployments with long-term storage, global query view, and unlimited retention across multiple clusters. A complete Thanos deployment runs the Query, Query Frontend, Compact, and Store Gateway components against an S3-compatible object storage bucket. This mission installs all four core components and explains how to wire them to AWS S3, GCS, or Azure Blob Storage for production use.",
     "type": "deploy",
     "status": "completed",
     "steps": [
       {
-        "title": "Add the Bitnami Helm repository",
-        "description": "Add the Bitnami Helm chart repository to your local Helm configuration to access the Thanos chart.\n```bash\nhelm repo add bitnami https://charts.bitnami.com/bitnami\nhelm repo update\n```"
+        "title": "Add the stevehipwell Helm repository",
+        "description": "Add the community-maintained Thanos Helm chart repository to your local Helm configuration. This chart pulls images directly from the upstream 'quay.io/thanos/thanos' registry.\n```bash\nhelm repo add stevehipwell https://steve.hipwell.xyz/helm-charts\nhelm repo update\n```"
       },
       {
-        "title": "Install Thanos using Helm",
-        "description": "Install Thanos in a new namespace called 'thanos' using the Bitnami chart.\n```bash\nhelm install thanos bitnami/thanos --version 17.4.1 --namespace thanos --create-namespace\n```"
+        "title": "Install Thanos with all production components enabled",
+        "description": "Install Thanos in a new namespace called 'thanos'. Query and Store Gateway are on by default. Compact and Query Frontend must be enabled explicitly. The chart's default objstoreConfig uses an on-disk filesystem path so the components come up cleanly on a fresh cluster, and the next step swaps it for real object storage before any data needs to be persisted.\n```bash\nhelm install thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos --create-namespace \\\n  --set compact.enabled=true \\\n  --set queryFrontend.enabled=true\n```"
       },
       {
         "title": "Verify the installation",
-        "description": "Check that the Thanos component pods (query, query-frontend, compactor, storegateway) are running successfully.\n```bash\nkubectl get pods --namespace thanos\n```"
+        "description": "Check that all four core component pods are running successfully. You should see thanos-query, thanos-query-frontend, thanos-compact, and thanos-store-gateway.\n```bash\nkubectl get pods --namespace thanos\nkubectl get statefulsets,deployments --namespace thanos\n```"
+      },
+      {
+        "title": "Configure production object storage",
+        "description": "Thanos requires S3-compatible object storage for durable long-term retention. The chart's default filesystem path is only suitable for getting components up. Create an objstore.yml for your cloud provider and apply it as a chart override. The chart will create a Secret named 'thanos-objstore' with the contents.\n\nAWS S3 example (objstore.yml):\n```yaml\ntype: S3\nconfig:\n  bucket: my-thanos-metrics\n  endpoint: s3.us-east-1.amazonaws.com\n  access_key: <ACCESS_KEY>\n  secret_key: <SECRET_KEY>\n```\nGCS example:\n```yaml\ntype: GCS\nconfig:\n  bucket: my-thanos-metrics\n  service_account: |-\n    <contents of service-account.json>\n```\nAzure Blob example:\n```yaml\ntype: AZURE\nconfig:\n  storage_account: mystorageaccount\n  storage_account_key: <KEY>\n  container: thanos-metrics\n```\nApply by upgrading the release with the new objstoreConfig:\n```bash\nhelm upgrade thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos \\\n  --reuse-values \\\n  --set-file objstoreConfig.value=objstore.yml\n```\nThe Compact and Store Gateway pods will restart and reconnect to the new bucket."
+      },
+      {
+        "title": "Enable persistence on Compact and Store Gateway",
+        "description": "Persistence is disabled by default to allow a clean install on clusters without a StorageClass. For real workloads, enable PVCs so Compact and Store Gateway keep block metadata across restarts.\n```bash\nhelm upgrade thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos \\\n  --reuse-values \\\n  --set compact.persistence.enabled=true \\\n  --set storeGateway.persistence.enabled=true\n```"
       },
       {
         "title": "Configure resource limits",
-        "description": "Set resource limits for the Thanos query component to ensure it runs efficiently under load.\n```bash\nkubectl patch deployment thanos-query -n thanos -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"query\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"1Gi\"}}}]}}}}'\n```"
+        "description": "Set resource limits on the components that do the heavy lifting (Compact, Store Gateway, Query). Tune to match your cluster size and ingest rate.\n```bash\nhelm upgrade thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos \\\n  --reuse-values \\\n  --set query.resources.limits.cpu=500m \\\n  --set query.resources.limits.memory=1Gi \\\n  --set compact.resources.limits.cpu=1 \\\n  --set compact.resources.limits.memory=2Gi \\\n  --set storeGateway.resources.limits.cpu=500m \\\n  --set storeGateway.resources.limits.memory=2Gi\n```"
       },
       {
         "title": "Access the Thanos Query UI",
-        "description": "Set up port forwarding to access the Thanos Query UI from your local machine.\n```bash\nkubectl port-forward svc/thanos-query-frontend --namespace thanos 9090:9090\n```"
+        "description": "Set up port forwarding to the Query Frontend service and open the Thanos UI. The Query Frontend caches and splits long-range queries before sending them on to Query.\n```bash\nkubectl port-forward svc/thanos-query-frontend --namespace thanos 10902:10902\n```\nOpen http://localhost:10902. The Stores tab should list the connected store-gateway and any sidecars or remote endpoints you've configured."
       }
     ],
     "uninstall": [
       {
         "title": "Remove the Helm release",
-        "description": "Uninstall the Thanos Helm release from the cluster.\n```bash\nhelm uninstall thanos --namespace thanos\n```"
+        "description": "Uninstall the Thanos Helm release from the cluster. This deletes the deployments, statefulsets, services, and the chart-managed objstore secret.\n```bash\nhelm uninstall thanos --namespace thanos\n```"
       },
       {
-        "title": "Clean up persistent resources",
-        "description": "Delete any persistent volume claims (PVCs) created by the Thanos compactor and store gateway components.\n```bash\nkubectl delete pvc --all --namespace thanos\n```"
+        "title": "Clean up persistent volume claims",
+        "description": "If you enabled persistence on Compact, Store Gateway, Receive, or Rule, the PVCs are retained by default ('persistence.retainDeleted: true' in the chart). Delete them explicitly when you want the storage released.\n```bash\nkubectl delete pvc --all --namespace thanos\n```"
+      },
+      {
+        "title": "Empty the object storage bucket",
+        "description": "Helm uninstall does not touch your S3/GCS/Azure bucket. If you no longer need the historical metric blocks, empty the bucket via your cloud provider's CLI or console. For AWS S3:\n```bash\naws s3 rm s3://my-thanos-metrics --recursive\n```\nFor GCS:\n```bash\ngsutil -m rm -r gs://my-thanos-metrics/**\n```"
       },
       {
         "title": "Remove namespace and verify",
-        "description": "Delete the 'thanos' namespace to remove all remaining resources and verify the removal.\n```bash\nkubectl delete namespace thanos\nkubectl get namespaces\n```"
+        "description": "Delete the 'thanos' namespace and verify it has been removed.\n```bash\nkubectl delete namespace thanos\nkubectl get namespaces\n```"
       }
     ],
     "upgrade": [
       {
-        "title": "Backup current state",
-        "description": "Export the current Helm values and resources for Thanos before upgrading.\n```bash\nhelm get values thanos --namespace thanos > thanos-backup.yaml\n```"
+        "title": "Backup current values and objstore config",
+        "description": "Export the current Helm values and the objstore secret before upgrading.\n```bash\nhelm get values thanos --namespace thanos > thanos-backup.yaml\nkubectl get secret thanos-objstore -n thanos -o yaml > thanos-objstore-backup.yaml\n```"
       },
       {
         "title": "Update the Helm repository",
-        "description": "Make sure the Bitnami Helm repository is up to date with the latest charts.\n```bash\nhelm repo update\n```"
+        "description": "Refresh the stevehipwell Helm repository to pick up the latest chart.\n```bash\nhelm repo update\nhelm search repo stevehipwell/thanos --versions | head -5\n```"
       },
       {
         "title": "Upgrade Thanos",
-        "description": "Upgrade the Thanos installation to the latest chart version.\n```bash\nhelm upgrade thanos bitnami/thanos --namespace thanos --version 17.4.1\n```"
+        "description": "Upgrade the release to the desired chart version. The Thanos blocks format is forward-compatible across recent versions, but always review the chart and Thanos release notes for any breaking changes before upgrading production.\n```bash\nhelm upgrade thanos stevehipwell/thanos --namespace thanos --version 1.23.0 --reuse-values\n```"
       },
       {
         "title": "Verify the upgrade",
-        "description": "Check that the Thanos pods are running the new version successfully.\n```bash\nkubectl get pods --namespace thanos\n```"
+        "description": "Check that all components rolled out and are running the new image.\n```bash\nkubectl rollout status deploy/thanos-query -n thanos\nkubectl rollout status deploy/thanos-query-frontend -n thanos\nkubectl rollout status statefulset/thanos-store-gateway -n thanos\nkubectl rollout status statefulset/thanos-compact -n thanos\nkubectl get pods -n thanos -o jsonpath='{.items[*].spec.containers[*].image}' | tr ' ' '\\n' | sort -u\n```"
       }
     ],
     "troubleshooting": [
       {
-        "title": "Pods stuck in CrashLoopBackOff",
-        "description": "If Thanos component pods are in a CrashLoopBackOff state, check the logs for configuration errors or missing object storage credentials.\n```bash\nkubectl logs <pod-name> --namespace thanos\n```\nA common cause is a missing or malformed objstore.yml secret required by the compactor, storegateway, and sidecar components."
+        "title": "Compact or Store Gateway in CrashLoopBackOff after enabling object storage",
+        "description": "The most common cause is a malformed or unreachable objstore config. Check the pod logs for the parsed config and any S3/GCS/Azure error.\n```bash\nkubectl logs -n thanos statefulset/thanos-compact --tail=100\nkubectl logs -n thanos statefulset/thanos-store-gateway --tail=100\nkubectl get secret thanos-objstore -n thanos -o jsonpath='{.data.config}' | base64 -d\n```\nVerify the bucket exists, the credentials are valid, and the IAM policy allows s3:GetObject, s3:PutObject, s3:DeleteObject, and s3:ListBucket on the bucket and its objects."
       },
       {
-        "title": "Query UI not reachable",
-        "description": "If the Thanos Query UI is not accessible, verify the service is running and the port forward targets the correct service.\n```bash\nkubectl get svc --namespace thanos\n```"
+        "title": "Query UI shows no stores",
+        "description": "If the Stores tab in the Query UI is empty, the Query component has not discovered the Store Gateway. The chart enables DNS service discovery by default. Confirm the Store Gateway service exists and is reachable.\n```bash\nkubectl get svc -n thanos thanos-store-gateway-headless\nkubectl exec -n thanos deploy/thanos-query -c thanos -- wget -qO- http://localhost:10902/api/v1/stores\n```"
       },
       {
         "title": "No metrics from existing Prometheus",
-        "description": "If queries return no data, ensure the Thanos sidecar is deployed alongside each Prometheus instance and is discoverable by the query component. Check the configured store endpoints.\n```bash\nkubectl exec -n thanos deploy/thanos-query -- wget -qO- http://localhost:10902/api/v1/stores\n```"
+        "description": "Thanos serves historical metrics from object storage and live metrics from sidecars or remote-write Receive endpoints. If queries return no data, ensure each Prometheus instance has a Thanos sidecar uploading blocks to the same bucket, and that the sidecar's StoreAPI is reachable from Query. Add the sidecar endpoints to query.additionalEndpoints in the chart values.\n```bash\nkubectl exec -n thanos deploy/thanos-query -c thanos -- wget -qO- http://localhost:10902/api/v1/stores\n```"
       },
       {
-        "title": "High memory usage in compactor",
-        "description": "If the Thanos compactor is consuming excessive memory, adjust its resource limits. Check current usage first.\n```bash\nkubectl top pods --namespace thanos\n```\nThen update the limits through Helm values or by editing the statefulset."
+        "title": "Image pull errors referencing 'docker.io/bitnami'",
+        "description": "Older Thanos install instructions used the Bitnami chart, whose default image registry was migrated to 'docker.io/bitnamilegacy/' in September 2025 and is no longer updated. This mission uses the community 'stevehipwell/thanos' chart, which pulls directly from 'quay.io/thanos/thanos'. If you see ImagePullBackOff errors mentioning 'docker.io/bitnami/thanos', confirm you are following this mission's helm command and not an older Bitnami-based snippet.\n```bash\nkubectl describe pod <pod-name> --namespace thanos | grep -A2 Image\n```"
+      },
+      {
+        "title": "Compact running but blocks not being downsampled",
+        "description": "Compact processes blocks once they're old enough (default 40h for the first downsampling level, 10d for the second). For a freshly-deployed cluster you won't see downsampled data immediately. Confirm Compact is healthy and is reading blocks from the bucket.\n```bash\nkubectl logs -n thanos statefulset/thanos-compact --tail=200 | grep -E 'compaction|downsample'\nkubectl exec -n thanos statefulset/thanos-compact -- wget -qO- http://localhost:10902/metrics | grep thanos_compact\n```"
+      },
+      {
+        "title": "High memory usage in Store Gateway",
+        "description": "Store Gateway caches block index data in memory. On large buckets this can grow significantly. Tune 'storeGateway.extraArgs' with --index-cache-size and --chunk-pool-size, or increase the resource limits.\n```bash\nkubectl top pods --namespace thanos\n```"
       }
     ],
     "resolution": {
-      "summary": "A successful installation of Thanos will have all component pods (query, query-frontend, compactor, storegateway) running in the 'thanos' namespace, and you will be able to access the Thanos Query UI at http://localhost:9090. Resource limits should be set appropriately and object storage should be configured to enable long-term metric retention.",
+      "summary": "A successful production install of Thanos has the Query, Query Frontend, Compact, and Store Gateway pods all Running in the 'thanos' namespace, an 'objstore.yml' Secret pointing at an S3, GCS, or Azure bucket, and the Query UI reachable on the Query Frontend service. With persistence enabled and resource limits set per component, the deployment is ready to ingest blocks from Prometheus sidecars or Thanos Receive and serve historical queries against the bucket.",
       "codeSnippets": [
-        "helm repo add bitnami https://charts.bitnami.com/bitnami\nhelm repo update",
-        "helm install thanos bitnami/thanos --version 17.4.1 --namespace thanos --create-namespace",
+        "helm repo add stevehipwell https://steve.hipwell.xyz/helm-charts\nhelm repo update",
+        "helm install thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos --create-namespace \\\n  --set compact.enabled=true \\\n  --set queryFrontend.enabled=true",
         "kubectl get pods --namespace thanos",
-        "kubectl patch deployment thanos-query -n thanos -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"query\",\"resources\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"1Gi\"}}}]}}}}'",
-        "kubectl port-forward svc/thanos-query-frontend --namespace thanos 9090:9090"
+        "helm upgrade thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos --reuse-values \\\n  --set-file objstoreConfig.value=objstore.yml",
+        "helm upgrade thanos stevehipwell/thanos --version 1.23.0 \\\n  --namespace thanos --reuse-values \\\n  --set compact.persistence.enabled=true \\\n  --set storeGateway.persistence.enabled=true",
+        "kubectl port-forward svc/thanos-query-frontend --namespace thanos 10902:10902"
       ]
     }
   },
@@ -107,6 +128,7 @@
       "Deployment",
       "StatefulSet",
       "Service",
+      "Secret",
       "Namespace"
     ],
     "difficulty": "intermediate",
@@ -118,14 +140,14 @@
       "helm"
     ],
     "maturity": "incubating",
-    "projectVersion": "v0.39.2",
+    "projectVersion": "v0.41.0",
     "containerImages": [
-      "docker.io/bitnami/thanos:0.39.2"
+      "quay.io/thanos/thanos:v0.41.0"
     ],
     "sourceUrls": {
       "docs": "https://thanos.io",
       "repo": "https://github.com/thanos-io/thanos",
-      "helm": "https://charts.bitnami.com/bitnami"
+      "helm": "https://steve.hipwell.xyz/helm-charts"
     },
     "qualityScore": 100
   },
@@ -135,10 +157,10 @@
       "helm",
       "kubectl"
     ],
-    "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. For production use, you will also need an object storage bucket (such as S3, GCS, or MinIO) to enable long-term metric retention."
+    "description": "Production Thanos requires an S3-compatible object storage bucket (AWS S3, GCS, Azure Blob, or any S3-compatible store such as MinIO or Ceph RGW) with credentials that can read, write, list, and delete objects. A default StorageClass is recommended once persistence is enabled on Compact and Store Gateway. Helm and kubectl must be installed locally."
   },
   "security": {
-    "scannedAt": "2026-05-12T00:00:00.000Z",
+    "scannedAt": "2026-05-15T00:00:00.000Z",
     "scannerVersion": "cncf-install-gen-1.0.0",
     "sanitized": true,
     "findings": []


### PR DESCRIPTION
## Description

Two corrections to the four CNCF install missions I contributed in #2231 and #2233 (Thanos, KubeRay, APISIX, Tetragon).

### 1. Rewrite Thanos install mission for production use

The previous mission used the Bitnami Thanos chart, whose default image registry (`docker.io/bitnami/thanos`) was migrated to `docker.io/bitnamilegacy` on Sept 29, 2025 and is no longer updated. New users following the mission hit `ImagePullBackOff` out of the box.

This PR switches to the community-maintained [`stevehipwell/helm-charts/thanos`](https://github.com/stevehipwell/helm-charts/tree/main/charts/thanos) chart, which pulls images directly from the upstream `quay.io/thanos/thanos` registry and ships application version `v0.41.0`.

The mission now installs the **full production-grade Thanos stack** — Query, Query Frontend, Compact, and Store Gateway — and walks the user through:

- Configuring object storage with examples for AWS S3, GCS, and Azure Blob, applied to the chart via the `objstoreConfig` values key
- Enabling persistence on Compact and Store Gateway for durable block metadata across restarts
- Setting per-component resource limits tuned for real workloads
- Accessing the Query Frontend UI for caching and long-range query splitting

Troubleshooting now covers objstore misconfiguration, Query stores discovery failures, downsampling expectations, Store Gateway memory tuning, and pointers for users hitting the Bitnami migration error.

**Validation:** Tested end-to-end on a fresh kind cluster:
- All four production components reach `1/1 Running`
- Thanos Query UI loads on `http://localhost:10902`
- Store Gateway is shown **UP** and health-checking on the Endpoints page

<img width="1440" height="776" alt="Thanos Query UI" src="https://github.com/user-attachments/assets/e26c2ccb-b9cc-46bd-96c6-338e4e5cf56f" />

#### Mission diff (Thanos)

| Field | Before | After |
|-------|--------|-------|
| Helm repo | `bitnami` | `stevehipwell` |
| Chart | `bitnami/thanos 17.4.1` | `stevehipwell/thanos 1.23.0` |
| App version | `v0.39.2` | `v0.41.0` |
| Image | `docker.io/bitnami/thanos:0.39.2` (404) | `quay.io/thanos/thanos:v0.41.0` |
| Components installed | Query, Query Frontend, Compact, Store Gateway | Query, Query Frontend, Compact, Store Gateway (production-shaped) |
| Object storage | Required, undocumented | Step with full S3/GCS/Azure examples |
| Persistence | Implicit | Explicit step for Compact + Store Gateway |
| Resource tuning | Single-component patch | Per-component `--set` for Query, Compact, Store Gateway |
| `sourceUrls.helm` | charts.bitnami.com | github.com/stevehipwell/helm-charts |

### 2. Correct author attribution across all four missions

The four missions in #2231 and #2233 were submitted with `author: "KubeStellar Bot"` and `authorGithub: "kubestellar"` because I copied those values from existing bot-generated mission templates. They should reflect the actual human contributor. Updated all four files to `author: "Vinay B M"` and `authorGithub: "bmvinay7"`.

Files affected:

- `fixes/cncf-install/install-thanos.json`
- `fixes/cncf-install/install-apisix.json`
- `fixes/cncf-install/install-tetragon.json`
- `fixes/cncf-install/install-kuberay.json`

## Related Issue

Follow-up to #2231 and #2233.

References:
- Bitnami catalog migration context: bitnami/charts#35164
- Replacement chart: [stevehipwell/helm-charts/thanos](https://github.com/stevehipwell/helm-charts/tree/main/charts/thanos)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [x] I have signed off my commits (`git commit -s`)
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

## Additional Notes

The Thanos chart switch and the production-shaped install were validated against the nightly KB validation pattern (run install commands from the mission against a fresh `kind` cluster, assert all pods reach Running). All four Thanos components reached `1/1 Running` with no manual fixups, and the Query Frontend showed the Store Gateway endpoint as `UP` on the Endpoints page.

@clubanderson Please review this, Thank You.
