### PR TITLE
🌱 kagent: [FEATURE] Support for OAuth2/OpenID Connect Integration (Azure Entra ID,

### DIFF
--- a/fixes/cncf-generated/kagent/kagent-476-feature-support-for-oauth2-openid-connect-integration-azure-entra-id-.json
+++ b/fixes/cncf-generated/kagent/kagent-476-feature-support-for-oauth2-openid-connect-integration-azure-entra-id-.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kagent-476-feature-support-for-oauth2-openid-connect-integration-azure-entra-id-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kagent: [FEATURE] Support for OAuth2/OpenID Connect Integration (Azure Entra ID, Keycloak, etc.) in Webchat",
+    "description": "[FEATURE] Support for OAuth2/OpenID Connect Integration (Azure Entra ID, Keycloak, etc.) in Webchat. Requested by 6+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current kagent deployment",
+        "description": "Verify your kagent version and configuration:\n```bash\nkubectl get pods -n kagent -l app.kubernetes.io/name=kagent\nhelm list -n kagent 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working kagent installation."
+      },
+      {
+        "title": "Review kagent configuration",
+        "description": "Inspect the relevant kagent configuration:\n```bash\nkubectl get all -n kagent -l app.kubernetes.io/name=kagent\nkubectl get configmap -n kagent -l app.kubernetes.io/part-of=kagent\n```\n### 📋 Prerequisites\n\n### 📝 Feature Summary\n\nWe would like to request the implementation of a feature that allows the webchat to integrate with an external authentication and authorization server (e.g., OAuth2, OpenID Connect)."
+      },
+      {
+        "title": "Apply the fix for [FEATURE] Support for OAuth2/OpenID Connect Integration…",
+        "description": "Adding your own security solution also adds a security risk compared to an already hardened existing one ( let's assume oauth2 proxy (or a sidecar of user's choice) is as such) \n\n>if is possible to integrate OAuth2 directly into the application itself, that is preferable. Doing so avoids introducing an additional component, \n\nWhether a mechanism is built-in or not, the additional component is introduced the same.\nFurther down the line, _not_ introducing the component opens the capability for\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n kagent -l app.kubernetes.io/name=kagent\nkubectl get events -n kagent --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[FEATURE] Support for OAuth2/OpenID Connect Integration…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Adding your own security solution also adds a security risk compared to an already hardened existing one ( let's assume oauth2 proxy (or a sidecar of user's choice) is as such) \n\n>if is possible to integrate OAuth2 directly into the application itself, that is preferable.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kagent",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "kagent"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/kagent-dev/kagent/issues/476",
+      "repo": "https://github.com/kagent-dev/kagent"
+    },
+    "reactions": 6,
+    "comments": 16,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kagent installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-16T07:05:01.117Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kagent — [FEATURE] Support for OAuth2/OpenID Connect Integration (Azure Entra ID, Keycloak, etc.) in Webchat

**Type:** feature | **Source:** https://github.com/kagent-dev/kagent/issues/476 (6 reactions)
**File:** `fixes/cncf-generated/kagent/kagent-476-feature-support-for-oauth2-openid-connect-integration-azure-entra-id-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*