### PR TITLE
Change 'install-kubestellar' to 'install-kubestellar-controller'

### DIFF
--- a/runbooks/install-kubestellar-controller.json
+++ b/runbooks/install-kubestellar-controller.json
@@ -1,12 +1,12 @@
 {
   "version": "kc-mission-v1",
-  "name": "runbook-install-kubestellar",
+  "name": "runbook-install-kubestellar-controller",
   "missionClass": "runbook",
   "author": "KubeStellar Admin",
   "authorGithub": "kubestellar",
   "mission": {
-    "title": "Install KubeStellar via Helm (Standalone Mode)",
-    "description": "Production-grade, idempotent runbook to install KubeStellar in standalone mode using the 'kubestellar/kubestellar-core' Helm chart. IMPORTANT: This chart deploys KubeStellar core controllers into the kubestellar-system namespace only. It does NOT provision KubeFlex, virtual control planes, ITS (Inventory & Transport Space), or WDS (Workload Description Space). Those components require separate provisioning steps beyond the scope of this runbook. Every step is deterministic, fail-fast, and safe to re-run.",
+    "title": "Install KubeStellar controller via Helm (Standalone Mode)",
+    "description": "Production-grade, idempotent runbook to install KubeStellar controller in standalone mode using the 'kubestellar/kubestellar-core' Helm chart. IMPORTANT: This chart deploys KubeStellar core controllers into the kubestellar-system namespace only. It does NOT provision KubeFlex, virtual control planes, ITS (Inventory & Transport Space), or WDS (Workload Description Space). Those components require separate provisioning steps beyond the scope of this runbook. Every step is deterministic, fail-fast, and safe to re-run.",
     "type": "deploy",
     "status": "completed",
     "estimatedMinutes": 10,


### PR DESCRIPTION
## Description

The planned runbook shows how to install a Kubestellar controller, but it was specified as install kubestellar
The same person who created it is likely referring to the controller.

## Related Issue

<!-- Link to the issue this PR addresses, e.g., Fixes #123 -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Infrastructure/CI change

## Checklist

- [X] I have signed off my commits (`git commit -s`)
- [X] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass

## Additional Notes

<!-- Any additional information that reviewers should know -->
