### PR TITLE
fix: make scan workflow comment non-fatal for fork PRs

### DIFF
--- a/.github/workflows/scan-missions.yml
+++ b/.github/workflows/scan-missions.yml
@@ -52,10 +52,14 @@ jobs:
             const fs = require('fs');
             if (fs.existsSync('scan-results.md')) {
               const body = fs.readFileSync('scan-results.md', 'utf8');
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: body
+                });
+              } catch (err) {
+                core.warning(`Could not post scan results (fork PRs have read-only tokens): ${err.message}`);
+              }
             }


### PR DESCRIPTION
## Summary
- Fork PRs run with read-only GitHub tokens, causing the `Post results` step to fail with `403 Resource not accessible by integration`
- This marks the entire `scan` check as failed even though the actual mission scan passed
- Wraps the comment-posting in try/catch so fork PRs get a warning instead of a failure
- Fixes blocked PRs #2253 and #2254 (both from fork, both scan-clean but marked red)

## Test plan
- [ ] Verify scan check passes on this PR (no mission files changed, so scan step is skipped)
- [ ] Re-run scan on #2253 or #2254 after merge to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)