### PR TITLE
feat(install-mission): add guided install mission for HashiCorp Vault

### DIFF
--- a/fixes/cncf-install/install-vault.json
+++ b/fixes/cncf-install/install-vault.json
@@ -1,0 +1,169 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-vault",
+  "missionClass": "install",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Install and Configure HashiCorp Vault on Kubernetes",
+    "description": "HashiCorp Vault is the industry-standard tool for secrets management, encryption-as-a-service, and identity-based access. The official Helm chart supports four deployment modes: dev (single pod, in-memory storage, auto-unsealed for evaluation), standalone (single pod with file storage, manual init and unseal), HA (3+ replicas with Raft integrated storage and manual init and unseal), and external (point at an existing Vault cluster). This mission walks through dev mode as the bootstrap install path, points users at HA + Raft for production, and covers the auto-unseal patterns (cloud KMS, transit-seal) that production deployments need to avoid manual unseal at every restart.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the HashiCorp Helm repository",
+        "description": "Add the official HashiCorp Helm chart repository to your local Helm configuration.\n```bash\nhelm repo add hashicorp https://helm.releases.hashicorp.com\nhelm repo update\n```"
+      },
+      {
+        "title": "Install Vault in dev mode",
+        "description": "Install Vault in dev mode for a fast bootstrap install. Dev mode runs a single pod with an in-memory storage backend, auto-unseals the vault on startup, and uses the root token 'root'. The next step replaces dev mode with HA + Raft for any environment that needs durable storage or rotation-resilient auth.\n```bash\nhelm install vault hashicorp/vault --version 0.32.0 \\\n  --namespace vault --create-namespace \\\n  --set 'server.dev.enabled=true' \\\n  --set 'server.dev.devRootToken=root'\n```\nThe dev-mode warning printed by the chart is expected. **Never run dev mode in production: storage is in-memory and lost on every restart.**"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the Vault pod is running and the agent injector pods are up.\n```bash\nkubectl get pods --namespace vault\nkubectl get svc --namespace vault\n```"
+      },
+      {
+        "title": "Test secret read and write",
+        "description": "Exec into the Vault pod and write/read a secret to confirm the API is healthy. Run each command separately. The dev-mode root token is 'root'.\n```bash\nkubectl exec --namespace vault vault-0 -- vault login root\nkubectl exec --namespace vault vault-0 -- vault kv put secret/demo username=admin password=hunter2\nkubectl exec --namespace vault vault-0 -- vault kv get secret/demo\n```"
+      },
+      {
+        "title": "Switch to HA mode with Raft for production",
+        "description": "Production deployments use HA mode with Raft integrated storage. Three replicas form a Raft consensus group, data is persisted to PVCs, and the cluster survives a single node loss. Reinstall with HA enabled and disable dev mode.\n```bash\nhelm upgrade vault hashicorp/vault --version 0.32.0 \\\n  --namespace vault \\\n  --reuse-values \\\n  --set 'server.dev.enabled=false' \\\n  --set 'server.ha.enabled=true' \\\n  --set 'server.ha.raft.enabled=true' \\\n  --set 'server.ha.replicas=3' \\\n  --set 'server.dataStorage.enabled=true' \\\n  --set 'server.dataStorage.size=2Gi'\n```\nReplicas come up sealed. The next step covers initializing and unsealing the cluster."
+      },
+      {
+        "title": "Initialize and unseal the HA cluster",
+        "description": "After switching to HA mode, run vault operator init once on the first pod to generate unseal keys and the root token. Save the output securely. Then unseal each replica with three of the five keys (default Shamir threshold). For an automated production setup, configure auto-unseal via a cloud KMS instead of the manual flow.\n```bash\nkubectl exec --namespace vault vault-0 -- vault operator init -key-shares=5 -key-threshold=3\nkubectl exec --namespace vault vault-0 -- vault operator unseal <UNSEAL_KEY_1>\nkubectl exec --namespace vault vault-0 -- vault operator unseal <UNSEAL_KEY_2>\nkubectl exec --namespace vault vault-0 -- vault operator unseal <UNSEAL_KEY_3>\nkubectl exec --namespace vault vault-1 -- vault operator raft join http://vault-0.vault-internal:8200\nkubectl exec --namespace vault vault-1 -- vault operator unseal <UNSEAL_KEY_1>\nkubectl exec --namespace vault vault-1 -- vault operator unseal <UNSEAL_KEY_2>\nkubectl exec --namespace vault vault-1 -- vault operator unseal <UNSEAL_KEY_3>\n```\nRepeat for vault-2. **Persist the unseal keys and root token in a secret manager off-cluster (1Password, AWS Secrets Manager) before tearing down your shell.** Losing them is unrecoverable."
+      },
+      {
+        "title": "Configure auto-unseal (recommended for production)",
+        "description": "Manual unseal at every pod restart is impractical for production. Configure auto-unseal via a cloud KMS so Vault unseals itself on startup. Each cloud provider has a stanza under 'server.ha.config'. AWS KMS example:\n```yaml\nserver:\n  ha:\n    config: |\n      ui = true\n      listener \"tcp\" {\n        tls_disable = 1\n        address = \"[::]:8200\"\n        cluster_address = \"[::]:8201\"\n      }\n      storage \"raft\" {\n        path = \"/vault/data\"\n      }\n      seal \"awskms\" {\n        region     = \"us-east-1\"\n        kms_key_id = \"arn:aws:kms:us-east-1:111111111111:key/abc-123\"\n      }\n```\nGCP KMS, Azure Key Vault, OCI Vault, Transit (another Vault), and AliCloud KMS are also supported. See the Vault Auto-Unseal docs for the exact config syntax for each provider."
+      },
+      {
+        "title": "Access the Vault UI and API",
+        "description": "Set up port forwarding to reach the Vault UI on port 8200.\n```bash\nkubectl port-forward svc/vault --namespace vault 8200:8200\n```\nOpen http://localhost:8200 in a browser. Log in with the root token (dev mode uses 'root', HA mode uses the token printed by 'vault operator init'). The Vault CLI also works against the forwarded port:\n```bash\nexport VAULT_ADDR=http://127.0.0.1:8200\nexport VAULT_TOKEN=root\nvault status\nvault secrets list\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Vault release. This removes the StatefulSet, Service, and agent injector deployment.\n```bash\nhelm uninstall vault --namespace vault\n```"
+      },
+      {
+        "title": "Clean up persistent resources",
+        "description": "PVCs are retained by default after uninstall. Delete them to release storage.\n```bash\nkubectl delete pvc --all --namespace vault\n```"
+      },
+      {
+        "title": "Remove namespace and verify",
+        "description": "Delete the 'vault' namespace and verify it has been removed.\n```bash\nkubectl delete namespace vault\nkubectl get namespaces\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current values and Raft snapshot",
+        "description": "Export the current Helm values before upgrading. For HA deployments, take a Raft snapshot of the Vault data so a rollback is possible.\n```bash\nhelm get values vault --namespace vault > vault-backup.yaml\nkubectl exec --namespace vault vault-0 -- vault operator raft snapshot save /tmp/raft-snapshot.snap\nkubectl cp vault/vault-0:/tmp/raft-snapshot.snap ./raft-snapshot.snap\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the HashiCorp Helm repository to pick up the latest chart.\n```bash\nhelm repo update\nhelm search repo hashicorp/vault --versions | head -5\n```"
+      },
+      {
+        "title": "Upgrade Vault",
+        "description": "Upgrade the release to the desired chart version. For HA deployments, the chart uses an OnDelete update strategy so you must manually delete each pod to roll out the new image. Always upgrade and unseal one replica at a time.\n```bash\nhelm upgrade vault hashicorp/vault --namespace vault --version 0.32.0 --reuse-values\nkubectl delete pod --namespace vault vault-2\nkubectl exec --namespace vault vault-2 -- vault operator unseal <UNSEAL_KEY_1>\nkubectl exec --namespace vault vault-2 -- vault operator unseal <UNSEAL_KEY_2>\nkubectl exec --namespace vault vault-2 -- vault operator unseal <UNSEAL_KEY_3>\n```\nRepeat for vault-1, then vault-0 (the leader, which steps down before restart)."
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that all pods rolled out and Raft replication is healthy.\n```bash\nkubectl get pods -n vault\nkubectl exec --namespace vault vault-0 -- vault operator raft list-peers\nkubectl exec --namespace vault vault-0 -- vault status\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "HA pods stuck Sealed after init",
+        "description": "After 'vault operator init' on vault-0, the other replicas come up sealed and not yet members of the Raft cluster. They must join Raft and unseal individually before the cluster is healthy. Check Raft membership and unseal each follower.\n```bash\nkubectl exec --namespace vault vault-0 -- vault operator raft list-peers\nkubectl exec --namespace vault vault-1 -- vault status\nkubectl exec --namespace vault vault-1 -- vault operator raft join http://vault-0.vault-internal:8200\n```"
+      },
+      {
+        "title": "Lost unseal keys or root token",
+        "description": "If the unseal keys or root token are lost, the data is unrecoverable. There is no recovery procedure — Vault is designed this way. The only option is to redeploy and restore from a Raft snapshot taken before the loss. Always store unseal keys and the root token in an off-cluster secret manager immediately after init.\n```bash\nkubectl exec --namespace vault vault-0 -- vault operator raft snapshot save /tmp/snap\n```"
+      },
+      {
+        "title": "Pod stuck in CrashLoopBackOff with 'storage backend' errors",
+        "description": "If Vault pods crash with storage errors, the most common causes are PVC binding failures (no StorageClass), corrupted Raft snapshots, or a configured KMS auto-unseal endpoint that is unreachable. Check the logs and PVC state.\n```bash\nkubectl logs -n vault vault-0 --tail=100\nkubectl get pvc -n vault\nkubectl describe pod -n vault vault-0 | tail -20\n```"
+      },
+      {
+        "title": "Auto-unseal fails with 'access denied'",
+        "description": "If auto-unseal via cloud KMS fails, the pod's IAM identity does not have permission to use the KMS key. For AWS, the pod ServiceAccount needs an IAM role with kms:Decrypt and kms:Encrypt on the key. For GCP, the ServiceAccount needs Workload Identity bound to a GSA with cloudkms.cryptoKeyEncrypterDecrypter on the key.\n```bash\nkubectl logs -n vault vault-0 --tail=100 | grep -i seal\nkubectl describe sa -n vault vault\n```"
+      },
+      {
+        "title": "Agent injector not injecting secrets into pods",
+        "description": "If the Vault agent injector is not adding secrets to pods that have the right annotations, check that the injector is running and the pod's annotations match the expected schema.\n```bash\nkubectl get pods -n vault -l app.kubernetes.io/name=vault-agent-injector\nkubectl logs -n vault -l app.kubernetes.io/name=vault-agent-injector --tail=100\nkubectl get pod <consumer-pod> -o jsonpath='{.metadata.annotations}'\n```"
+      },
+      {
+        "title": "UI redirects to https on a port-forward setup",
+        "description": "If you forward 8200 and the UI immediately redirects to an https URL the browser cannot reach, you have TLS enabled but are pointing at http. Either disable TLS in the chart for evaluation ('global.tlsDisable=true' is set by default in the dev mode), or import the chart-generated cert into your truststore for production. Confirm what is configured.\n```bash\nhelm get values vault --namespace vault | grep -A2 tlsDisable\nkubectl get secret -n vault | grep -i tls\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful production install of Vault has three Vault pods Running in the 'vault' namespace with Raft integrated storage backed by PVCs, the cluster initialized once with the unseal keys and root token persisted to a secret manager off-cluster, auto-unseal configured via a cloud KMS so pods unseal themselves on restart, the Vault agent injector running for in-cluster secret injection, and the UI/API reachable on port 8200. From there you can mount secret engines (kv, database, pki, aws), define auth methods (kubernetes, jwt, oidc), and integrate Vault with downstream consumers via the agent injector or CSI driver.",
+      "codeSnippets": [
+        "helm repo add hashicorp https://helm.releases.hashicorp.com\nhelm repo update",
+        "helm install vault hashicorp/vault --version 0.32.0 \\\n  --namespace vault --create-namespace \\\n  --set 'server.dev.enabled=true' \\\n  --set 'server.dev.devRootToken=root'",
+        "kubectl get pods --namespace vault",
+        "kubectl exec --namespace vault vault-0 -- vault operator init -key-shares=5 -key-threshold=3",
+        "kubectl exec --namespace vault vault-0 -- vault operator unseal <UNSEAL_KEY_1>",
+        "kubectl port-forward svc/vault --namespace vault 8200:8200"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "security"
+    ],
+    "cncfProjects": [
+      "vault"
+    ],
+    "targetResourceKinds": [
+      "StatefulSet",
+      "Deployment",
+      "Service",
+      "Secret",
+      "PersistentVolumeClaim",
+      "ServiceAccount",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "projectVersion": "v1.21.2",
+    "containerImages": [
+      "docker.io/hashicorp/vault:1.21.2",
+      "docker.io/hashicorp/vault-k8s:1.7.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://developer.hashicorp.com/vault/docs",
+      "repo": "https://github.com/hashicorp/vault-helm",
+      "helm": "https://helm.releases.hashicorp.com"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "A default StorageClass is required for the Raft data PVCs in HA mode. For production, plan an off-cluster secret manager for the unseal keys and root token, configure auto-unseal via a cloud KMS (AWS KMS, GCP KMS, Azure Key Vault, OCI Vault, or another Vault's transit engine) to avoid manual unseal at every restart, and budget at least 3 replicas for the HA Raft consensus group. Helm and kubectl must be installed locally."
+  },
+  "security": {
+    "scannedAt": "2026-05-17T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## Description

Adds a guided install mission for **HashiCorp Vault**, the industry-standard tool for secrets management, encryption-as-a-service, and identity-based access.

The [`kubestellar.io/docs/console/knowledge-base`](https://kubestellar.io/docs/console/knowledge-base) page lists Vault under Security & Policy with **Install Mission: Yes**, but no `install-vault.json` existed in `console-kb` until this PR. (The pre-existing `install-bank-vaults.json` covers the Banzai Cloud bank-vaults wrapper, which is a separate project; this mission targets HashiCorp Vault directly.)

## What the mission covers

- Helm install of chart `0.32.0` (Vault app version `1.21.2`) in **dev mode** for fast bootstrap
- Pod and service verification
- Test secret write/read with the dev root token
- **Switch to HA mode with Raft integrated storage** (3 replicas, durable PVC-backed storage)
- Initialize the cluster and unseal each replica (5-key Shamir, threshold 3)
- **Auto-unseal via cloud KMS** for production (AWS KMS, GCP KMS, Azure Key Vault, Transit)
- Vault UI access on port 8200
- Three-step uninstall (helm uninstall + PVC cleanup + namespace delete)
- Four-step upgrade (Raft snapshot + repo update + helm upgrade + one-pod-at-a-time rollout with manual unseal)
- Six troubleshooting entries: HA pods stuck Sealed, lost unseal keys (unrecoverable), CrashLoopBackOff on storage errors, auto-unseal IAM failures, agent injector not injecting, UI redirecting to https

## Validation

```text
$ node scripts/validate-schema.mjs fixes/cncf-install/install-vault.json
✅ Valid kc-mission-v1

$ node scripts/test-kb-quality-ci.mjs fixes/cncf-install/install-vault.json
Score: 100/100

$ node scripts/scan-pr.mjs fixes/cncf-install/install-vault.json
✅ Schema · ✅ Sensitive data · ✅ Security
