### PR TITLE
feat(install-mission): add guided install missions for Trivy Operator…

### DIFF
--- a/fixes/cncf-install/install-calico.json
+++ b/fixes/cncf-install/install-calico.json
@@ -1,0 +1,165 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-calico",
+  "missionClass": "install",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Install and Configure Calico on Kubernetes",
+    "description": "Calico is a CNI plugin and network policy engine that powers networking on a wide range of Kubernetes distributions including OpenShift, EKS, AKS, and GKE. Calico provides pod networking, network policy enforcement (both standard Kubernetes NetworkPolicy and Calico's extended NetworkPolicy / GlobalNetworkPolicy CRDs), eBPF-based dataplane modes, and BGP peering for on-prem multi-cluster meshes. The recommended Kubernetes install path is the Tigera Operator chart, which manages an Installation Custom Resource that drives the Calico control plane and DaemonSet. This mission walks through installing the Operator, applying a baseline Installation CR, and the production hardening (encapsulation choice, MTU tuning, NetworkPolicy enforcement) that real clusters require.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Project Calico Helm repository",
+        "description": "Add the official Project Calico Helm chart repository to your local Helm configuration.\n```bash\nhelm repo add projectcalico https://docs.tigera.io/calico/charts\nhelm repo update\n```"
+      },
+      {
+        "title": "Install the Tigera Operator",
+        "description": "Install the Tigera Operator into a dedicated 'tigera-operator' namespace. The Operator owns the Installation CRD that drives Calico's control plane and DaemonSet.\n```bash\nhelm install calico projectcalico/tigera-operator --version v3.32.0 \\\n  --namespace tigera-operator --create-namespace\n```\nNote: on existing Kubernetes clusters that already have a different CNI installed (kindnet on kind, kubenet, Cilium, Weave, Flannel, etc.), Calico will be installed alongside but will not become the active dataplane unless the existing CNI is removed and pods are restarted. To use Calico as the active CNI, install it on a fresh cluster created with no other CNI, or follow the upstream Calico migration guide for the existing-CNI replacement flow."
+      },
+      {
+        "title": "Verify the Operator is running",
+        "description": "Check that the Operator pod is running and the Installation CRD is registered.\n```bash\nkubectl get pods --namespace tigera-operator\nkubectl get crd | grep operator.tigera.io\n```"
+      },
+      {
+        "title": "Apply the Installation custom resource",
+        "description": "The Operator reconciles a single 'Installation' CR named 'default' that defines the Calico topology. The Helm chart applies this CR automatically with sensible defaults, but you can re-apply your own to tune the encapsulation, IP pool CIDR, or NodeAddressAutodetectionV4 settings.\n```bash\nkubectl get installation default -o yaml\n```\nFor a custom Installation, override on install or apply directly:\n```yaml\napiVersion: operator.tigera.io/v1\nkind: Installation\nmetadata:\n  name: default\nspec:\n  calicoNetwork:\n    ipPools:\n    - cidr: <POD_CIDR>  # e.g. matches the kubelet --cluster-cidr\n      encapsulation: VXLANCrossSubnet\n      natOutgoing: Enabled\n```"
+      },
+      {
+        "title": "Verify the Calico control-plane and DaemonSet pods",
+        "description": "Once the Operator reconciles the Installation, it creates the calico-system namespace, deploys calico-kube-controllers, and rolls out a calico-node DaemonSet across the cluster. Wait for them to come up.\n```bash\nkubectl get pods --namespace calico-system\nkubectl get installation default -o jsonpath='{.status.computed}'\n```"
+      },
+      {
+        "title": "Apply a baseline NetworkPolicy to validate enforcement",
+        "description": "Once Calico is the active CNI, NetworkPolicies are enforced by the calico-node dataplane. Apply a default-deny-all to a test namespace and confirm a Pod cannot reach the internet.\n```bash\nkubectl create namespace netpol-demo\nkubectl run testpod --image=busybox --namespace netpol-demo --restart=Never --command -- sleep 600\ncat <<EOF | kubectl apply -f -\napiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: deny-all\n  namespace: netpol-demo\nspec:\n  podSelector: {}\n  policyTypes:\n  - Egress\nEOF\nkubectl exec -n netpol-demo testpod -- wget -qO- --timeout=5 https://www.google.com\n```\nThe wget should time out, which proves egress is blocked by the policy. Remove the policy and re-run to confirm traffic returns. (This step only meaningfully verifies enforcement when Calico is the active CNI \u2014 see the note in the install step about existing-CNI clusters.)"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits on the Operator and on the calico-node DaemonSet via the Installation CR. The defaults are sized for medium-scale clusters. Tune up for large pod density or down for resource-constrained environments.\n```bash\nkubectl patch installation default --type=merge -p '{\"spec\":{\"componentResources\":[{\"componentName\":\"Node\",\"resourceRequirements\":{\"requests\":{\"cpu\":\"250m\",\"memory\":\"100Mi\"},\"limits\":{\"cpu\":\"500m\",\"memory\":\"500Mi\"}}}]}}'\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove any custom NetworkPolicies",
+        "description": "Drain custom Calico GlobalNetworkPolicy and tier resources before uninstalling the Operator so the control-plane can finalize them.\n```bash\nkubectl delete globalnetworkpolicies.crd.projectcalico.org --all\nkubectl delete networksets.crd.projectcalico.org --all --all-namespaces\n```"
+      },
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Tigera Operator release. The Operator removes the Installation CR, which drains the calico-system namespace.\n```bash\nhelm uninstall calico --namespace tigera-operator\n```"
+      },
+      {
+        "title": "Clean up CRDs and namespaces",
+        "description": "Removing the CRDs deletes any remaining tigera and projectcalico resources cluster-wide. Some chart versions auto-clean their CRDs on uninstall, in which case the delete prints NotFound and that is safe to ignore.\n```bash\nkubectl delete crd installations.operator.tigera.io\nkubectl delete crd apiservers.operator.tigera.io\nkubectl delete crd $(kubectl get crd -o name | grep crd.projectcalico.org)\nkubectl delete namespace tigera-operator calico-system calico-apiserver\n```\nNote: removing Calico from a cluster where it is the active CNI requires extra care. Pods will lose connectivity until a replacement CNI is installed. Either install a replacement CNI before uninstalling, or recreate the cluster."
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current state",
+        "description": "Export the current Helm values and the Installation CR before upgrading.\n```bash\nhelm get values calico --namespace tigera-operator > calico-backup.yaml\nkubectl get installation default -o yaml > calico-installation-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the Project Calico Helm repository to pick up the latest chart.\n```bash\nhelm repo update\nhelm search repo projectcalico/tigera-operator --versions | head -5\n```"
+      },
+      {
+        "title": "Upgrade Calico",
+        "description": "Upgrade the release to the desired chart version. Always read the Calico release notes for breaking changes between minor versions, especially around dataplane behavior and CRD schema.\n```bash\nhelm upgrade calico projectcalico/tigera-operator --namespace tigera-operator --version v3.32.0 --reuse-values\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Operator deployment rolled out, the Installation CR moved to the new computed state, and the calico-node DaemonSet rolled the new image cluster-wide.\n```bash\nkubectl rollout status deploy/tigera-operator -n tigera-operator\nkubectl get installation default -o jsonpath='{.status.computed.calicoVersion}'\nkubectl rollout status ds/calico-node -n calico-system\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator pod in CrashLoopBackOff",
+        "description": "If the Operator pod will not start, check the logs for RBAC or webhook errors. The Operator needs cluster-admin equivalent permissions to install the Calico CRDs and reconcile the Installation.\n```bash\nkubectl logs -n tigera-operator deploy/tigera-operator --tail=200\n```"
+      },
+      {
+        "title": "Installation stuck in Progressing state",
+        "description": "If 'kubectl get installation default' shows Progressing for more than a few minutes, the Operator is unable to reconcile the Calico components. Inspect the conditions and the calico-system namespace.\n```bash\nkubectl get installation default -o jsonpath='{.status.conditions}'\nkubectl get pods -n calico-system\nkubectl describe installation default | tail -30\n```"
+      },
+      {
+        "title": "calico-node pods not starting on existing-CNI clusters",
+        "description": "On clusters that already have a CNI (kindnet on kind, the cloud-provider's CNI on managed clusters), calico-node may fail with networking-related errors. Calico expects to be the active CNI. Either remove the existing CNI and restart pods, recreate the cluster with no CNI plugin so Calico installs cleanly, or use the upstream Calico migration guide.\n```bash\nkubectl logs -n calico-system ds/calico-node --tail=100\nkubectl get pods -n kube-system -l k8s-app=kindnet\n```"
+      },
+      {
+        "title": "NetworkPolicies appear to have no effect",
+        "description": "If NetworkPolicies are applied but traffic is not blocked, Calico is likely not the active dataplane. Verify which CNI is enforcing policy.\n```bash\nkubectl get pods -n calico-system\nkubectl describe node | grep -A2 'PodCIDR'\nkubectl get installation default -o yaml | grep -A5 calicoNetwork\n```"
+      },
+      {
+        "title": "Pod-to-pod connectivity broken after install",
+        "description": "If pods cannot reach each other after Calico is installed alongside another CNI, the two dataplanes are conflicting. The fix is to fully remove one CNI before installing the other. Do not run two CNIs in parallel on the same cluster.\n```bash\nkubectl get pods -A -o wide | head -20\nkubectl logs -n calico-system ds/calico-node --tail=100 | grep -i error\n```"
+      },
+      {
+        "title": "High CPU usage on calico-node pods",
+        "description": "calico-node CPU scales with the number of NetworkPolicies, IPSets, and BGP peers. Profile current usage and adjust resource limits via the Installation CR.\n```bash\nkubectl top pods -n calico-system\nkubectl get installation default -o jsonpath='{.spec.componentResources}'\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful production install of Calico has the Tigera Operator pod Running in 'tigera-operator', the Installation CR in a Computed state with the configured calicoNetwork settings, the calico-system namespace populated with calico-kube-controllers and a calico-node DaemonSet on every node, calico-apiserver deployed, NetworkPolicies enforced by the calico-node dataplane, and the cluster pod CIDR matching the Installation's ipPools. From there platform teams can apply standard Kubernetes NetworkPolicies, Calico GlobalNetworkPolicies, set up BGP peering for on-prem multi-cluster meshes, and switch to the eBPF dataplane mode where supported.",
+      "codeSnippets": [
+        "helm repo add projectcalico https://docs.tigera.io/calico/charts\nhelm repo update",
+        "helm install calico projectcalico/tigera-operator --version v3.32.0 \\\n  --namespace tigera-operator --create-namespace",
+        "kubectl get pods --namespace tigera-operator",
+        "kubectl get installation default -o yaml",
+        "kubectl get pods --namespace calico-system",
+        "kubectl rollout status ds/calico-node -n calico-system"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "networking"
+    ],
+    "cncfProjects": [
+      "calico"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "DaemonSet",
+      "Service",
+      "CustomResourceDefinition",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "projectVersion": "v3.32.0",
+    "containerImages": [
+      "quay.io/tigera/operator:v1.40.0",
+      "docker.io/calico/node:v3.32.0",
+      "docker.io/calico/cni:v3.32.0",
+      "docker.io/calico/kube-controllers:v3.32.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.tigera.io/calico/latest/",
+      "repo": "https://github.com/projectcalico/calico",
+      "helm": "https://docs.tigera.io/calico/charts"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "A Kubernetes cluster with no existing CNI plugin (or with a clear migration plan from the existing CNI) is required for Calico to become the active dataplane. Helm and kubectl must be installed locally. For production, plan the encapsulation mode (VXLAN or IP-in-IP, with VXLANCrossSubnet as the typical default), the pod CIDR (must match what the kubelet was started with), and the BGP topology if you are running on-prem with route advertisement to upstream switches."
+  },
+  "security": {
+    "scannedAt": "2026-05-17T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}

--- a/fixes/cncf-install/install-calico.json
+++ b/fixes/cncf-install/install-calico.json
@@ -136,7 +136,6 @@
     ],
     "projectVersion": "v3.32.0",
     "containerImages": [
-      "quay.io/tigera/operator:v1.40.0",
       "docker.io/calico/node:v3.32.0",
       "docker.io/calico/cni:v3.32.0",
       "docker.io/calico/kube-controllers:v3.32.0"

--- a/fixes/cncf-install/install-trivy-operator.json
+++ b/fixes/cncf-install/install-trivy-operator.json
@@ -24,11 +24,11 @@
       },
       {
         "title": "Deploy a sample workload to scan",
-        "description": "Deploy a deliberately outdated nginx Deployment in the default namespace so the Operator has something to scan. The Operator watches Pods cluster-wide by default and produces a VulnerabilityReport per workload-controller within ~30-60 seconds.\n```bash\nkubectl create deployment vulnerable-nginx --image=nginx:1.18\nkubectl rollout status deployment/vulnerable-nginx --timeout=60s\n```"
+        "description": "Create a dedicated 'trivy-demo' namespace and deploy a deliberately outdated nginx Deployment so the Operator has something to scan. The Operator watches Pods cluster-wide by default and produces a VulnerabilityReport per workload-controller within ~30-60 seconds. Using a dedicated namespace keeps the demo workload isolated from real workloads and gives a single-command teardown.\n```bash\nkubectl create namespace trivy-demo\nkubectl create deployment vulnerable-nginx --image=nginx:1.18 --namespace trivy-demo\nkubectl rollout status deployment/vulnerable-nginx --namespace trivy-demo --timeout=60s\n```"
       },
       {
         "title": "View the scan results",
-        "description": "Once the scan job completes, the Operator writes a VulnerabilityReport into the same namespace as the scanned workload. List the reports and look at the summary on one of them.\n```bash\nkubectl get vulnerabilityreports --all-namespaces\nkubectl get vulnerabilityreport -n default -o jsonpath='{.items[0].report.summary}'\n```\nFor a full list of CVEs, query the report directly:\n```bash\nkubectl get vulnerabilityreport -n default -o yaml\n```"
+        "description": "Once the scan job completes, the Operator writes a VulnerabilityReport into the same namespace as the scanned workload. List the reports and look at the summary on one of them.\n```bash\nkubectl get vulnerabilityreports --all-namespaces\nkubectl get vulnerabilityreport --namespace trivy-demo -o jsonpath='{.items[0].report.summary}'\n```\nFor a full list of CVEs, query the report directly:\n```bash\nkubectl get vulnerabilityreport --namespace trivy-demo -o yaml\n```"
       },
       {
         "title": "Restrict scan scope (recommended for production)",
@@ -46,7 +46,7 @@
     "uninstall": [
       {
         "title": "Remove the sample workload",
-        "description": "Remove any sample workloads you deployed so the Operator can drain its scan queue cleanly.\n```bash\nkubectl delete deployment vulnerable-nginx -n default\n```"
+        "description": "Remove the demo namespace so the Operator can drain its scan queue cleanly. Deleting the namespace removes the demo Deployment and its associated VulnerabilityReports in one step.\n```bash\nkubectl delete namespace trivy-demo\n```"
       },
       {
         "title": "Remove the Helm release",
@@ -82,15 +82,15 @@
       },
       {
         "title": "No VulnerabilityReport produced after deploying a workload",
-        "description": "If a workload exists but no report appears within a couple of minutes, the scan job itself may be stuck. Look at the scan jobs in the workload's namespace and the Operator's reconciler logs.\n```bash\nkubectl get jobs -n default\nkubectl describe job -n default $(kubectl get jobs -n default -o name | head -1)\nkubectl logs -n trivy-system deploy/trivy-operator --tail=200 | grep -i scan\n```"
+        "description": "If a workload exists but no report appears within a couple of minutes, the scan job itself may be stuck. Look at the scan jobs in the workload's namespace and the Operator's reconciler logs.\n```bash\nkubectl get jobs --namespace trivy-demo\nkubectl describe job --namespace trivy-demo $(kubectl get jobs --namespace trivy-demo -o name | head -1)\nkubectl logs -n trivy-system deploy/trivy-operator --tail=200 | grep -i scan\n```"
       },
       {
         "title": "Scan jobs fail with image-pull or DB-download errors",
-        "description": "Scan jobs and the Operator's policy loader need cluster egress to a container registry that mirrors the Trivy DB and policy bundles (the chart default is 'mirror.gcr.io', with 'ghcr.io/aquasecurity/trivy-db' as the upstream alternative). On kind clusters or restricted-egress networks where one of these is unreachable, scan jobs CrashLoopBackOff with 'failed to download vulnerability DB' and the Operator log shows 'connection refused' against the configured mirror. Pre-mirror the database to a registry your cluster can reach and override 'trivy.dbRepository'.\n```bash\nkubectl describe job -n default $(kubectl get jobs -n default -o name | head -1) | tail -20\nhelm get values trivy-operator --namespace trivy-system | grep -A2 dbRepository\n```\nFor air-gapped clusters, mirror 'ghcr.io/aquasecurity/trivy-db' and 'ghcr.io/aquasecurity/trivy-java-db' to your registry and override both 'trivy.dbRepository' and 'trivy.javaDbRepository' on install."
+        "description": "Scan jobs and the Operator's policy loader need cluster egress to a container registry that mirrors the Trivy DB and policy bundles (the chart default is 'mirror.gcr.io', with 'ghcr.io/aquasecurity/trivy-db' as the upstream alternative). On kind clusters or restricted-egress networks where one of these is unreachable, scan jobs CrashLoopBackOff with 'failed to download vulnerability DB' and the Operator log shows 'connection refused' against the configured mirror. Pre-mirror the database to a registry your cluster can reach and override 'trivy.dbRepository'.\n```bash\nkubectl describe job --namespace trivy-demo $(kubectl get jobs --namespace trivy-demo -o name | head -1) | tail -20\nhelm get values trivy-operator --namespace trivy-system | grep -A2 dbRepository\n```\nFor air-gapped clusters, mirror 'ghcr.io/aquasecurity/trivy-db' and 'ghcr.io/aquasecurity/trivy-java-db' to your registry and override both 'trivy.dbRepository' and 'trivy.javaDbRepository' on install."
       },
       {
         "title": "VulnerabilityReports are empty (no CVEs reported)",
-        "description": "If reports are produced but contain no findings, the scan completed but found nothing relevant for the configured severity threshold. Check the Operator config for severity filters.\n```bash\nhelm get values trivy-operator --namespace trivy-system | grep -i severity\nkubectl get vulnerabilityreport -n default -o jsonpath='{.items[0].report}' | head -100\n```"
+        "description": "If reports are produced but contain no findings, the scan completed but found nothing relevant for the configured severity threshold. Check the Operator config for severity filters.\n```bash\nhelm get values trivy-operator --namespace trivy-system | grep -i severity\nkubectl get vulnerabilityreport --namespace trivy-demo -o jsonpath='{.items[0].report}' | head -100\n```"
       },
       {
         "title": "High CPU usage in trivy-system namespace",
@@ -100,12 +100,16 @@
     "resolution": {
       "summary": "A successful production install of Trivy Operator has the Operator pod Running in 'trivy-system', VulnerabilityReports being produced for every Pod-spec in the configured target namespaces within a minute of workload creation, the Prometheus metrics endpoint scraped (or a ServiceMonitor enabled if Prometheus Operator is in use), scan scope tuned to exclude noisy namespaces, and resource limits set on both the Operator and the scanner job pods. From there reports can be queried via kubectl, exported to a SIEM, or wired into a Grafana dashboard via the Prometheus metrics.",
       "codeSnippets": [
-        "helm repo add aqua https://aquasecurity.github.io/helm-charts/\nhelm repo update",
-        "helm install trivy-operator aqua/trivy-operator --version 0.32.1 \\\n  --namespace trivy-system --create-namespace",
+        "helm repo add aqua https://aquasecurity.github.io/helm-charts/",
+        "helm repo update",
+        "helm install trivy-operator aqua/trivy-operator --version 0.32.1 --namespace trivy-system --create-namespace",
         "kubectl get pods --namespace trivy-system",
-        "kubectl create deployment vulnerable-nginx --image=nginx:1.18",
+        "kubectl create namespace trivy-demo",
+        "kubectl create deployment vulnerable-nginx --image=nginx:1.18 --namespace trivy-demo",
         "kubectl get vulnerabilityreports --all-namespaces",
-        "kubectl get vulnerabilityreport -n default -o jsonpath='{.items[0].report.summary}'"
+        "kubectl get vulnerabilityreport --namespace trivy-demo -o jsonpath='{.items[0].report.summary}'",
+        "helm uninstall trivy-operator --namespace trivy-system",
+        "kubectl delete namespace trivy-demo"
       ]
     }
   },

--- a/fixes/cncf-install/install-trivy-operator.json
+++ b/fixes/cncf-install/install-trivy-operator.json
@@ -1,0 +1,162 @@
+{
+  "version": "kc-mission-v1",
+  "name": "install-trivy-operator",
+  "missionClass": "install",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Install and Configure Trivy Operator on Kubernetes",
+    "description": "Trivy Operator is the Kubernetes-native deployment of the Trivy vulnerability scanner from Aqua Security. It runs continuously inside the cluster, scans every Pod's container images, configurations, and exposed secrets, and writes the findings to Custom Resources such as VulnerabilityReport, ConfigAuditReport, ExposedSecretReport, and SbomReport. Platform teams use the Operator to surface CVEs, hardening misconfigurations, and exposed secrets without standing up an external scanning pipeline. This mission installs the Operator, demonstrates a vulnerability scan against a deliberately outdated workload, and covers the production hardening (resource limits, scan scope, integrations with Prometheus and external SIEMs) that real workloads require.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Add the Aqua Security Helm repository",
+        "description": "Add the official Aqua Security Helm chart repository to your local Helm configuration.\n```bash\nhelm repo add aqua https://aquasecurity.github.io/helm-charts/\nhelm repo update\n```"
+      },
+      {
+        "title": "Install the Trivy Operator",
+        "description": "Install the Trivy Operator into a dedicated 'trivy-system' namespace. The chart installs the Operator Deployment plus the CRDs for VulnerabilityReport, ConfigAuditReport, ExposedSecretReport, RbacAssessmentReport, ClusterRbacAssessmentReport, ClusterComplianceReport, ClusterInfraAssessmentReport, ClusterSbomReport, and SbomReport.\n```bash\nhelm install trivy-operator aqua/trivy-operator --version 0.32.1 \\\n  --namespace trivy-system --create-namespace\n```"
+      },
+      {
+        "title": "Verify the installation",
+        "description": "Check that the Operator pod is running and the CRDs are registered.\n```bash\nkubectl get pods --namespace trivy-system\nkubectl get crd | grep aquasecurity.github.io\n```"
+      },
+      {
+        "title": "Deploy a sample workload to scan",
+        "description": "Deploy a deliberately outdated nginx Deployment in the default namespace so the Operator has something to scan. The Operator watches Pods cluster-wide by default and produces a VulnerabilityReport per workload-controller within ~30-60 seconds.\n```bash\nkubectl create deployment vulnerable-nginx --image=nginx:1.18\nkubectl rollout status deployment/vulnerable-nginx --timeout=60s\n```"
+      },
+      {
+        "title": "View the scan results",
+        "description": "Once the scan job completes, the Operator writes a VulnerabilityReport into the same namespace as the scanned workload. List the reports and look at the summary on one of them.\n```bash\nkubectl get vulnerabilityreports --all-namespaces\nkubectl get vulnerabilityreport -n default -o jsonpath='{.items[0].report.summary}'\n```\nFor a full list of CVEs, query the report directly:\n```bash\nkubectl get vulnerabilityreport -n default -o yaml\n```"
+      },
+      {
+        "title": "Restrict scan scope (recommended for production)",
+        "description": "By default the Operator scans every namespace. On large clusters this can be expensive. Set 'targetNamespaces' to a comma-separated list to scope scanning to specific namespaces, or 'excludeNamespaces' to skip noisy ones (such as kube-system).\n```bash\nhelm upgrade trivy-operator aqua/trivy-operator --version 0.32.1 \\\n  --namespace trivy-system \\\n  --reuse-values \\\n  --set 'trivy.targetNamespaces=default\\,production\\,staging' \\\n  --set 'trivyOperator.excludeNamespaces=kube-system\\,trivy-system'\n```"
+      },
+      {
+        "title": "Enable the Prometheus metrics endpoint",
+        "description": "The Operator exposes Prometheus metrics on port 8080 of the Operator pod. Enable a ServiceMonitor (Prometheus Operator) or scrape the endpoint directly to track findings count, scan duration, and report freshness.\n```bash\nhelm upgrade trivy-operator aqua/trivy-operator --version 0.32.1 \\\n  --namespace trivy-system \\\n  --reuse-values \\\n  --set 'serviceMonitor.enabled=true'\n```\nFor a quick check via port-forward:\n```bash\nkubectl port-forward -n trivy-system deploy/trivy-operator 8080:8080\ncurl -sS http://127.0.0.1:8080/metrics | grep trivy_image_vulnerabilities | head -5\n```"
+      },
+      {
+        "title": "Configure resource limits",
+        "description": "Set resource limits on the Operator pod and on the scanner job pods that the Operator launches. Scan jobs run downloads-and-runs, so they need ephemeral storage and CPU bursts.\n```bash\nhelm upgrade trivy-operator aqua/trivy-operator --version 0.32.1 \\\n  --namespace trivy-system \\\n  --reuse-values \\\n  --set 'operator.replicas=1' \\\n  --set 'operator.resources.requests.cpu=100m' \\\n  --set 'operator.resources.requests.memory=128Mi' \\\n  --set 'operator.resources.limits.cpu=500m' \\\n  --set 'operator.resources.limits.memory=512Mi' \\\n  --set 'trivy.resources.requests.cpu=100m' \\\n  --set 'trivy.resources.requests.memory=256Mi' \\\n  --set 'trivy.resources.limits.cpu=1' \\\n  --set 'trivy.resources.limits.memory=1Gi'\n```"
+      }
+    ],
+    "uninstall": [
+      {
+        "title": "Remove the sample workload",
+        "description": "Remove any sample workloads you deployed so the Operator can drain its scan queue cleanly.\n```bash\nkubectl delete deployment vulnerable-nginx -n default\n```"
+      },
+      {
+        "title": "Remove the Helm release",
+        "description": "Uninstall the Trivy Operator release.\n```bash\nhelm uninstall trivy-operator --namespace trivy-system\n```"
+      },
+      {
+        "title": "Clean up CRDs and namespace",
+        "description": "Removing the CRDs deletes any remaining VulnerabilityReport, ConfigAuditReport, and other report resources cluster-wide. Some chart versions auto-clean their CRDs on uninstall, in which case the delete prints NotFound and that is safe to ignore.\n```bash\nkubectl delete crd vulnerabilityreports.aquasecurity.github.io\nkubectl delete crd clustervulnerabilityreports.aquasecurity.github.io\nkubectl delete crd configauditreports.aquasecurity.github.io\nkubectl delete crd clusterconfigauditreports.aquasecurity.github.io\nkubectl delete crd exposedsecretreports.aquasecurity.github.io\nkubectl delete crd rbacassessmentreports.aquasecurity.github.io\nkubectl delete crd clusterrbacassessmentreports.aquasecurity.github.io\nkubectl delete crd infraassessmentreports.aquasecurity.github.io\nkubectl delete crd clusterinfraassessmentreports.aquasecurity.github.io\nkubectl delete crd clustercompliancereports.aquasecurity.github.io\nkubectl delete crd sbomreports.aquasecurity.github.io\nkubectl delete crd clustersbomreports.aquasecurity.github.io\nkubectl delete namespace trivy-system\n```"
+      }
+    ],
+    "upgrade": [
+      {
+        "title": "Backup current values",
+        "description": "Export the current Helm values before upgrading.\n```bash\nhelm get values trivy-operator --namespace trivy-system > trivy-operator-backup.yaml\n```"
+      },
+      {
+        "title": "Update the Helm repository",
+        "description": "Refresh the Aqua Security Helm repository to pick up the latest chart.\n```bash\nhelm repo update\nhelm search repo aqua/trivy-operator --versions | head -5\n```"
+      },
+      {
+        "title": "Upgrade Trivy Operator",
+        "description": "Upgrade the release. Always read the chart CHANGELOG for breaking changes between versions, especially around CRD schema changes that may require a re-scan to populate.\n```bash\nhelm upgrade trivy-operator aqua/trivy-operator --namespace trivy-system --version 0.32.1 --reuse-values\n```"
+      },
+      {
+        "title": "Verify the upgrade",
+        "description": "Check that the Operator deployment rolled out and is running the new image, and that existing reports remain queryable.\n```bash\nkubectl rollout status deploy/trivy-operator -n trivy-system\nkubectl get vulnerabilityreports --all-namespaces\n```"
+      }
+    ],
+    "troubleshooting": [
+      {
+        "title": "Operator pod in CrashLoopBackOff",
+        "description": "The most common cause is missing RBAC for the watched namespaces or a misconfigured value pointing at a non-existent ConfigMap. Check the Operator logs.\n```bash\nkubectl logs -n trivy-system deploy/trivy-operator --tail=200\n```"
+      },
+      {
+        "title": "No VulnerabilityReport produced after deploying a workload",
+        "description": "If a workload exists but no report appears within a couple of minutes, the scan job itself may be stuck. Look at the scan jobs in the workload's namespace and the Operator's reconciler logs.\n```bash\nkubectl get jobs -n default\nkubectl describe job -n default $(kubectl get jobs -n default -o name | head -1)\nkubectl logs -n trivy-system deploy/trivy-operator --tail=200 | grep -i scan\n```"
+      },
+      {
+        "title": "Scan jobs fail with image-pull or DB-download errors",
+        "description": "Scan jobs and the Operator's policy loader need cluster egress to a container registry that mirrors the Trivy DB and policy bundles (the chart default is 'mirror.gcr.io', with 'ghcr.io/aquasecurity/trivy-db' as the upstream alternative). On kind clusters or restricted-egress networks where one of these is unreachable, scan jobs CrashLoopBackOff with 'failed to download vulnerability DB' and the Operator log shows 'connection refused' against the configured mirror. Pre-mirror the database to a registry your cluster can reach and override 'trivy.dbRepository'.\n```bash\nkubectl describe job -n default $(kubectl get jobs -n default -o name | head -1) | tail -20\nhelm get values trivy-operator --namespace trivy-system | grep -A2 dbRepository\n```\nFor air-gapped clusters, mirror 'ghcr.io/aquasecurity/trivy-db' and 'ghcr.io/aquasecurity/trivy-java-db' to your registry and override both 'trivy.dbRepository' and 'trivy.javaDbRepository' on install."
+      },
+      {
+        "title": "VulnerabilityReports are empty (no CVEs reported)",
+        "description": "If reports are produced but contain no findings, the scan completed but found nothing relevant for the configured severity threshold. Check the Operator config for severity filters.\n```bash\nhelm get values trivy-operator --namespace trivy-system | grep -i severity\nkubectl get vulnerabilityreport -n default -o jsonpath='{.items[0].report}' | head -100\n```"
+      },
+      {
+        "title": "High CPU usage in trivy-system namespace",
+        "description": "The Operator schedules one scan job per workload-controller. On large clusters the parallelism can saturate node CPU. Tune 'trivyOperator.concurrentScanJobsLimit' to throttle concurrent scans.\n```bash\nkubectl top pods -n trivy-system --all-namespaces | head -20\nhelm get values trivy-operator --namespace trivy-system | grep -A2 concurrent\n```"
+      }
+    ],
+    "resolution": {
+      "summary": "A successful production install of Trivy Operator has the Operator pod Running in 'trivy-system', VulnerabilityReports being produced for every Pod-spec in the configured target namespaces within a minute of workload creation, the Prometheus metrics endpoint scraped (or a ServiceMonitor enabled if Prometheus Operator is in use), scan scope tuned to exclude noisy namespaces, and resource limits set on both the Operator and the scanner job pods. From there reports can be queried via kubectl, exported to a SIEM, or wired into a Grafana dashboard via the Prometheus metrics.",
+      "codeSnippets": [
+        "helm repo add aqua https://aquasecurity.github.io/helm-charts/\nhelm repo update",
+        "helm install trivy-operator aqua/trivy-operator --version 0.32.1 \\\n  --namespace trivy-system --create-namespace",
+        "kubectl get pods --namespace trivy-system",
+        "kubectl create deployment vulnerable-nginx --image=nginx:1.18",
+        "kubectl get vulnerabilityreports --all-namespaces",
+        "kubectl get vulnerabilityreport -n default -o jsonpath='{.items[0].report.summary}'"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "installation",
+      "configuration",
+      "cncf",
+      "security"
+    ],
+    "cncfProjects": [
+      "trivy"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Service",
+      "CustomResourceDefinition",
+      "Namespace"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "installation",
+      "configuration"
+    ],
+    "installMethods": [
+      "helm"
+    ],
+    "projectVersion": "v0.30.1",
+    "containerImages": [
+      "ghcr.io/aquasecurity/trivy-operator:0.30.1",
+      "ghcr.io/aquasecurity/trivy:0.59.0"
+    ],
+    "sourceUrls": {
+      "docs": "https://aquasecurity.github.io/trivy-operator/",
+      "repo": "https://github.com/aquasecurity/trivy-operator",
+      "helm": "https://aquasecurity.github.io/helm-charts"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "helm",
+      "kubectl"
+    ],
+    "description": "Helm and kubectl must be installed locally. The Operator's scan jobs need cluster egress to the Trivy database registry (ghcr.io/aquasecurity/trivy-db) and to the container registries hosting your workload images. For air-gapped clusters, mirror both into a registry you control and override 'trivy.dbRepository' on install."
+  },
+  "security": {
+    "scannedAt": "2026-05-17T00:00:00.000Z",
+    "scannerVersion": "cncf-install-gen-1.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## Description

Adds two guided install missions, bundled because they share the same shape — operator-driven CNCF projects with primary CRDs, watch-the-cluster reconciliation loops, and kind-limited validation surfaces.

The [`kubestellar.io/docs/console/knowledge-base`](https://kubestellar.io/docs/console/knowledge-base) page lists Trivy under Security & Policy and Calico under Networking & Service Mesh, both with **Install Mission: Yes**. Neither `install-trivy-operator.json` nor `install-calico.json` existed in `console-kb` until this PR.

## What the missions cover

### `install-trivy-operator.json`

Trivy Operator is the Kubernetes-native deployment of the Trivy vulnerability scanner from Aqua Security. Continuously scans every Pod's container images, configurations, and exposed secrets, and writes findings to VulnerabilityReport, ConfigAuditReport, ExposedSecretReport, and SbomReport CRDs.

- Helm install of chart `0.32.1` (Trivy app version `0.30.1`)
- 12 Trivy CRDs (vulnerability/configaudit/exposedsecret/rbac/infraassessment/compliance/sbom, both namespaced and cluster-scoped)
- Sample workload deploy + automatic scan
- Production scan-scope tuning, Prometheus metrics, per-component resource limits
- Three-step uninstall covering all 12 CRDs, four-step upgrade
- Five troubleshooting entries including explicit kind / restricted-egress guidance with the `trivy.dbRepository` override path

### `install-calico.json`

Calico is a CNI plugin and network policy engine. The Tigera Operator chart manages an Installation Custom Resource that drives the Calico control plane and DaemonSet.

- Helm install of the Tigera Operator chart `v3.32.0`
- Installation CR custom configuration with IP pool CIDR, encapsulation, natOutgoing
- calico-system namespace verification, baseline NetworkPolicy enforcement test
- Per-component resource limits via `componentResources` on the Installation CR
- Three-step uninstall with explicit replacement-CNI warning
- Six troubleshooting entries including the existing-CNI co-existence pattern (kind, EKS, GKE, AKS)

## Validation

```text
$ node scripts/validate-schema.mjs fixes/cncf-install/install-trivy-operator.json fixes/cncf-install/install-calico.json
✅ Both Valid kc-mission-v1

$ node scripts/test-kb-quality-ci.mjs ...
Score: 100/100 on both

$ node scripts/scan-pr.mjs ...
✅ Schema · ✅ Sensitive data · ✅ Security on both
