### PR TITLE
🌱 etcd: Learner promotion not being persisted into v3store may be propagated across

### DIFF
--- a/fixes/cncf-generated/etcd/etcd-20793-learner-promotion-not-being-persisted-into-v3store-may-be-propagated-.json
+++ b/fixes/cncf-generated/etcd/etcd-20793-learner-promotion-not-being-persisted-into-v3store-may-be-propagated-.json
@@ -1,0 +1,84 @@
+{
+  "version": "kc-mission-v1",
+  "name": "etcd-20793-learner-promotion-not-being-persisted-into-v3store-may-be-propagated-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "etcd: Learner promotion not being persisted into v3store may be propagated across multiple upgrades",
+    "description": "Learner promotion not being persisted into v3store may be propagated across multiple upgrades. This issue affects 5+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify etcd troubleshoot symptoms",
+        "description": "Check for the issue in your etcd deployment:\n```bash\nkubectl get pods -n etcd -l app.kubernetes.io/name=etcd\nkubectl logs -l app.kubernetes.io/name=etcd -n etcd --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review etcd configuration",
+        "description": "Inspect the relevant etcd configuration:\n```bash\nkubectl get all -n etcd -l app.kubernetes.io/name=etcd\nkubectl get configmap -n etcd -l app.kubernetes.io/part-of=etcd\n```\n### Bug report criteria\n\n### What happened?\n\n### Issue and analysis\nWhen users upgrade from 1.32.3 (etcd 3.5.19) --> 1.33.1 (etcd 3.5.21) --> 1.34.1 (etcd 3.6.4), the upgrade is always successful in 1.32.3 --> 1.33.1 upgrade, but may fail during"
+      },
+      {
+        "title": "Apply the fix for Learner promotion not being persisted into v3store may be…",
+        "description": "Fix https://github.com/etcd-io/etcd/issues/20793\n\nVerified the fix using [upgradeDemo](https://github.com/ahrtr/etcd-issues/tree/master/etcd/upgradeDemo) with config below. \n\n```\n{\n  \"clusterSize\": 3,\n  \"upgradePath\": [\n    {\n      \"version\": \"v3.5.19\",\n      \"path\": \"/usr/local/bin/etcd-v3.5.19\"\n \n```yaml\n</details>\n\n\n### Etcd configuration (command line flags or environment variables)\n\n<details>\n\n# paste your configuration here\n\n</details>\n\n\n### Etcd debug information (please run commands below, feel free to obfuscate the IP address or FQDN in the output)\n\n<details>\n```"
+      },
+      {
+        "title": "Upgrade etcd to include the fix",
+        "description": "If the fix is included in a newer release, upgrade etcd:\n```bash\nhelm repo update\nhelm upgrade etcd etcd/etcd --namespace etcd\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n etcd\nhelm list -n etcd\n```"
+      },
+      {
+        "title": "Confirm Learner promotion not being persisted into… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=etcd -n etcd --tail=50 --since=5m\nkubectl get events -n etcd --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "Fix https://github.com/etcd-io/etcd/issues/20793\n\nVerified the fix using [upgradeDemo](https://github.com/ahrtr/etcd-issues/tree/master/etcd/upgradeDemo) with config below.",
+      "codeSnippets": [
+        "</details>\n\n\n### Etcd configuration (command line flags or environment variables)\n\n<details>\n\n# paste your configuration here\n\n</details>\n\n\n### Etcd debug information (please run commands below, feel free to obfuscate the IP address or FQDN in the output)\n\n<details>",
+        "</details>\n\n\n### Relevant log output",
+        "Fix https://github.com/etcd-io/etcd/issues/20793\n\nVerified the fix using [upgradeDemo](https://github.com/ahrtr/etcd-issues/tree/master/etcd/upgradeDemo) with config below."
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "etcd",
+      "graduated",
+      "orchestration",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "etcd"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Node"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/etcd-io/etcd/issues/20793",
+      "repo": "https://github.com/etcd-io/etcd",
+      "pr": "https://github.com/etcd-io/etcd/pull/20797"
+    },
+    "reactions": 5,
+    "comments": 7,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with etcd installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-22T07:18:26.616Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: etcd — Learner promotion not being persisted into v3store may be propagated across multiple upgrades

**Type:** troubleshoot | **Source:** https://github.com/etcd-io/etcd/issues/20793 (5 reactions)
**Fix PR:** https://github.com/etcd-io/etcd/pull/20797
**File:** `fixes/cncf-generated/etcd/etcd-20793-learner-promotion-not-being-persisted-into-v3store-may-be-propagated-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*