### PR TITLE
🌱 n8n: Error with the public API of n8n when registering a webhook

### DIFF
--- a/fixes/cncf-generated/n8n/n8n-14267-error-with-the-public-api-of-n8n-when-registering-a-webhook.json
+++ b/fixes/cncf-generated/n8n/n8n-14267-error-with-the-public-api-of-n8n-when-registering-a-webhook.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "n8n-14267-error-with-the-public-api-of-n8n-when-registering-a-webhook",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "n8n: Error with the public API of n8n when registering a webhook",
+    "description": "Error with the public API of n8n when registering a webhook. This issue affects 5+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify n8n troubleshoot symptoms",
+        "description": "Check for the issue in your n8n deployment:\n```bash\nkubectl get pods -n n8n -l app.kubernetes.io/name=n8n\nkubectl logs -l app.kubernetes.io/name=n8n -n n8n --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review n8n configuration",
+        "description": "Inspect the relevant n8n configuration:\n```bash\nkubectl get all -n n8n -l app.kubernetes.io/name=n8n\nkubectl get configmap -n n8n -l app.kubernetes.io/part-of=n8n\n```\n### Bug Description\n\nI'm generating a workflow using the public API of n8n. Within it, I include a webhook. Once the webhook is activated, I get the path to run the automation, but the webhook does not respond."
+      },
+      {
+        "title": "Apply the fix for Error with the public API of n8n when registering a webhook",
+        "description": "Closing — this is the older parent ticket for the same webhook-registration failure tracked in #21614, which was fixed internally on 2026-03-23 (released ~2.14 onwards). Current shipping versions should not exhibit this. Please open a fresh issue if it reproduces on a current version.\n```yaml\n{\n    \"id\": \"webhook-1\",\n    \"name\": \"Webhook\",\n    \"type\": \"n8n-nodes-base.webhook\",\n    \"typeVersion\": 1,\n    \"position\": [250, 300],\n    \"webhookId\": \"56d7c763-8c1c-4037-bd3a-77abe8e930e2\",\n    \"parameters\": {\n        \"path\": \"test-webhook\",\n        \"httpMethod\": \"POST\",\n        \"responseMode\": \"responseNode\",\n    }\n}\n```"
+      },
+      {
+        "title": "Upgrade n8n to include the fix",
+        "description": "If the fix is included in a newer release, upgrade n8n:\n```bash\nhelm repo update\nhelm upgrade n8n n8n/n8n --namespace n8n\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n n8n\nhelm list -n n8n\n```"
+      },
+      {
+        "title": "Confirm Error with the public API of n8n when registering… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=n8n -n n8n --tail=50 --since=5m\nkubectl get events -n n8n --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "Closing — this is the older parent ticket for the same webhook-registration failure tracked in #21614, which was fixed internally on 2026-03-23 (released ~2.14 onwards). Current shipping versions should not exhibit this. Please open a fresh issue if it reproduces on a current version.",
+      "codeSnippets": [
+        "{\n    \"id\": \"webhook-1\",\n    \"name\": \"Webhook\",\n    \"type\": \"n8n-nodes-base.webhook\",\n    \"typeVersion\": 1,\n    \"position\": [250, 300],\n    \"webhookId\": \"56d7c763-8c1c-4037-bd3a-77abe8e930e2\",\n    \"parameters\": {\n        \"path\": \"test-webhook\",\n        \"httpMethod\": \"POST\",\n        \"responseMode\": \"responseNode\",\n    }\n}"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "n8n",
+      "community",
+      "workflow",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "n8n"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/n8n-io/n8n/issues/14267",
+      "repo": "https://github.com/n8n-io/n8n"
+    },
+    "reactions": 5,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with n8n installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-22T07:40:57.503Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: n8n — Error with the public API of n8n when registering a webhook

**Type:** troubleshoot | **Source:** https://github.com/n8n-io/n8n/issues/14267 (5 reactions)
**File:** `fixes/cncf-generated/n8n/n8n-14267-error-with-the-public-api-of-n8n-when-registering-a-webhook.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*