### PR TITLE
feat(install-mission): add guided install mission for Grafana Loki

### DIFF
--- a/fixes/cncf-install/install-loki.json
+++ b/fixes/cncf-install/install-loki.json
@@ -1,0 +1,167 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-loki",
+  "missionClass": "install",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Install and Configure Grafana Loki on Kubernetes",
+    "description": "Grafana Loki is a horizontally scalable, multi-tenant log aggregation system inspired by Prometheus. Loki indexes only metadata labels and stores compressed log chunks in S3-compatible object storage, making large-scale log retention significantly cheaper than full-text indexing systems. The official Helm chart supports three deployment modes: SingleBinary for small or evaluation installs, SimpleScalable for medium-scale read/write/backend separation, and Distributed for full microservices topology. This mission walks through SingleBinary as the bootstrap path, points users at SimpleScalable or Distributed for production, and covers the object storage configuration that all three modes require.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Grafana Helm repository",
+        "description": "Add the official Grafana Helm chart repository to your local Helm configuration.\n```bash\nhelm repo add grafana https://grafana.github.io/helm-charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Loki using Helm",
+        "description": "Install Loki in a new namespace called 'loki' using the SingleBinary deployment mode for the bootstrap install. Persistence is enabled and the chart's bundled MinIO subchart is turned on so the install comes up cleanly on a fresh cluster. The next step replaces the bundled MinIO with production object storage.\n```bash\nhelm install loki grafana/loki --version 7.0.0 \\\n  --namespace loki --create-namespace \\\n  --set deploymentMode=SingleBinary \\\n  --set singleBinary.replicas=1 \\\n  --set 'loki.commonConfig.replication_factor=1' \\\n  --set 'loki.useTestSchema=true' \\\n  --set minio.enabled=true \\\n  --set chunksCache.enabled=false \\\n  --set resultsCache.enabled=false \\\n  --set read.replicas=0 \\\n  --set write.replicas=0 \\\n  --set backend.replicas=0\n```\nThe bundled MinIO is suitable for evaluation only and is a single replica with no resilience guarantees."
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the Loki SingleBinary pod and the bundled MinIO pod are running. The chart also creates a gateway pod that fronts the API.\n```bash\nkubectl get pods --namespace loki\nkubectl get svc --namespace loki\n```"
+      },
+      {
+        "title": "Configure production object storage",
+        "description": "Loki requires S3-compatible object storage for chunks and the ruler. The bundled MinIO is a single-replica evaluation backend only. Production should use AWS S3, GCS, Azure Blob, or a managed S3-compatible service. Disable the bundled MinIO and point Loki at your bucket via 'loki.storage'.\n\nAWS S3 example (loki-storage-values.yaml):\n```yaml\nminio:\n  enabled: false\nloki:\n  storage:\n    type: s3\n    bucketNames:\n      chunks: my-loki-chunks\n      ruler: my-loki-ruler\n    s3:\n      region: us-east-1\n      accessKeyId: <ACCESS_KEY>\n      secretAccessKey: <SECRET_KEY>\n      s3ForcePathStyle: false\n      insecure: false\n```\nGCS example:\n```yaml\nminio:\n  enabled: false\nloki:\n  storage:\n    type: gcs\n    bucketNames:\n      chunks: my-loki-chunks\n      ruler: my-loki-ruler\n    gcs:\n      chunkBufferSize: 0\n      requestTimeout: 0s\n      enableHttp2: true\n```\n(Mount the GCS service-account JSON via 'serviceAccount.annotations' for Workload Identity, or via 'extraVolumes' as a Secret-backed file.)\n\nApply by upgrading the release with the values file:\n```bash\nhelm upgrade loki grafana/loki --version 7.0.0 \\\n  --namespace loki \\\n  --reuse-values \\\n  -f loki-storage-values.yaml\n```\nLoki will restart and write new chunks to the configured bucket. Existing chunks in the bundled MinIO are not migrated automatically."
+      },
+      {
+        "title": "Send logs to Loki",
+        "description": "Loki receives logs through Promtail, Grafana Alloy, Vector, Fluent Bit, or any client that speaks the Loki push API. Install a log-shipper that targets the gateway service. Promtail is deprecated in favor of Grafana Alloy, but Promtail is still the simplest path for a quick verification.\n```bash\nhelm install alloy grafana/alloy --namespace loki \\\n  --set 'alloy.configMap.content=loki.write \"default\" { endpoint { url = \"http://loki-gateway.loki.svc.cluster.local/loki/api/v1/push\" } }\\nlocal.file_match \"node\" { path_targets = [{__path__ = \"/var/log/*.log\"}] }\\nloki.source.file \"node\" { targets = local.file_match.node.targets, forward_to = [loki.write.default.receiver] }'\n```\nFor production deployments, define the Alloy config as a separate values file rather than inline."
+      },
+      {
+        "title": "Query logs from the Loki API",
+        "description": "Set up port forwarding to the Loki gateway and query the API to confirm logs are flowing.\n```bash\nkubectl port-forward svc/loki-gateway --namespace loki 3100:80\n```\nIn another terminal:\n```bash\ncurl -sS \"http://127.0.0.1:3100/loki/api/v1/labels\"\ncurl -sS \"http://127.0.0.1:3100/loki/api/v1/query_range?query=%7Bjob%3D%22varlogs%22%7D&limit=5\"\n```\nFor a UI experience, add the Loki gateway as a Grafana datasource (URL 'http://loki-gateway.loki.svc.cluster.local') and explore logs from the Explore tab."
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits on the Loki SingleBinary deployment to match your ingest rate and retention window. For SimpleScalable or Distributed mode, tune each component (read, write, backend, distributor, ingester, querier) separately.\n```bash\nhelm upgrade loki grafana/loki --version 7.0.0 \\\n  --namespace loki \\\n  --reuse-values \\\n  --set singleBinary.resources.requests.cpu=200m \\\n  --set singleBinary.resources.requests.memory=512Mi \\\n  --set singleBinary.resources.limits.cpu=1 \\\n  --set singleBinary.resources.limits.memory=2Gi\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Loki release from the cluster. This deletes Loki, the gateway, and the bundled MinIO if it was enabled.\n```bash\nhelm uninstall loki --namespace loki\n```"
+      },
+      {
+        "title": "Clean up persistent resources",
+        "description": "PVCs are retained by default after uninstall. Delete them to release storage.\n```bash\nkubectl delete pvc --all --namespace loki\n```"
+      },
+      {
+        "title": "Empty the object storage bucket (production only)",
+        "description": "Helm uninstall does not touch external buckets. If you no longer need historical chunks, empty the bucket via your cloud provider.\n```bash\naws s3 rm s3://my-loki-chunks --recursive\naws s3 rm s3://my-loki-ruler --recursive\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'loki' namespace and verify it has been removed.\n```bash\nkubectl delete namespace loki\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current values and storage config",
+        "description": "Export the current Helm values before upgrading. Bucket data is the source of truth for ingested logs and is not part of the helm release.\n```bash\nhelm get values loki --namespace loki > loki-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the Grafana Helm repository to pick up the latest chart.\n```bash\nhelm repo update\nhelm search repo grafana/loki --versions | head -5\n```"
+      },
+      {
+        "title": "Upgrade Loki",
+        "description": "Upgrade to the desired chart version. Always read the chart's CHANGELOG for breaking changes between major versions, especially around storage schemas and deployment-mode renames.\n```bash\nhelm upgrade loki grafana/loki --namespace loki --version 7.0.0 --reuse-values\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the deployments rolled out and the new image is running.\n```bash\nkubectl rollout status -n loki statefulset/loki\nkubectl get pods -n loki -o jsonpath='{.items[*].spec.containers[*].image}' | tr ' ' '\\n' | sort -u\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Loki pod stuck in CrashLoopBackOff after enabling object storage",
+        "description": "The most common cause is a malformed bucket config or invalid credentials. Check the parsed config and the storage error in the logs.\n```bash\nkubectl logs -n loki statefulset/loki --tail=200\nkubectl get secret -n loki loki -o yaml | grep -A2 storage\n```\nVerify the bucket exists, credentials are valid, and the IAM policy grants s3:GetObject, s3:PutObject, s3:DeleteObject, and s3:ListBucket on the bucket and its objects."
+      },
+      {
+        "title": "No labels returned from /loki/api/v1/labels",
+        "description": "If the labels endpoint returns an empty list, no logs have been ingested yet. Confirm a log shipper is running and pointed at the Loki gateway.\n```bash\nkubectl get pods -n loki -l app.kubernetes.io/name=alloy\nkubectl logs -n loki -l app.kubernetes.io/name=alloy --tail=100\nkubectl get svc -n loki loki-gateway\n```"
+      },
+      {
+        "title": "Ingester rejects pushes with 'too far behind'",
+        "description": "Loki rejects log entries with timestamps too far in the past relative to the ingester's clock. This usually surfaces when replaying older logs into a fresh deployment. Either enable the 'reject_old_samples_max_age' override or backfill via the loki-canary or boltdb-shipper compactor.\n```bash\nkubectl logs -n loki statefulset/loki --tail=100 | grep -i 'too far'\n```"
+      },
+      {
+        "title": "Compactor running but old chunks not deleted",
+        "description": "The compactor needs the retention configuration to match your retention window, and bucket lifecycle rules must permit deletes. Confirm the compactor is healthy and the right limits are applied.\n```bash\nkubectl logs -n loki statefulset/loki --tail=100 | grep -i compact\nhelm get values loki --namespace loki | grep -A20 'compactor\\|retention'\n```"
+      },
+      {
+        "title": "High memory usage on the read/querier path",
+        "description": "Querier memory grows with the number of chunks scanned per query. Tighten 'limits_config.max_query_length' and 'split_queries_by_interval', and increase the chunk cache.\n```bash\nkubectl top pods -n loki\nhelm get values loki --namespace loki | grep -A5 limits_config\n```"
+      },
+      {
+        "title": "Image pull errors referencing 'docker.io/bitnami'",
+        "description": "Loki itself ships from 'docker.io/grafana/loki' on Docker Hub. Some out-of-date Loki Helm setups pinned the bundled MinIO subchart to 'docker.io/bitnami/minio', which moved to 'docker.io/bitnamilegacy' in late 2025. The chart 7.0.0 default is the pgsty community fork at 'docker.io/pgsty/minio', which is unaffected. If you see Bitnami pull errors, you are running an older chart version, and the durable fix is to disable the bundled MinIO and use external object storage.\n```bash\nkubectl describe pod -n loki -l app.kubernetes.io/name=minio | grep -A2 Image\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful production install of Loki has the SingleBinary, SimpleScalable, or Distributed pods Running in the 'loki' namespace, an external S3, GCS, or Azure bucket configured under 'loki.storage', the bundled MinIO disabled, the gateway service reachable, and a log shipper (Alloy, Promtail, Vector, or Fluent Bit) writing logs to '/loki/api/v1/push'. Logs are queryable via the Loki HTTP API or through Grafana with Loki added as a datasource pointing at 'http://loki-gateway.loki.svc.cluster.local'.",
+      "codeSnippets": [
+        "helm repo add grafana https://grafana.github.io/helm-charts\nhelm repo update",
+        "helm install loki grafana/loki --version 7.0.0 \\\n  --namespace loki --create-namespace \\\n  --set deploymentMode=SingleBinary \\\n  --set singleBinary.replicas=1 \\\n  --set 'loki.commonConfig.replication_factor=1' \\\n  --set 'loki.useTestSchema=true' \\\n  --set minio.enabled=true \\\n  --set chunksCache.enabled=false \\\n  --set resultsCache.enabled=false \\\n  --set read.replicas=0 --set write.replicas=0 --set backend.replicas=0",
+        "kubectl get pods --namespace loki",
+        "helm upgrade loki grafana/loki --version 7.0.0 \\\n  --namespace loki --reuse-values \\\n  -f loki-storage-values.yaml",
+        "kubectl port-forward svc/loki-gateway --namespace loki 3100:80",
+        "curl -sS \"http://127.0.0.1:3100/loki/api/v1/labels\""
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "observability"
+    ],
+    "cncfProjects": [
+      "loki"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "StatefulSet",
+      "Service",
+      "Secret",
+      "PersistentVolumeClaim",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "projectVersion": "v3.6.7",
+    "containerImages": [
+      "docker.io/grafana/loki:3.6.7"
+    ],
+    "sourceUrls": {
+      "docs": "https://grafana.com/docs/loki/latest/",
+      "repo": "https://github.com/grafana/loki",
+      "helm": "https://grafana.github.io/helm-charts"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Production Loki requires an S3-compatible object storage bucket (AWS S3, GCS, Azure Blob, or any S3-compatible store such as MinIO, Ceph RGW, or DigitalOcean Spaces) with credentials that can read, write, list, and delete objects in the chunks and ruler buckets. A default StorageClass is recommended for the SingleBinary PVC. Helm and kubectl must be installed locally."
+  },
+  "security": {
+    "scannedAt": "2026-05-16T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## Description

Adds a guided install mission for **Grafana Loki**, a horizontally scalable, multi-tenant log aggregation system that indexes only metadata labels and stores compressed log chunks in S3-compatible object storage.

The [`kubestellar.io/docs/console/knowledge-base`](https://kubestellar.io/docs/console/knowledge-base) page lists Loki under Observability with **Install Mission: Yes**, but no `install-loki.json` existed in `console-kb` until this PR.

## What the mission covers

- Helm repo + install with chart `7.0.0` (Loki app version `3.6.7`), pulling `docker.io/grafana/loki:3.6.7`
- SingleBinary deployment mode as the bootstrap path, with pointers to SimpleScalable and Distributed for production
- Production object storage configuration (full values-file examples for AWS S3 and GCS)
- Log shipper setup using Grafana Alloy (Promtail's documented successor)
- HTTP API access via port-forward, with `/labels` and `/query_range` examples
- Per-component resource tuning (separate guidance for SingleBinary vs SimpleScalable/Distributed)
- Four-step uninstall (helm + PVC + bucket cleanup + namespace)
- Four-step upgrade (backup + repo update + helm upgrade + verify rollout)
- Six troubleshooting entries: CrashLoopBackOff after objstore enablement, empty labels list, ingester reject-old-samples, compactor retention, querier memory tuning, and Bitnami legacy migration on older bundled MinIO versions

## Validation

```text
$ node scripts/validate-schema.mjs fixes/cncf-install/install-loki.json
✅ Valid kc-mission-v1

$ node scripts/test-kb-quality-ci.mjs fixes/cncf-install/install-loki.json
Score: 100/100

$ node scripts/scan-pr.mjs fixes/cncf-install/install-loki.json
✅ Schema · ✅ Sensitive data · ✅ Security
