### PR TITLE
feat(install-mission): add guided install mission for Grafana

### DIFF
--- a/fixes/cncf-install/install-grafana.json
+++ b/fixes/cncf-install/install-grafana.json
@@ -1,0 +1,162 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-grafana",
+  "missionClass": "install",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Install and Configure Grafana on Kubernetes",
+    "description": "Grafana is the open-source dashboard and observability platform that lets teams query, visualize, alert on, and explore metrics, logs, and traces from data sources such as Prometheus, Loki, Thanos, Mimir, Tempo, Elasticsearch, and many more. This mission installs Grafana via the official Helm chart and walks through accessing the UI, retrieving the bootstrap admin password, and the production hardening users typically apply (persistent storage, ingress, externalized admin credentials, datasource provisioning).",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Grafana Helm repository",
+        "description": "Add the official Grafana Helm chart repository to your local Helm configuration.\n```bash\nhelm repo add grafana https://grafana.github.io/helm-charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Grafana using Helm",
+        "description": "Install Grafana into a new namespace called 'grafana'. Persistence is disabled by default in the chart, which is fine for a fresh install. The next step turns it on for any environment where dashboard state must survive a pod restart.\n```bash\nhelm install grafana grafana/grafana --version 10.5.15 --namespace grafana --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the Grafana pod is running and the Service is created.\n```bash\nkubectl get pods --namespace grafana\nkubectl get svc --namespace grafana\n```"
+      },
+      {
+        "title": "Enable persistence (recommended for any non-throwaway install)",
+        "description": "Without persistence, dashboards, datasources, and the SQLite database for users and folders are lost on every pod restart. Enable persistence so a PVC backs the Grafana data directory.\n```bash\nhelm upgrade grafana grafana/grafana --version 10.5.15 \\\n  --namespace grafana \\\n  --reuse-values \\\n  --set persistence.enabled=true \\\n  --set persistence.size=10Gi\n```\nA default StorageClass must exist on the cluster for the PVC to bind. On clusters with multiple StorageClasses, set 'persistence.storageClassName' to pick one explicitly."
+      },
+      {
+        "title": "Retrieve the bootstrap admin password",
+        "description": "The chart auto-generates an admin password on first install and stores it in a Secret. Read it once and rotate it immediately for any environment that is reachable beyond your laptop.\n```bash\nkubectl get secret grafana --namespace grafana -o jsonpath='{.data.admin-password}' | base64 -d ; echo\n```\nFor production, do not rely on the auto-generated password. Pre-create a Secret with your own admin credentials and point the chart at it via 'admin.existingSecret', or set 'adminPassword' as a chart value pulled from your secret manager."
+      },
+      {
+        "title": "Access the Grafana UI",
+        "description": "Set up port forwarding to reach the Grafana UI from your local machine.\n```bash\nkubectl port-forward svc/grafana --namespace grafana 3000:80\n```\nOpen http://localhost:3000 in a browser. Log in with username 'admin' and the password you retrieved in the previous step."
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits on the Grafana deployment to match your dashboard load and concurrent-user count.\n```bash\nhelm upgrade grafana grafana/grafana --version 10.5.15 \\\n  --namespace grafana \\\n  --reuse-values \\\n  --set resources.requests.cpu=100m \\\n  --set resources.requests.memory=256Mi \\\n  --set resources.limits.cpu=500m \\\n  --set resources.limits.memory=512Mi\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Grafana release from the cluster.\n```bash\nhelm uninstall grafana --namespace grafana\n```"
+      },
+      {
+        "title": "Clean up persistent resources",
+        "description": "If persistence was enabled, the PVC is retained by default after uninstall. Delete it explicitly when you want the storage released.\n```bash\nkubectl delete pvc --all --namespace grafana\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'grafana' namespace and verify it has been removed.\n```bash\nkubectl delete namespace grafana\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current values and SQLite database",
+        "description": "Export the current Helm values before upgrading. If persistence is enabled, also snapshot the SQLite database that backs Grafana's users, folders, and dashboard metadata.\n```bash\nhelm get values grafana --namespace grafana > grafana-backup.yaml\nkubectl exec -n grafana deploy/grafana -c grafana -- sqlite3 /var/lib/grafana/grafana.db .dump > grafana-db-backup.sql\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the Grafana Helm repository to pick up the latest chart.\n```bash\nhelm repo update\nhelm search repo grafana/grafana --versions | head -5\n```"
+      },
+      {
+        "title": "Upgrade Grafana",
+        "description": "Upgrade the release to the desired chart version. Always review the chart and Grafana release notes for any breaking changes before upgrading production.\n```bash\nhelm upgrade grafana grafana/grafana --namespace grafana --version 10.5.15 --reuse-values\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Grafana deployment rolled out and is running the new image.\n```bash\nkubectl rollout status deploy/grafana -n grafana\nkubectl get pods -n grafana -o jsonpath='{.items[*].spec.containers[*].image}'\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Pod stuck in Pending after enabling persistence",
+        "description": "If the Grafana pod stays Pending after 'persistence.enabled=true' is set, the PVC has nothing to bind to. Confirm a default StorageClass exists or that 'persistence.storageClassName' points at a real one.\n```bash\nkubectl get pvc -n grafana\nkubectl get storageclass\nkubectl describe pod -n grafana -l app.kubernetes.io/name=grafana | tail -20\n```"
+      },
+      {
+        "title": "Cannot log in with the bootstrap admin password",
+        "description": "The chart only generates a password on the first install. If the Secret was deleted or recreated, the persisted SQLite database may have a different password. Check what is actually in the Secret and what is in the database file.\n```bash\nkubectl get secret grafana -n grafana -o jsonpath='{.data.admin-password}' | base64 -d ; echo\nkubectl exec -n grafana deploy/grafana -c grafana -- grafana-cli admin reset-admin-password NEW_PASSWORD\n```"
+      },
+      {
+        "title": "Datasource added in the UI disappears after restart",
+        "description": "Datasources added through the UI are written to the SQLite database. If persistence is disabled, the database lives on the pod's emptyDir and is lost on restart. Either enable persistence as in the install steps, or provision datasources as code through 'datasources.datasources.yaml' chart values so they are reapplied on each rollout.\n```bash\nkubectl get pvc -n grafana\nhelm get values grafana --namespace grafana | grep -A20 datasources\n```"
+      },
+      {
+        "title": "OOMKilled under dashboard load",
+        "description": "Grafana renders dashboards in-memory. Heavy dashboards or many concurrent users can push the pod past its memory limit. Check current usage and bump the limit.\n```bash\nkubectl top pods --namespace grafana\nkubectl describe pod -n grafana -l app.kubernetes.io/name=grafana | grep -A4 Limits\n```"
+      },
+      {
+        "title": "UI not reachable through ingress",
+        "description": "If 'ingress.enabled=true' but the UI does not load, check that the ingress controller is installed, the Ingress resource is admitted, and the host header matches.\n```bash\nkubectl get ingress -n grafana\nkubectl describe ingress -n grafana grafana\n```"
+      },
+      {
+        "title": "Plugin install fails on pod startup",
+        "description": "If you set 'plugins:' in chart values, Grafana installs them on container start by reaching out to grafana.com. Pods that cannot egress to the internet will fail at this step. Either pre-bake plugins into a custom image, or vendor them via 'extraInitContainers' from an internal mirror.\n```bash\nkubectl logs -n grafana -l app.kubernetes.io/name=grafana --tail=200\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful install of Grafana shows the grafana pod Running in the 'grafana' namespace, a Service on port 80 forwarding to container port 3000, and the UI reachable on http://localhost:3000 after port-forward. With persistence enabled the SQLite database survives restarts. Production deployments should additionally set externalized admin credentials, an Ingress with TLS, and provisioned datasources/dashboards from chart values rather than UI-created state.",
+      "codeSnippets": [
+        "helm repo add grafana https://grafana.github.io/helm-charts\nhelm repo update",
+        "helm install grafana grafana/grafana --version 10.5.15 --namespace grafana --create-namespace",
+        "kubectl get pods --namespace grafana",
+        "helm upgrade grafana grafana/grafana --version 10.5.15 \\\n  --namespace grafana --reuse-values \\\n  --set persistence.enabled=true --set persistence.size=10Gi",
+        "kubectl get secret grafana --namespace grafana -o jsonpath='{.data.admin-password}' | base64 -d ; echo",
+        "kubectl port-forward svc/grafana --namespace grafana 3000:80"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "observability"
+    ],
+    "cncfProjects": [
+      "grafana"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "Secret",
+      "PersistentVolumeClaim",
+      "Namespace"
+    ],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "projectVersion": "v12.3.1",
+    "containerImages": [
+      "docker.io/grafana/grafana:12.3.1"
+    ],
+    "sourceUrls": {
+      "docs": "https://grafana.com/docs/grafana/latest/",
+      "repo": "https://github.com/grafana/grafana",
+      "helm": "https://grafana.github.io/helm-charts"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Ensure you have a Kubernetes cluster running and have Helm and kubectl installed on your local machine. A default StorageClass is needed for the PVC if persistence is enabled (the recommended path beyond a throwaway demo)."
+  },
+  "security": {
+    "scannedAt": "2026-05-16T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## Description

Adds a guided install mission for **Grafana**, the open-source dashboard and observability platform that lets teams query, visualize, alert on, and explore metrics, logs, and traces from data sources such as Prometheus, Loki, Thanos, Mimir, Tempo, and Elasticsearch.

The [`kubestellar.io/docs/console/knowledge-base`](https://kubestellar.io/docs/console/knowledge-base) page lists Grafana under Observability with **Install Mission: Yes**, but no `install-grafana.json` existed in `console-kb` until this PR.

## What the mission covers

- Helm repo + install with chart `10.5.15` (Grafana app version `12.3.1`), pulling `docker.io/grafana/grafana:12.3.1`
- Pod and service verification
- Persistence enablement on a dedicated PVC for any non-throwaway install
- Bootstrap admin password retrieval from the chart-managed Secret, plus production guidance to externalize admin credentials via `admin.existingSecret`
- Port-forward access to the UI on port 3000
- Per-deployment resource limits tuned for real dashboard load
- Three-step uninstall (helm uninstall + PVC cleanup + namespace delete)
- Four-step upgrade (backup values + SQLite dump + repo update + helm upgrade + verify rollout)
- Six troubleshooting entries

## Validation

```text
$ node scripts/validate-schema.mjs fixes/cncf-install/install-grafana.json
✅ Valid kc-mission-v1

$ node scripts/test-kb-quality-ci.mjs fixes/cncf-install/install-grafana.json
Score: 100/100

$ node scripts/scan-pr.mjs fixes/cncf-install/install-grafana.json
✅ Schema · ✅ Sensitive data · ✅ Security
