### PR TITLE
Harden APISIX install mission and fix KubeRay uninstall

### DIFF
--- a/fixes/cncf-install/install-apisix.json
+++ b/fixes/cncf-install/install-apisix.json
@@ -2,11 +2,11 @@
   "version": "kc-mission-v1",
   "name": "install-apisix",
   "missionClass": "install",
-  "author": "KubeStellar Bot",
-  "authorGithub": "kubestellar",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
   "mission": {
     "title": "Install and Configure Apache APISIX on Kubernetes",
-    "description": "Apache APISIX is a dynamic, real-time, high-performance API gateway. It provides traffic management features including load balancing, dynamic upstream, canary release, circuit breaking, authentication, and observability. APISIX can handle north-south traffic as well as east-west traffic between services and can also run as a Kubernetes ingress controller.",
+    "description": "Apache APISIX is a dynamic, real-time, high-performance API gateway. It provides traffic management features including load balancing, dynamic upstream, canary release, circuit breaking, authentication, and observability. APISIX can handle north-south traffic as well as east-west traffic between services and can also run as a Kubernetes ingress controller. The upstream Helm chart bundles an etcd subchart for fast getting-started installs; for production the chart maintainers recommend disabling the bundled etcd and pointing APISIX at an externally-managed etcd cluster. This mission covers both: a clean bootstrap install and the steps needed to harden it for production (external etcd, rotated admin key).",
     "type": "deploy",
     "status": "completed",
     "steps": [
@@ -16,11 +16,19 @@
       },
       {
         "title": "Install APISIX using Helm",
-        "description": "Install APISIX in a new namespace called 'ingress-apisix' using the upstream chart. The chart bundles etcd as a dependency for APISIX's configuration store.\n```bash\nhelm install apisix apisix/apisix --version 2.13.0 --namespace ingress-apisix --create-namespace\n```"
+        "description": "Install APISIX in a new namespace called 'ingress-apisix' using the upstream chart. The chart bundles an etcd subchart for the configuration store, which is sufficient to bring APISIX up cleanly on a fresh cluster but is not intended for production. The next two steps replace it with an external etcd and rotate the default admin key. The bundled etcd subchart pulls from 'docker.io/bitnamilegacy/etcd:latest' on the legacy Bitnami registry (the Bitnami catalog migrated to 'bitnamilegacy' on Aug 28, 2025 and is no longer updated). Pin '--set etcd.image.tag=latest' if image pulls fail.\n```bash\nhelm install apisix apisix/apisix --version 2.13.0 --namespace ingress-apisix --create-namespace\n```"
       },
       {
         "title": "Verify the installation",
         "description": "Check that the APISIX and etcd pods are running successfully.\n```bash\nkubectl get pods --namespace ingress-apisix\n```"
+      },
+      {
+        "title": "Point APISIX at an external etcd (recommended for production)",
+        "description": "The bundled etcd subchart is fine for evaluation but is unmaintained on a single 'latest' tag from the Bitnami legacy registry, and the APISIX chart maintainers themselves recommend using an externally-managed etcd for production. Stand up a production etcd cluster separately (etcd-operator, a managed offering, or your own etcd StatefulSet) and reconfigure APISIX to talk to it. The chart disables the bundled etcd via 'etcd.enabled=false' and accepts a list of external endpoints via 'etcd.host'.\n```bash\nhelm upgrade apisix apisix/apisix --version 2.13.0 \\\n  --namespace ingress-apisix \\\n  --reuse-values \\\n  --set etcd.enabled=false \\\n  --set etcd.host[0]=http://etcd.etcd-system.svc.cluster.local:2379 \\\n  --set etcd.prefix=/apisix\n```\nFor TLS-protected etcd, also pass 'etcd.tls.*' values (see the chart's values.yaml for the full schema). After the upgrade, the bundled etcd StatefulSet is removed and APISIX writes its configuration to your external cluster."
+      },
+      {
+        "title": "Rotate the default admin API key",
+        "description": "The chart ships with a well-known default admin key ('edd1c9f034335f136f87ad84b625c8f1') under 'apisix.admin.credentials.admin'. Anyone reaching the Admin API with that key can rewrite routes, so rotate it before exposing the gateway. Generate two random keys with openssl and paste them into the helm upgrade command.\n```bash\nopenssl rand -hex 16\n# example output: 8a91b3c4d5e6f7081234567890abcdef\nopenssl rand -hex 16\n# example output: cdef1234567890ab8a91b3c4d5e6f708\n```\nStore the values in your secret manager, then apply them as chart overrides (replace ADMIN_KEY and VIEWER_KEY with the values you just generated):\n```bash\nhelm upgrade apisix apisix/apisix --version 2.13.0 \\\n  --namespace ingress-apisix \\\n  --reuse-values \\\n  --set apisix.admin.credentials.admin=ADMIN_KEY \\\n  --set apisix.admin.credentials.viewer=VIEWER_KEY\n```\nAll subsequent Admin API calls must send 'X-API-KEY: ADMIN_KEY'."
       },
       {
         "title": "Check the gateway service",
@@ -28,7 +36,7 @@
       },
       {
         "title": "Access the Admin API",
-        "description": "Set up port forwarding to reach the APISIX Admin API from your local machine. The chart ships with a default admin key that you should rotate before using in production.\n```bash\nkubectl port-forward -n ingress-apisix svc/apisix-admin 9180:9180\n```"
+        "description": "Set up port forwarding to reach the APISIX Admin API from your local machine, then verify the rotated admin key from the previous step is accepted (replace ADMIN_KEY with the value you generated).\n```bash\nkubectl port-forward -n ingress-apisix svc/apisix-admin 9180:9180 &\ncurl -sS -H \"X-API-KEY: ADMIN_KEY\" http://127.0.0.1:9180/apisix/admin/routes\n```"
       }
     ],
     "uninstall": [
@@ -70,7 +78,11 @@
       },
       {
         "title": "Admin API returning 401",
-        "description": "APISIX requires the X-API-KEY header for Admin API requests. The default key is defined in the chart values under 'apisix.admin.credentials.admin'. Confirm the key you are using matches the one in the cluster.\n```bash\nkubectl get -n ingress-apisix secret apisix -o jsonpath='{.data}'\nhelm get values apisix --namespace ingress-apisix\n```"
+        "description": "APISIX requires the X-API-KEY header for Admin API requests. The key in use is whichever value 'apisix.admin.credentials.admin' is set to -- the chart default if you skipped rotation, or the value you set during the rotation step. Confirm what is actually configured in the cluster.\n```bash\nhelm get values apisix --namespace ingress-apisix | grep -A2 credentials\nkubectl get -n ingress-apisix configmap apisix -o yaml | grep -A2 admin_key\n```"
+      },
+      {
+        "title": "etcd pods fail with ImagePullBackOff referencing 'docker.io/bitnamilegacy'",
+        "description": "The chart's bundled etcd subchart points at 'docker.io/bitnamilegacy/etcd:latest'. The Bitnami catalog was archived to the 'bitnamilegacy' registry on Aug 28, 2025 and that registry only ships 'latest' going forward (deletion of legacy assets is scheduled). If the bundled etcd pods fail to pull, you are seeing the legacy migration. The durable fix is to disable the bundled etcd and use external etcd as covered above. The short-term workaround is to pin 'etcd.image.tag=latest' or override 'etcd.image.repository' to a registry you control.\n```bash\nkubectl describe pod -n ingress-apisix -l app.kubernetes.io/name=etcd | grep -A2 Image\nhelm upgrade apisix apisix/apisix --namespace ingress-apisix --reuse-values --set etcd.enabled=false\n```"
       },
       {
         "title": "Gateway service stuck in Pending",
@@ -82,11 +94,13 @@
       }
     ],
     "resolution": {
-      "summary": "A successful installation of APISIX will show both the APISIX and etcd pods running in the 'ingress-apisix' namespace, an apisix-gateway Service reachable on its external IP or NodePort, and an Admin API accepting requests with the configured X-API-KEY. You can then register upstream services and routes through the Admin API or the ingress controller.",
+      "summary": "A successful production install of APISIX has the APISIX pods running in 'ingress-apisix', the bundled etcd disabled in favor of an externally-managed etcd cluster, the default admin API key rotated to a random value stored in your secret manager, the apisix-gateway Service reachable on its external IP or NodePort, and the Admin API accepting requests with the rotated X-API-KEY. From there you can register upstream services and routes through the Admin API or the ingress controller.",
       "codeSnippets": [
         "helm repo add apisix https://apache.github.io/apisix-helm-chart\nhelm repo update",
         "helm install apisix apisix/apisix --version 2.13.0 --namespace ingress-apisix --create-namespace",
         "kubectl get pods --namespace ingress-apisix",
+        "helm upgrade apisix apisix/apisix --version 2.13.0 \\\n  --namespace ingress-apisix --reuse-values \\\n  --set etcd.enabled=false \\\n  --set etcd.host[0]=http://etcd.etcd-system.svc.cluster.local:2379 \\\n  --set etcd.prefix=/apisix",
+        "helm upgrade apisix apisix/apisix --version 2.13.0 \\\n  --namespace ingress-apisix --reuse-values \\\n  --set apisix.admin.credentials.admin=ADMIN_KEY \\\n  --set apisix.admin.credentials.viewer=VIEWER_KEY",
         "kubectl get svc apisix-gateway --namespace ingress-apisix",
         "kubectl port-forward -n ingress-apisix svc/apisix-admin 9180:9180"
       ]
@@ -135,10 +149,10 @@
       "helm",
       "kubectl"
     ],
