### PR TITLE
feat(runbooks): add upgrade and rollback runbooks for kubestellar-core

### DIFF
--- a/fixes/index.json
+++ b/fixes/index.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-18T13:03:05.878Z",
-  "count": 1570,
+  "generatedAt": "2026-05-18T17:44:26.210Z",
+  "count": 1572,
   "missions": [
     {
       "path": "fixes/cncf-generated/akri/akri-85-extensibility-http-protocol.json",
@@ -57004,6 +57004,50 @@
       "qualitySuggestions": []
     },
     {
+      "path": "runbooks/rollback-kubestellar-controller.json",
+      "title": "Roll back kubestellar-core to a known-good Helm revision",
+      "description": "Production-grade, idempotent runbook to revert the kubestellar-core Helm release to a previous revision after a failed or regressing upgrade. The workflow inspects the release history, picks the targe",
+      "category": "rollback-kubestellar-controller.json",
+      "missionClass": "runbook",
+      "author": "Vinay B M",
+      "authorGithub": "bmvinay7",
+      "authorAvatar": "https://github.com/bmvinay7.png",
+      "tags": [
+        "kubestellar",
+        "rollback",
+        "helm",
+        "lifecycle",
+        "controller",
+        "runbook"
+      ],
+      "cncfProjects": [
+        "kubestellar"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Pod",
+        "Service",
+        "ConfigMap"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [],
+      "type": "rollback",
+      "installMethods": [
+        "helm"
+      ],
+      "qualityScore": 100,
+      "qualityPass": true,
+      "qualityBreakdown": {
+        "clarity": 100,
+        "completeness": 100,
+        "correctness": 100,
+        "structure": 100,
+        "observability": 100
+      },
+      "qualityIssues": [],
+      "qualitySuggestions": []
+    },
+    {
       "path": "fixes/cncf-generated/rook/rook-1169-add-support-for-dynamically-resizing-volumes-provisioned-with-rook.json",
       "title": "rook: Add support for dynamically resizing volumes provisioned with Rook",
       "description": "Enable dynamic PersistentVolumeClaim (PVC) expansion for Rook-Ceph provisioned volumes. Requested by 45+ users. This feature allows resizing Ceph RBD and CephFS volumes without downtime by leveraging ",
@@ -61537,6 +61581,54 @@
       "qualitySuggestions": [
         "Include command outputs or log tailing instructions (e.g., kubectl get events/logs) to help users confirm success"
       ]
+    },
+    {
+      "path": "runbooks/upgrade-kubestellar-controller.json",
+      "title": "Upgrade KubeStellar controller via Helm with health gates and rollback readiness",
+      "description": "Production-grade, idempotent runbook to upgrade the kubestellar-core Helm release in place. The workflow records the current revision, verifies cluster and pod health before changing anything, refresh",
+      "category": "upgrade-kubestellar-controller.json",
+      "missionClass": "runbook",
+      "author": "Vinay B M",
+      "authorGithub": "bmvinay7",
+      "authorAvatar": "https://github.com/bmvinay7.png",
+      "tags": [
+        "kubestellar",
+        "upgrade",
+        "helm",
+        "lifecycle",
+        "controller",
+        "runbook"
+      ],
+      "cncfProjects": [
+        "kubestellar"
+      ],
+      "targetResourceKinds": [
+        "Deployment",
+        "Pod",
+        "Service",
+        "ConfigMap"
+      ],
+      "difficulty": "intermediate",
+      "issueTypes": [
+        "CrashLoopBackOff",
+        "ImagePullBackOff",
+        "NodeNotReady"
+      ],
+      "type": "upgrade",
+      "installMethods": [
+        "helm"
+      ],
+      "qualityScore": 100,
+      "qualityPass": true,
+      "qualityBreakdown": {
+        "clarity": 100,
+        "completeness": 100,
+        "correctness": 100,
+        "structure": 100,
+        "observability": 100
+      },
+      "qualityIssues": [],
+      "qualitySuggestions": []
     },
     {
       "path": "fixes/cncf-generated/urunc/urunc-119-create-a-document-for-knative-and-urunc.json",

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -21,6 +21,12 @@ All runbooks follow the `kc-mission-v1` schema with `missionClass: "runbook"`. T
 | File | Operation | Difficulty |
 |------|-----------|------------|
 | [`install-kubestellar-controller.json`](./install-kubestellar-cotroller.json) | Install KubeStellar core controllers via Helm (`kubestellar/kubestellar-core` chart, standalone mode). **Does NOT provision KubeFlex, ITS, or WDS.** | Intermediate |
+| [`upgrade-kubestellar-controller.json`](./upgrade-kubestellar-controller.json) | In-place Helm upgrade of `kubestellar-core` with health gates, dry-run diff, and `--atomic` rollback safety. | Intermediate |
+| [`rollback-kubestellar-controller.json`](./rollback-kubestellar-controller.json) | Helm rollback of `kubestellar-core` to a known-good revision after a failed upgrade. Pairs with `upgrade-kubestellar-controller.json`. | Intermediate |
+| [`certificate-rotation.json`](./certificate-rotation.json) | Rotate kubeadm control-plane certificates and refresh kubeconfig. Resolves preflight `EXPIRED_CREDENTIALS`. | Intermediate |
+| [`cluster-upgrade.json`](./cluster-upgrade.json) | Upgrade a kubeadm-managed cluster with health gates. | Intermediate |
+| [`node-drain.json`](./node-drain.json) | Cordon, drain, and uncordon a node for maintenance. | Beginner |
+| [`rbac-audit.json`](./rbac-audit.json) | Audit and remediate `RBAC_DENIED` with least-privilege bindings. | Beginner |
 
 > **⚠️ Deprecation notice — legacy `kubestellar/kubestellar` Helm components**
 >
@@ -32,10 +38,7 @@ All runbooks follow the `kc-mission-v1` schema with `missionClass: "runbook"`. T
 
 ## Planned Runbooks
 
-- `upgrade-kubestellar-controller.json` — Safe in-place upgrade with pre-flight checks and rollback
-- `rollback-kubestellar-controller.json` — Helm rollback with state reconciliation
 - `disaster-recovery.json` — Full cluster backup verification and restore
-- `sync-failure-triage.json` — Multi-cluster WDS→WEC propagation failure diagnosis
 
 ## Contributing a Runbook
 

--- a/runbooks/rollback-kubestellar-controller.json
+++ b/runbooks/rollback-kubestellar-controller.json
@@ -1,0 +1,180 @@
+{
+  "version": "kc-mission-v1",
+  "name": "runbook-rollback-kubestellar-controller",
+  "missionClass": "runbook",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Roll back kubestellar-core to a known-good Helm revision",
+    "description": "Production-grade, idempotent runbook to revert the kubestellar-core Helm release to a previous revision after a failed or regressing upgrade. The workflow inspects the release history, picks the target revision, runs helm rollback, waits for pods to reach Ready, and confirms the release status returned to deployed. Pair this with upgrade-kubestellar-controller as the safety net for any in-place upgrade.",
+    "type": "rollback",
+    "status": "completed",
+    "estimatedMinutes": 10,
+    "steps": [
+      {
+        "id": "step-01-cluster-access",
+        "title": "Verify cluster access and current release status",
+        "description": "Confirm the kubeconfig context resolves and the kubestellar-core release exists in kubestellar-system before doing anything destructive.",
+        "commands": [
+          "kubectl cluster-info\n",
+          "kubectl config current-context\n",
+          "helm status kubestellar-core --namespace kubestellar-system --output json | jq '{name, version, status: .info.status}'\n"
+        ],
+        "validation": "helm status kubestellar-core --namespace kubestellar-system > /dev/null 2>&1\n",
+        "failureHandling": "If kubectl cannot reach the API server, run credentials-setup first. If helm status reports no release, there is nothing to roll back. Reinstall through install-kubestellar-controller instead."
+      },
+      {
+        "id": "step-02-inspect-history",
+        "title": "Inspect the Helm revision history",
+        "description": "Print the full release history so you can identify the previous deployed revision. The most recent deployed revision before the failing upgrade is the safe rollback target. Capture this output before continuing.",
+        "commands": [
+          "helm history kubestellar-core --namespace kubestellar-system\n",
+          "helm history kubestellar-core --namespace kubestellar-system --output json | jq '[.[] | {revision, status, chart, app_version}]'\n"
+        ],
+        "validation": "helm history kubestellar-core --namespace kubestellar-system --output json | jq -e 'length > 1'\n",
+        "failureHandling": "If the history shows only one revision, there is no prior state to roll back to. Run install-kubestellar-controller's uninstall section followed by a clean reinstall instead of attempting a rollback."
+      },
+      {
+        "id": "step-03-choose-target-revision",
+        "title": "Choose and confirm the rollback target revision",
+        "description": "Set ROLLBACK_REVISION to the revision number you want to land on. The script prints the chosen revision so the operator can confirm before applying. Pick a revision whose status was deployed and that you know to be healthy.",
+        "commands": [
+          "ROLLBACK_REVISION=\"${ROLLBACK_REVISION:-}\"\nif test -z \"$ROLLBACK_REVISION\"; then\n  echo \"Set ROLLBACK_REVISION to the revision number from helm history\"\n  exit 1\nfi\necho \"Rolling back kubestellar-core to revision $ROLLBACK_REVISION\"\n",
+          "helm history kubestellar-core --namespace kubestellar-system --output json | jq --arg rev \"$ROLLBACK_REVISION\" '.[] | select((.revision|tostring)==$rev)'\n"
+        ],
+        "validation": "test -n \"${ROLLBACK_REVISION:-}\"\n",
+        "failureHandling": "If the chosen revision does not appear in helm history, the value is wrong. Re-run step-02 and copy the exact revision integer. Do not pass a revision whose status field is failed."
+      },
+      {
+        "id": "step-04-pre-rollback-snapshot",
+        "title": "Capture pre-rollback pod snapshot",
+        "description": "Record the current pod inventory in kubestellar-system before the rollback so you can correlate state changes afterwards.",
+        "commands": [
+          "kubectl get pods --namespace kubestellar-system -o wide\n",
+          "kubectl get deployments --namespace kubestellar-system -o wide\n",
+          "kubectl get events --namespace kubestellar-system --sort-by=.lastTimestamp | tail -20\n"
+        ],
+        "validation": "kubectl get pods --namespace kubestellar-system > /dev/null 2>&1\n",
+        "failureHandling": "If kubectl cannot list pods, the API server may be degraded. Resolve API connectivity before applying the rollback because helm rollback also needs to talk to the API server."
+      },
+      {
+        "id": "step-05-apply-rollback",
+        "title": "Apply the Helm rollback to the target revision",
+        "description": "Run helm rollback with --wait so the command blocks until the older revision converges and pods reach Ready under the rolled-back manifests.",
+        "commands": [
+          "ROLLBACK_REVISION=\"${ROLLBACK_REVISION:-}\"\nhelm rollback kubestellar-core \"$ROLLBACK_REVISION\" --namespace kubestellar-system --wait --timeout 10m\n"
+        ],
+        "validation": "helm status kubestellar-core --namespace kubestellar-system --output json | grep -q '\"status\":\"deployed\"'\n",
+        "failureHandling": "If helm rollback fails or times out, inspect kubectl describe pod and kubectl logs in kubestellar-system. Common causes are PVC binding delays or admission webhook conflicts. Resolve the blocker, then re-run helm rollback. If the release is now stuck in pending-rollback, run helm history again and choose a different known-good revision."
+      },
+      {
+        "id": "step-06-verify-pod-readiness",
+        "title": "Verify pods reached Ready under the rolled-back revision",
+        "description": "Confirm every pod in kubestellar-system is Ready under the rolled-back revision. Capture kubectl get pods, kubectl get events, and kubectl logs output so the rollback can be audited later.",
+        "commands": [
+          "kubectl get pods --namespace kubestellar-system -o wide\n",
+          "kubectl wait --for=condition=Ready pod --all --namespace kubestellar-system --timeout=300s\n",
+          "kubectl get events --namespace kubestellar-system --sort-by=.lastTimestamp | tail -20\n"
+        ],
+        "validation": "kubectl get pods --namespace kubestellar-system --no-headers | awk '$3 != \"Running\" && $3 != \"Completed\" { exit 1 }'\n",
+        "failureHandling": "If pods still fail to reach Ready, the chosen revision is not actually healthy on this cluster. Choose an earlier revision from helm history and re-run step-05. If no prior revision is healthy, run install-kubestellar-controller's uninstall and reinstall path."
+      },
+      {
+        "id": "step-07-confirm-rollback",
+        "title": "Confirm the release reports the expected revision",
+        "description": "Verify that helm status reflects the new current revision and the chart version matches what you expected. Print helm history so the new entry from the rollback is captured next to the upgrade timeline.",
+        "commands": [
+          "helm status kubestellar-core --namespace kubestellar-system --output json | jq '{name, version, status: .info.status, chart: .chart.metadata.version}'\n",
+          "helm history kubestellar-core --namespace kubestellar-system\n",
+          "kubectl get deployments --namespace kubestellar-system -o wide\n"
+        ],
+        "validation": "helm status kubestellar-core --namespace kubestellar-system --output json | grep -q '\"status\":\"deployed\"'\n",
+        "failureHandling": "If status is anything other than deployed, do not declare success. Inspect the helm history entry created by the rollback. If it shows failed, you need to escalate or pick another revision."
+      }
+    ],
+    "resolution": {
+      "summary": "kubestellar-core was rolled back to a known-good revision via helm rollback with health checks. The release is back in deployed state and pods are Ready under the previous chart version.",
+      "codeSnippets": [
+        "helm history kubestellar-core --namespace kubestellar-system",
+        "helm rollback kubestellar-core \"$ROLLBACK_REVISION\" --namespace kubestellar-system --wait --timeout 10m",
+        "kubectl wait --for=condition=Ready pod --all --namespace kubestellar-system --timeout=300s",
+        "helm status kubestellar-core --namespace kubestellar-system --output json"
+      ]
+    },
+    "troubleshooting": [
+      {
+        "id": "ts-01-pending-rollback",
+        "title": "Release stuck in pending-rollback",
+        "description": "An interrupted helm rollback can leave the release in pending-rollback. Run helm history to confirm. If a healthy older revision still exists, retry helm rollback against that revision. If not, uninstall through install-kubestellar-controller's uninstall section and reinstall."
+      },
+      {
+        "id": "ts-02-no-prior-revision",
+        "title": "helm history shows only the failed revision",
+        "description": "No prior state means a rollback is not possible. Run install-kubestellar-controller's uninstall steps to remove the broken release, then reinstall the chart at a known-good chart version."
+      },
+      {
+        "id": "ts-03-pvc-binding-delay",
+        "title": "Pods Pending after rollback because of PVC binding",
+        "description": "When persistence is enabled the rollback may need to bind a PVC before the pod can run. Run kubectl describe pod and kubectl get pvc in kubestellar-system. Confirm the StorageClass exists and the PVC was Bound under the previous revision."
+      },
+      {
+        "id": "ts-04-webhook-conflict",
+        "title": "Mutating or validating webhooks reject pod creation",
+        "description": "If the failed upgrade installed an incompatible webhook configuration, the rollback can be blocked. Inspect kubectl get mutatingwebhookconfiguration and kubectl get validatingwebhookconfiguration and temporarily set the webhook failurePolicy to Ignore so the rollback can complete, then restore the policy after the controllers are stable."
+      }
+    ]
+  },
+  "metadata": {
+    "tags": [
+      "kubestellar",
+      "rollback",
+      "helm",
+      "lifecycle",
+      "controller",
+      "runbook"
+    ],
+    "platform": "kubernetes",
+    "platformType": "management",
+    "platformProvider": "KubeStellar",
+    "category": "runbook",
+    "supportedK8sVersions": [
+      "1.27",
+      "1.28",
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [
+      "kubestellar"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Pod",
+      "Service",
+      "ConfigMap"
+    ],
+    "difficulty": "intermediate",
+    "installMethods": [
+      "helm"
+    ],
+    "operationTypes": [
+      "rollback",
+      "lifecycle"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.kubestellar.io/main/direct/get-started/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.27",
+    "tools": [
+      "kubectl",
+      "helm",
+      "jq"
+    ],
+    "cloudCLI": "none",
+    "resources": "An existing kubestellar-core release with at least two revisions in helm history.",
+    "description": "Pair this runbook with upgrade-kubestellar-controller. Export ROLLBACK_REVISION to the revision number you want to land on before running the mission."
+  }
+}

--- a/runbooks/upgrade-kubestellar-controller.json
+++ b/runbooks/upgrade-kubestellar-controller.json
@@ -1,0 +1,193 @@
+{
+  "version": "kc-mission-v1",
+  "name": "runbook-upgrade-kubestellar-controller",
+  "missionClass": "runbook",
+  "author": "Vinay B M",
+  "authorGithub": "bmvinay7",
+  "mission": {
+    "title": "Upgrade KubeStellar controller via Helm with health gates and rollback readiness",
+    "description": "Production-grade, idempotent runbook to upgrade the kubestellar-core Helm release in place. The workflow records the current revision, verifies cluster and pod health before changing anything, refreshes the chart repository, runs a dry-run diff, applies helm upgrade, waits for the new pods to reach Ready, and confirms the release is in deployed status. Every step is fail-fast and prints enough state for the rollback runbook to take over if something goes wrong.",
+    "type": "upgrade",
+    "status": "completed",
+    "estimatedMinutes": 15,
+    "steps": [
+      {
+        "id": "step-01-cluster-connectivity",
+        "title": "Verify cluster connectivity and existing release",
+        "description": "Confirm the active kubeconfig context reaches the API server and the kubestellar-core release exists in the kubestellar-system namespace before touching anything.",
+        "commands": [
+          "kubectl cluster-info\n",
+          "kubectl config current-context\n",
+          "helm status kubestellar-core --namespace kubestellar-system --output json\n"
+        ],
+        "validation": "helm status kubestellar-core --namespace kubestellar-system --output json | grep -q '\"status\":\"deployed\"'\n",
+        "failureHandling": "If kubectl cannot reach the API server, stop and use the credentials-setup mission. If helm status reports the release is missing, run install-kubestellar-controller first instead of upgrade. Do not continue when the current state is unknown."
+      },
+      {
+        "id": "step-02-record-current-revision",
+        "title": "Record the current Helm revision and chart version",
+        "description": "Capture the current revision and chart version. The rollback runbook uses these values to return the release to a known good state if the new revision fails to come up clean.",
+        "commands": [
+          "helm history kubestellar-core --namespace kubestellar-system\n",
+          "helm get values kubestellar-core --namespace kubestellar-system\n",
+          "helm list --namespace kubestellar-system --output json | jq '.[] | select(.name==\"kubestellar-core\")'\n"
+        ],
+        "validation": "helm history kubestellar-core --namespace kubestellar-system --output json | jq -e 'length > 0'\n",
+        "failureHandling": "If helm history is empty, the release was created out of band and is not safe to upgrade with this runbook. Reinstall it cleanly through install-kubestellar-controller before retrying."
+      },
+      {
+        "id": "step-03-pod-health-baseline",
+        "title": "Verify all controller pods are Ready before upgrading",
+        "description": "Upgrading on top of a degraded release usually masks the existing failure as a new one. Confirm every pod in kubestellar-system is Ready first and capture the pod inventory for diff later.",
+        "commands": [
+          "kubectl get pods --namespace kubestellar-system\n",
+          "kubectl wait --for=condition=Ready pod --all --namespace kubestellar-system --timeout=180s\n",
+          "kubectl get deployments --namespace kubestellar-system -o wide\n"
+        ],
+        "validation": "kubectl get pods --namespace kubestellar-system --no-headers | awk '$3 != \"Running\" && $3 != \"Completed\" { exit 1 }'\n",
+        "failureHandling": "If any pod is not Ready, run troubleshoot-general against kubestellar-system, fix the root cause, then return to this step. Do not attempt to upgrade a release with unhealthy pods."
+      },
+      {
+        "id": "step-04-refresh-helm-repo",
+        "title": "Refresh the KubeStellar Helm repository",
+        "description": "Update the local chart cache so helm sees the published target version. The repo add line is idempotent. helm repo update populates the latest chart metadata.",
+        "commands": [
+          "helm repo add kubestellar https://kubestellar.github.io/helm 2>/dev/null || true\n",
+          "helm repo update kubestellar\n",
+          "helm search repo kubestellar/kubestellar-core --versions | head -5\n"
+        ],
+        "validation": "helm search repo kubestellar/kubestellar-core --output json | jq -e 'length > 0'\n",
+        "failureHandling": "If helm repo update fails, check outbound HTTPS to https://kubestellar.github.io/helm/index.yaml. Corporate proxies may need HTTPS_PROXY exported. If the repo URL itself responds 404, escalate before continuing."
+      },
+      {
+        "id": "step-05-dry-run-diff",
+        "title": "Render the upgrade as a dry run and inspect the diff",
+        "description": "Render the upgrade with helm template plus helm upgrade --dry-run so you can see exactly what will change. Set TARGET_CHART_VERSION to the chart version you want to land on. Leave it empty to upgrade to the latest published chart.",
+        "commands": [
+          "TARGET_CHART_VERSION=\"${TARGET_CHART_VERSION:-}\"\necho \"Target chart version: ${TARGET_CHART_VERSION:-latest}\"\n",
+          "if test -n \"${TARGET_CHART_VERSION:-}\"; then\n  helm upgrade kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --version \"$TARGET_CHART_VERSION\" --dry-run --debug 2>&1 | tail -40\nelse\n  helm upgrade kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --dry-run --debug 2>&1 | tail -40\nfi\n"
+        ],
+        "validation": "helm upgrade kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --dry-run > /dev/null 2>&1\n",
+        "failureHandling": "If the dry run fails on schema or values errors, stop. Investigate which values need to change for the new chart version. Never apply an upgrade that did not pass dry run."
+      },
+      {
+        "id": "step-06-apply-upgrade",
+        "title": "Apply the Helm upgrade with wait and timeout",
+        "description": "Run helm upgrade with --install for idempotency, --wait so the command blocks until the new pods are Ready, and --timeout long enough to cover image pulls. The --rollback-on-failure flag automatically rolls back if the upgrade fails to converge inside the timeout window.",
+        "commands": [
+          "TARGET_CHART_VERSION=\"${TARGET_CHART_VERSION:-}\"\nif test -n \"${TARGET_CHART_VERSION:-}\"; then\n  helm upgrade --install kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --version \"$TARGET_CHART_VERSION\" --wait --rollback-on-failure --timeout 15m\nelse\n  helm upgrade --install kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --wait --rollback-on-failure --timeout 15m\nfi\n"
+        ],
+        "validation": "helm status kubestellar-core --namespace kubestellar-system --output json | grep -q '\"status\":\"deployed\"'\n",
+        "failureHandling": "If --rollback-on-failure triggered an automatic rollback, helm status will report the previous revision as deployed. Inspect kubectl describe pod and kubectl logs in kubestellar-system, fix the root cause, then retry. If you are on Helm v3, use --atomic instead of --rollback-on-failure. Run the rollback runbook if the release is stuck."
+      },
+      {
+        "id": "step-07-verify-pod-readiness",
+        "title": "Verify the new pods reach Ready and inspect events",
+        "description": "Wait for all pods in kubestellar-system to reach Ready under the new revision and capture their state with kubectl get pods, kubectl get events, and kubectl logs. This is the load-bearing health gate before declaring the upgrade complete and gives you the full event tail in case anything regresses.",
+        "commands": [
+          "kubectl get pods --namespace kubestellar-system -o wide\n",
+          "kubectl wait --for=condition=Ready pod --all --namespace kubestellar-system --timeout=300s\n",
+          "kubectl get events --namespace kubestellar-system --sort-by=.lastTimestamp | tail -20\n"
+        ],
+        "validation": "kubectl get pods --namespace kubestellar-system --no-headers | awk '$3 != \"Running\" && $3 != \"Completed\" { exit 1 }'\n",
+        "failureHandling": "If pods are stuck Pending, check node capacity and image pull events with kubectl describe pod. If pods are CrashLoopBackOff, read kubectl logs and run the rollback runbook to return to the prior revision while you investigate."
+      },
+      {
+        "id": "step-08-confirm-deployed-revision",
+        "title": "Confirm Helm revision incremented and release is deployed",
+        "description": "Verify the Helm revision moved forward and the release is in the deployed state. Print the new history so the value is captured next to the upgrade output.",
+        "commands": [
+          "helm status kubestellar-core --namespace kubestellar-system --output json | jq '{name, version, status: .info.status}'\n",
+          "helm history kubestellar-core --namespace kubestellar-system\n",
+          "kubectl get deployments --namespace kubestellar-system -o wide\n"
+        ],
+        "validation": "helm status kubestellar-core --namespace kubestellar-system --output json | grep -q '\"status\":\"deployed\"'\n",
+        "failureHandling": "If status is anything other than deployed, do not declare the upgrade complete. Run the rollback runbook to return to the previous revision and triage offline."
+      }
+    ],
+    "resolution": {
+      "summary": "kubestellar-core was upgraded in place via helm upgrade with health checks before and after the change. The revision and release values are captured so the rollback runbook can revert cleanly if a regression surfaces later.",
+      "codeSnippets": [
+        "helm history kubestellar-core --namespace kubestellar-system",
+        "helm upgrade --install kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --wait --rollback-on-failure --timeout 15m",
+        "kubectl wait --for=condition=Ready pod --all --namespace kubestellar-system --timeout=300s",
+        "helm status kubestellar-core --namespace kubestellar-system --output json"
+      ]
+    },
+    "troubleshooting": [
+      {
+        "id": "ts-01-atomic-rollback",
+        "title": "helm reports the upgrade rolled back automatically",
+        "description": "When --rollback-on-failure triggers, helm status shows the previous revision still deployed. The new revision did not converge inside the timeout. Inspect events and pod logs in kubestellar-system, fix the cause, and only retry helm upgrade after a clean dry run."
+      },
+      {
+        "id": "ts-02-pending-install",
+        "title": "Release stuck in pending-upgrade",
+        "description": "A previous interrupted helm command can leave the release in pending-upgrade status. Inspect helm history. If a prior revision is healthy, run the rollback runbook to reset state. If not, uninstall and reinstall through install-kubestellar-controller."
+      },
+      {
+        "id": "ts-03-image-pull-backoff",
+        "title": "Pods stuck in ImagePullBackOff after upgrade",
+        "description": "Container registry rate limiting or a stale image tag can stall the new revision. Run kubectl describe pod to confirm the failure. Pre-pull images on nodes or configure imagePullSecrets, then retry the upgrade."
+      },
+      {
+        "id": "ts-04-values-incompatibility",
+        "title": "Dry run fails with values schema errors",
+        "description": "The new chart version may require migrated values. Compare helm get values kubestellar-core with the chart README for the target version, update the values file accordingly, and rerun step-05 before applying."
+      }
+    ]
+  },
+  "metadata": {
+    "tags": [
+      "kubestellar",
+      "upgrade",
+      "helm",
+      "lifecycle",
+      "controller",
+      "runbook"
+    ],
+    "platform": "kubernetes",
+    "platformType": "management",
+    "platformProvider": "KubeStellar",
+    "category": "runbook",
+    "supportedK8sVersions": [
+      "1.27",
+      "1.28",
+      "1.29",
+      "1.30",
+      "1.31"
+    ],
+    "cncfProjects": [
+      "kubestellar"
+    ],
+    "targetResourceKinds": [
+      "Deployment",
+      "Pod",
+      "Service",
+      "ConfigMap"
+    ],
+    "difficulty": "intermediate",
+    "installMethods": [
+      "helm"
+    ],
+    "operationTypes": [
+      "upgrade",
+      "lifecycle"
+    ],
+    "sourceUrls": {
+      "docs": "https://docs.kubestellar.io/main/direct/get-started/"
+    },
+    "qualityScore": 100
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.27",
+    "tools": [
+      "kubectl",
+      "helm",
+      "jq"
+    ],
+    "cloudCLI": "none",
+    "resources": "An existing kubestellar-core release in kubestellar-system and cluster-admin equivalent permissions to update Deployments, ConfigMaps, and CRDs.",
+    "description": "Pair this runbook with rollback-kubestellar-controller. Export TARGET_CHART_VERSION when you need to pin a specific chart version. Leave it empty to upgrade to the latest published chart."
+  }
+}


### PR DESCRIPTION
## Description

Adds two operational runbooks listed under **Planned Runbooks** in [`runbooks/README.md`](https://github.com/kubestellar/console-kb/blob/master/runbooks/README.md), completing the install → upgrade → rollback lifecycle for the `kubestellar/kubestellar-core` Helm chart introduced in `install-kubestellar-controller.json`.

## What the runbooks cover

### `runbooks/upgrade-kubestellar-controller.json`

In-place Helm upgrade with health gates and `--rollback-on-failure` safety.

- Cluster connectivity and existing release verification
- Records current Helm revision and values for rollback readiness
- Pod health baseline before changing anything
- `helm repo update` and target version selection via `TARGET_CHART_VERSION`
- `helm upgrade --dry-run` diff before applying
- `helm upgrade --install --wait --rollback-on-failure --timeout 15m`
- Pod readiness gate plus `kubectl get events` audit tail
- 4 troubleshooting entries: rollback-on-failure trigger, pending-upgrade, ImagePullBackOff, values incompatibility

### `runbooks/rollback-kubestellar-controller.json`

Helm rollback to a known-good revision after a failed or regressing upgrade. Pairs with the upgrade runbook as the safety net.

- `helm history` inspection and target revision selection via `ROLLBACK_REVISION`
- Pre-rollback pod and event snapshot
- `helm rollback --wait --timeout 10m`
- Pod readiness verification under the rolled-back revision
- 4 troubleshooting entries: pending-rollback, no-prior-revision, PVC binding delays, webhook conflicts

Also updates `runbooks/README.md` to move both runbooks from **Planned** into **Available**, and regenerates `fixes/index.json` (+2 entries).

## Validation

```text
$ node scripts/validate-schema.mjs runbooks/upgrade-kubestellar-controller.json runbooks/rollback-kubestellar-controller.json
✅ Valid kc-mission-v1 (both files)

$ node scripts/test-kb-quality-ci.mjs runbooks/upgrade-kubestellar-controller.json runbooks/rollback-kubestellar-controller.json
upgrade-kubestellar-controller.json -> 100/100
rollback-kubestellar-controller.json -> 100/100

$ node scripts/scan-pr.mjs runbooks/upgrade-kubestellar-controller.json runbooks/rollback-kubestellar-controller.json
✅ Schema · ✅ Sensitive data · ✅ Security (both files)
```

End-to-end on a kind cluster (kind-kb-test, K8s v1.35.0, Helm v4.1.4):

```text
# Install baseline
$ helm install kubestellar-core kubestellar/kubestellar-core --version 7 --namespace kubestellar-system --create-namespace --wait
STATUS: deployed, REVISION: 1
Pod: kubestellar-df494bf46-zf7d7  5/5 Running

# Upgrade (step-06)
$ helm upgrade --install kubestellar-core kubestellar/kubestellar-core --namespace kubestellar-system --wait --rollback-on-failure --timeout 5m
STATUS: deployed, REVISION: 5
Pod: 5/5 Running, condition met

# Rollback (step-05)
$ helm rollback kubestellar-core 1 --namespace kubestellar-system --wait --timeout 10m
Rollback was a success! Happy Helming!
STATUS: deployed, REVISION: 4

# Cleanup
$ helm uninstall kubestellar-core --namespace kubestellar-system --wait
release "kubestellar-core" uninstalled
$ kubectl delete namespace kubestellar-system
namespace "kubestellar-system" deleted
```

## Related Issue

Closes the `upgrade-kubestellar-controller.json` and `rollback-kubestellar-controller.json` items listed under **Planned Runbooks** in [`runbooks/README.md`](https://github.com/kubestellar/console-kb/blob/master/runbooks/README.md). Builds on @kubestellar-hive[bot]'s recent operational-runbooks PR (#2277) by completing the controller lifecycle.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have signed off my commits (`git commit -s`)
- [x] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

## Additional Notes

Validated the full install → upgrade → rollback → uninstall lifecycle on a kind cluster. Both runbooks use Helm 4-compatible flags (`--rollback-on-failure` instead of the deprecated `--atomic`, plain `--wait` instead of the removed `--recreate-pods`). Production prerequisites (HA, cloud KMS, admission policies) are documented in the runbook steps rather than verified by the kind run.

The "tests that prove my fix/feature works" box stays unchecked — runbooks have no unit-test framework in this repo; the schema validator, quality scorer, and security scanner are the de facto tests, and they are already covered by "All new and existing tests pass."
