### PR TITLE
🌱 headlamp: Mac signing is not working, need to setup CNCF based signing certificates

### DIFF
--- a/fixes/cncf-generated/headlamp/headlamp-3655-mac-signing-is-not-working-need-to-setup-cncf-based-signing-certif.json
+++ b/fixes/cncf-generated/headlamp/headlamp-3655-mac-signing-is-not-working-need-to-setup-cncf-based-signing-certif.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "headlamp-3655-mac-signing-is-not-working-need-to-setup-cncf-based-signing-certif",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "headlamp: Mac signing is not working, need to setup CNCF based signing certificates",
+    "description": "Mac signing is not working, need to setup CNCF based signing certificates. This issue affects 12+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify headlamp troubleshoot symptoms",
+        "description": "Check for the issue in your headlamp deployment:\n```bash\nkubectl get pods -n headlamp -l app.kubernetes.io/name=headlamp\nkubectl logs -l app.kubernetes.io/name=headlamp -n headlamp --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review headlamp configuration",
+        "description": "Inspect the relevant headlamp configuration:\n```bash\nkubectl get all -n headlamp -l app.kubernetes.io/name=headlamp\nkubectl get configmap -n headlamp -l app.kubernetes.io/part-of=headlamp\n```\n## Describe the bug\n\nA couple of people have reported that the last version, 0.33.0, is broken on Mac ARM.\nThe OS says the file is corrupted."
+      },
+      {
+        "title": "Apply the fix for Mac signing is not working, need to setup CNCF based…",
+        "description": "## Summary\n\nAdds `--no-quarantine` to the brew install command so that new users aren't confounded by corrupt binary errors (due to bad signature).\n```yaml\n% brew install --cask --no-quarantine headlamp\nWarning: Not upgrading headlamp, the latest version is already installed\n```"
+      },
+      {
+        "title": "Confirm Mac signing is not working, need to setup CNCF… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=headlamp -n headlamp --tail=50 --since=5m\nkubectl get events -n headlamp --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "## Summary\n\nAdds `--no-quarantine` to the brew install command so that new users aren't confounded by corrupt binary errors (due to bad signature).",
+      "codeSnippets": [
+        "% brew install --cask --no-quarantine headlamp\nWarning: Not upgrading headlamp, the latest version is already installed",
+        "> brew install --cask --no-quarantine headlamp\n>",
+        "> % brew install --cask --no-quarantine headlamp\n> Warning: Not upgrading headlamp, the latest version is already installed\n>"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "headlamp",
+      "sandbox",
+      "observability",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "headlamp"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/kubernetes-sigs/headlamp/issues/3655",
+      "repo": "https://github.com/kubernetes-sigs/headlamp",
+      "pr": "https://github.com/kubernetes-sigs/headlamp/pull/3658"
+    },
+    "reactions": 12,
+    "comments": 19,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with headlamp installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-05-23T07:03:40.825Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: headlamp — Mac signing is not working, need to setup CNCF based signing certificates

**Type:** troubleshoot | **Source:** https://github.com/kubernetes-sigs/headlamp/issues/3655 (12 reactions)
**Fix PR:** https://github.com/kubernetes-sigs/headlamp/pull/3658
**File:** `fixes/cncf-generated/headlamp/headlamp-3655-mac-signing-is-not-working-need-to-setup-cncf-based-signing-certif.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*