-    "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. The chart bundles etcd by default, so a StorageClass must be available in the cluster for the etcd PersistentVolumeClaims."
+    "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. For evaluation, the chart bundles a development-only etcd subchart and a default StorageClass must be available for the etcd PersistentVolumeClaims; that bundled etcd pulls from the 'docker.io/bitnamilegacy' registry, which only ships 'latest' going forward. For production, provision an externally-managed etcd cluster (etcd-operator, a managed offering, or your own etcd StatefulSet) and reach it from the APISIX namespace -- this mission walks through wiring APISIX to it and rotating the chart's default admin API key."
   },
   "security": {
-    "scannedAt": "2026-05-13T00:00:00.000Z",
+    "scannedAt": "2026-05-15T00:00:00.000Z",
     "scannerVersion": "cncf-install-gen-1.0.0",
     "sanitized": true,
     "findings": []

--- a/fixes/cncf-install/install-kuberay.json
+++ b/fixes/cncf-install/install-kuberay.json
@@ -2,8 +2,8 @@
   "version": "kc-mission-v1",
   "name": "install-kuberay",
   "missionClass": "install",
-  "author": "KubeStellar Bot",
-  "authorGithub": "kubestellar",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
   "mission": {
     "title": "Install and Configure KubeRay on Kubernetes",
     "description": "KubeRay is a Kubernetes operator for running Ray clusters, jobs, and services. It manages the lifecycle of distributed Ray workloads for machine learning, hyperparameter tuning, reinforcement learning, and model serving. Installing the KubeRay operator lets platform teams run Ray on Kubernetes as first-class RayCluster, RayJob, and RayService resources.",
@@ -42,7 +42,7 @@
       },
       {
         "title": "Clean up CRDs and namespace",
-        "description": "Delete the Ray CRDs and the operator namespace to finish cleaning up. Removing the CRDs deletes any remaining RayCluster, RayJob, and RayService resources across the cluster.\n```bash\nkubectl delete crd rayclusters.ray.io rayjobs.ray.io rayservices.ray.io\nkubectl delete namespace kuberay-operator\n```"
+        "description": "Delete the Ray CRDs and the operator namespace to finish cleaning up. The chart installs four CRDs, and removing them deletes any remaining RayCluster, RayCronJob, RayJob, and RayService resources across the cluster.\n```bash\nkubectl delete crd rayclusters.ray.io raycronjobs.ray.io rayjobs.ray.io rayservices.ray.io\nkubectl delete namespace kuberay-operator\n```"
       }
     ],
     "upgrade": [
@@ -137,7 +137,7 @@
     "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. For non-trivial workloads the cluster should have enough CPU and memory for the Ray head and worker pods."
   },
   "security": {
-    "scannedAt": "2026-05-13T00:00:00.000Z",
+    "scannedAt": "2026-05-15T00:00:00.000Z",
     "scannerVersion": "cncf-install-gen-1.0.0",
     "sanitized": true,
     "findings": []


### PR DESCRIPTION
## Description

Two follow-up fixes to the install missions I contributed in #2233, identified during a production-readiness review of the four CNCF install missions:

### 1. `install-apisix.json` — production hardening (mirrors the Thanos rewrite in #2253)

The mission stopped at `helm install` against the chart's bundled etcd subchart, with no warning that:

- The bundled etcd pulls from `docker.io/bitnamilegacy/etcd:latest` — the legacy Bitnami registry archived on Aug 28, 2025 (only `latest` going forward, no further maintenance).
- The APISIX chart README itself recommends an externally-managed etcd for production.
- The chart ships a well-known default admin API key (`apisix.admin.credentials.admin`) that grants full route-rewrite access.

Restructured along the lines of #2253:

| Change | Detail |
|---|---|
| Install step prose | Flags the bundled etcd as evaluation-only and names the Bitnami legacy migration |
| New step | "Point APISIX at an external etcd (recommended for production)" — `etcd.enabled=false`, `etcd.host[]`, `etcd.prefix`, with TLS pointer |
| New step | "Rotate the default admin API key" — random keys via `openssl rand -hex 16`, applied via `apisix.admin.credentials.{admin,viewer}` |
| Access the Admin API | Uses rotated key in a curl verification |
| Troubleshooting | "Admin API returning 401" updated for the rotation flow |
| Troubleshooting | New entry: `ImagePullBackOff` referencing `docker.io/bitnamilegacy` with durable fix + short-term workaround |
| Description / prerequisites / resolution | Spell out the external-etcd path as the production recommendation |

### 2. `install-kuberay.json` — complete the uninstall CRD list

The uninstall step deleted three CRDs (`rayclusters.ray.io`, `rayjobs.ray.io`, `rayservices.ray.io`) but the chart at both `1.6.0` and `1.6.1` installs a **fourth**, `raycronjobs.ray.io`. Following the mission as written left a cluster-scoped orphan CRD. Added it to the `kubectl delete crd …` command and enumerated all four kinds in the prose.

### Other

- Bumped `security.scannedAt` to `2026-05-15` on both files.
- Corrected `author` / `authorGithub` on both files to the actual human contributor. **Note:** this will trivially overlap with #2253 (also OPEN, also fixing attribution). Whichever PR merges second resolves a two-line conflict on those fields.

## Related Issue

No issue link. Follow-up to the production-readiness review of the four missions from #2231 and #2233.

## Type of Change

- [x] Bug fix (KubeRay uninstall left orphan CRD)
- [x] New feature (APISIX production hardening steps)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [x] I have signed off my commits (`git commit -s`)
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

## Additional Notes

Both CI checks pass locally:

- `node scripts/validate-schema.mjs fixes/cncf-install/install-apisix.json fixes/cncf-install/install-kuberay.json` → Valid kc-mission-v1 (2/2)
- `node scripts/test-kb-quality-ci.mjs fixes/cncf-install/install-apisix.json fixes/cncf-install/install-kuberay.json` → 100/100 on both files across clarity, completeness, correctness, structure, and observability

`fixes/index.json` intentionally not committed — the build-index workflow regenerates and commits it on master after merge.

## Test plan

- [ ] CI: `validate-schema.mjs` passes
- [ ] CI: `test-kb-quality-ci.mjs` passes
- [ ] Manual: `helm install apisix apisix/apisix --version 2.13.0` against a kind cluster reproduces the bundled-etcd image-pull state described in the new troubleshooting entry
- [ ] Manual: `helm upgrade … --set etcd.enabled=false --set etcd.host[0]=…` from step 4 cleanly swaps APISIX onto an external etcd
- [ ] Manual: `helm install kuberay-operator … --version 1.6.0` then run the updated uninstall steps and confirm `kubectl get crd | grep ray.io` returns nothing