### PR TITLE
🌱 vault: PROXY Protocol v2 logging support

### DIFF
--- a/fixes/cncf-generated/vault/vault-3807-proxy-protocol-v2-logging-support.json
+++ b/fixes/cncf-generated/vault/vault-3807-proxy-protocol-v2-logging-support.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "vault-3807-proxy-protocol-v2-logging-support",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "vault: PROXY Protocol v2 logging support",
+    "description": "PROXY Protocol v2 logging support. Requested by 12+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current vault setup",
+        "description": "Verify your vault version and configuration:\n```bash\nvault version\n```\nThis feature requires a working vault installation."
+      },
+      {
+        "title": "Review vault configuration",
+        "description": "Review the relevant vault configuration:\n**Feature Request:**\n\nVault currently supports using a client IP from a PROXY protocol header via the work done in #3098 and modified in #3195."
+      },
+      {
+        "title": "Apply the fix for PROXY Protocol v2 logging support",
+        "description": "I did not find tests for this so I added one trying to cover different\nconfigurations to make sure I did not break something. As far as I know,\nthe behavior should be exactly the same as before except for one thing\nwhen proxy_protocol_behavior is set to \"deny_unauthorized\", unauthorized\nrequests were previously silently reject because of https://github.com/armon/go-proxyproto/blob/7e956b284f0a/protocol.go#L81-L84\nbut it will now be logged.\n\nAlso fixes\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected.\nConfirm the feature described in \"PROXY Protocol v2 logging support\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "I did not find tests for this so I added one trying to cover different\nconfigurations to make sure I did not break something.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "vault",
+      "community",
+      "secrets",
+      "feature"
+    ],
+    "cncfProjects": [
+      "vault"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/hashicorp/vault/issues/3807",
+      "repo": "https://github.com/hashicorp/vault",
+      "pr": "https://github.com/hashicorp/vault/pull/13540"
+    },
+    "reactions": 12,
+    "comments": 8,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "vault"
+    ],
+    "description": "A working vault installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-05-23T07:18:59.963Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: vault — PROXY Protocol v2 logging support

**Type:** feature | **Source:** https://github.com/hashicorp/vault/issues/3807 (12 reactions)
**Fix PR:** https://github.com/hashicorp/vault/pull/13540
**File:** `fixes/cncf-generated/vault/vault-3807-proxy-protocol-v2-logging-support.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*