### PR TITLE
🌱 podman-container-tools: Alternate port_handler that keeps the source ip for user-defined rootless

### DIFF
--- a/fixes/cncf-generated/podman-container-tools/podman-container-tools-8193-alternate-port-handler-that-keeps-the-source-ip-for-.json
+++ b/fixes/cncf-generated/podman-container-tools/podman-container-tools-8193-alternate-port-handler-that-keeps-the-source-ip-for-.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "podman-container-tools-8193-alternate-port-handler-that-keeps-the-source-ip-for-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "podman-container-tools: Alternate port_handler that keeps the source ip for user-defined rootless networks",
+    "description": "Alternate port_handler that keeps the source ip for user-defined rootless networks. Requested by 29+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current podman-container-tools setup",
+        "description": "Verify your podman-container-tools version and configuration:\n```bash\npodman --version\n```\nThis feature requires a working podman-container-tools installation."
+      },
+      {
+        "title": "Review podman-container-tools configuration",
+        "description": "Review the relevant podman-container-tools configuration:\n**Is this a BUG REPORT or FEATURE REQUEST? (leave only one on its own line)**\r\n\n**Description**\n\nAlternate \"port_handler=slirt4netns\" provided in PR 6965 (https://github.com/containers/podman/pull/6965) for \"only 127.0.0.1 within containers\" **not"
+      },
+      {
+        "title": "Apply the fix for Alternate port_handler that keeps the source ip for…",
+        "description": "Since the \"port_handler=slirp4netns\" solution from PR [6965](https://github.com/containers/podman/pull/6965) was implemented to address the \"only 127.0.0.1\" problem within rootless containers (\"port_handler=rootlesskit\" by default), and since that solution **is not** implemented for user-defined\n```yaml\nVersion:      2.1.1\n        API Version:  2.0.0\n        Go Version:   go1.14\n        Built:        Wed Dec 31 16:00:00 1969\n        OS/Arch:      linux/amd64\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected.\nConfirm the feature described in \"Alternate port_handler that keeps the source ip for…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Since the \"port_handler=slirp4netns\" solution from PR [6965](https://github.com/containers/podman/pull/6965) was implemented to address the \"only 127.0.0.1\" problem within rootless containers (\"port_handler=rootlesskit\" by default), and since that solution **is not** implemented for user-defined rooteless cni networks, perhaps revisiting the \"only 127.0.0.1\" problem with",
+      "codeSnippets": [
+        "Version:      2.1.1\n        API Version:  2.0.0\n        Go Version:   go1.14\n        Built:        Wed Dec 31 16:00:00 1969\n        OS/Arch:      linux/amd64",
+        "host:\n  arch: amd64\n  buildahVersion: 1.16.1\n  cgroupManager: cgroupfs\n  cgroupVersion: v1\n  conmon:\n    package: 'conmon: /usr/libexec/podman/conmon'\n    path: /usr/libexec/podman/conmon\n    version: 'conmon version 2.0.20, commit: '\n  cpus: 4\n  distribution:\n    distribution: debian\n    version: \"10\"\n  eventLogger: journald\n  hostname: arachne\n  idMappings:\n    gidmap:\n    - container_id: 0\n      host_id: 2000\n      size: 1\n    - container_id: 1\n      host_id: 100001\n      size: 65536\n    uidmap:\n    - container_id: 0\n      host_id: 2000\n      size: 1\n    - container_id: 1\n      host_id: 100001\n      size: 65536\n  kernel: 4.19.0-10-amd64\n  linkmode: dynamic\n  memFree: 369057792\n  memTotal: 2091732992\n  ociRuntime:\n    name: runc\n    package: 'runc: /usr/sbin/runc'\n    path: /usr/sbin/run",
+        "podman/unknown,now 2.1.1~2 amd64 [installed]\npodman/unknown 2.1.1~2 arm64\npodman/unknown 2.1.1~2 armhf\npodman/unknown 2.1.1~2 ppc64el"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "podman-container-tools",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "podman-container-tools"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "expert",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/containers/podman/issues/8193",
+      "repo": "https://github.com/containers/podman"
+    },
+    "reactions": 29,
+    "comments": 59,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "podman"
+    ],
+    "description": "A working podman-container-tools installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-05-22T07:36:55.336Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: podman-container-tools — Alternate port_handler that keeps the source ip for user-defined rootless networks

**Type:** feature | **Source:** https://github.com/containers/podman/issues/8193 (29 reactions)
**File:** `fixes/cncf-generated/podman-container-tools/podman-container-tools-8193-alternate-port-handler-that-keeps-the-source-ip-for-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*