### PR TITLE
🌱 longhorn: [BUG] `snapshot-max-count` doesn't work on v2 volumes

### DIFF
--- a/fixes/cncf-generated/longhorn/longhorn-12921-bug-snapshot-max-count-doesn-t-work-on-v2-volumes.json
+++ b/fixes/cncf-generated/longhorn/longhorn-12921-bug-snapshot-max-count-doesn-t-work-on-v2-volumes.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "longhorn-12921-bug-snapshot-max-count-doesn-t-work-on-v2-volumes",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "longhorn: [BUG] `snapshot-max-count` doesn't work on v2 volumes",
+    "description": "[BUG] `snapshot-max-count` doesn't work on v2 volumes. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify longhorn troubleshoot symptoms",
+        "description": "Check for the issue in your longhorn deployment:\n```bash\nkubectl get pods -n longhorn -l app.kubernetes.io/name=longhorn\nkubectl logs -l app.kubernetes.io/name=longhorn -n longhorn --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review longhorn configuration",
+        "description": "Inspect the relevant longhorn configuration:\n```bash\nkubectl get all -n longhorn -l app.kubernetes.io/name=longhorn\nkubectl get configmap -n longhorn -l app.kubernetes.io/part-of=longhorn\n```\n### Describe the Bug\n\n`snapshot-max-count` doesn't work on v2 volumes."
+      },
+      {
+        "title": "Apply the fix for [BUG] `snapshot-max-count` doesn't work on v2 volumes",
+        "description": "## Pre Ready-For-Testing Checklist\n\n    Where are the reproduction or test steps documented?\n    Link:\n\n1. Set `Snapshot Maximum Count` to 2\n2. Create a v2 volume and attach it\n3. Take 3 snapshots, the third snapshot is not created successfully\n4. The failed snapshot status looks like \n```yaml\n   \n```yaml\n\"status\": {\n        \"checksum\": \"\",\n        \"children\": null,\n        \"creationTime\": \"\",\n        \"error\": \"proxyServer=192.168.85.114:8501 destination=192.168.85.114:0: failed to snapshot volume: rpc error: code = Internal desc = failed to create snapshot snap-dc37c4536fbe4cc9: failed to create snapshot snap-dc37c4536fbe4cc9: rpc error: code = Unknown desc = failed to create engine tmp-e-0 snapshot snap-dc37c4536fbe4cc9: rpc error: code = Unknown desc = snapshot count 2 is equal or larger than snapshotMaxCount 2\",\n        \"labels\": null,\n        \"markRemoved\": false,\n        \"ownerID\": \"\",\n  \n```"
+      },
+      {
+        "title": "Confirm [BUG] `snapshot-max-count` doesn't work on v2… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=longhorn -n longhorn --tail=50 --since=5m\nkubectl get events -n longhorn --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "## Pre Ready-For-Testing Checklist\n\n    Where are the reproduction or test steps documented?\n    Link:\n\n1. Set `Snapshot Maximum Count` to 2\n2. Create a v2 volume and attach it\n3. Take 3 snapshots, the third snapshot is not created successfully\n4.",
+      "codeSnippets": [
+        "\"status\": {\n        \"checksum\": \"\",\n        \"children\": null,\n        \"creationTime\": \"\",\n        \"error\": \"proxyServer=192.168.85.114:8501 destination=192.168.85.114:0: failed to snapshot volume: rpc error: code = Internal desc = failed to create snapshot snap-dc37c4536fbe4cc9: failed to create snapshot snap-dc37c4536fbe4cc9: rpc error: code = Unknown desc = failed to create engine tmp-e-0 snapshot snap-dc37c4536fbe4cc9: rpc error: code = Unknown desc = snapshot count 2 is equal or larger than snapshotMaxCount 2\",\n        \"labels\": null,\n        \"markRemoved\": false,\n        \"ownerID\": \"\",\n        \"parent\": \"\",\n        \"readyToUse\": false,\n        \"restoreSize\": 0,\n        \"size\": 0,\n        \"userCreated\": false\n    }"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "longhorn",
+      "incubating",
+      "storage",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "longhorn"
+    ],
+    "targetResourceKinds": [
+      "Node"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/longhorn/longhorn/issues/12921",
+      "repo": "https://github.com/longhorn/longhorn"
+    },
+    "reactions": 2,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with longhorn installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-18T07:32:11.033Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: longhorn — [BUG] `snapshot-max-count` doesn't work on v2 volumes

**Type:** troubleshoot | **Source:** https://github.com/longhorn/longhorn/issues/12921 (2 reactions)
**File:** `fixes/cncf-generated/longhorn/longhorn-12921-bug-snapshot-max-count-doesn-t-work-on-v2-volumes.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*