### PR TITLE
🌱 score: [BUG] resources.limits.memory regex rejects valid values like 1.5Gi and larger

### DIFF
--- a/fixes/cncf-generated/score/score-195-bug-resources-limits-memory-regex-rejects-valid-values-like-1-5gi-and-.json
+++ b/fixes/cncf-generated/score/score-195-bug-resources-limits-memory-regex-rejects-valid-values-like-1-5gi-and-.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "score-195-bug-resources-limits-memory-regex-rejects-valid-values-like-1-5gi-and-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "score: [BUG] resources.limits.memory regex rejects valid values like 1.5Gi and larger unit suffixes",
+    "description": "[BUG] resources.limits.memory regex rejects valid values like 1.5Gi and larger unit suffixes. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify score troubleshoot symptoms",
+        "description": "Check for the issue in your score installation:\n```bash\nscore-compose version\n```\nLook for errors or warnings that may indicate the issue."
+      },
+      {
+        "title": "Review score configuration",
+        "description": "Review the relevant score configuration:\nThe memory pattern in the schema is:\n`^[1-9]\\d*(K|M|G|T|Ki|Mi|Gi|Ti)?$`\nhttps://github.com/score-spec/spec/blob/main/score-v1b1.json#L185\nA couple of things slip through here that I don't think were intended:\n\n- Decimal values like `1.5Gi`, `0.5G`,"
+      },
+      {
+        "title": "Apply the fix for [BUG] resources.limits.memory regex rejects valid values…",
+        "description": "Updates the `resourcesLimits.memory` pattern in `score-v1b1.json` so it accepts the memory values Kubernetes already accepts.\n\nToday the pattern rejects `1.5Gi`, `0.5G`, `2.5M`, `1Pi`, and `2Ei` even though `kubectl apply` takes all of them without complaint. After this change those values\n```yaml\ncontainers:\n  main:\n    image: my-app\n    resources:\n      limits:\n        memory: \"1.5Gi\"\n```"
+      },
+      {
+        "title": "Confirm [BUG] resources.limits.memory regex rejects valid… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest score to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "Updates the `resourcesLimits.memory` pattern in `score-v1b1.json` so it accepts the memory values Kubernetes already accepts.\n\nToday the pattern rejects `1.5Gi`, `0.5G`, `2.5M`, `1Pi`, and `2Ei` even though `kubectl apply` takes all of them without complaint. After this change those values validate.",
+      "codeSnippets": [
+        "containers:\n  main:\n    image: my-app\n    resources:\n      limits:\n        memory: \"1.5Gi\"",
+        "- \"^[1-9]\\\\d*(K|M|G|T|Ki|Mi|Gi|Ti)?$\"\n+ \"^(0|[1-9]\\\\d*(\\\\.\\\\d+)?)(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki)?$\"",
+        "<quantity>        ::= <signedNumber><suffix>\n<digit>           ::= 0 | 1 | ... | 9\n<digits>          ::= <digit> | <digit><digits>\n<number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits>\n<sign>            ::= \"+\" | \"-\"\n<signedNumber>    ::= <number> | <sign><number>\n<suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI>\n<binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "score",
+      "sandbox",
+      "app-definition",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "score"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/score-spec/spec/issues/195",
+      "repo": "https://github.com/score-spec/spec",
+      "pr": "https://github.com/score-spec/spec/pull/199"
+    },
+    "reactions": 0,
+    "comments": 11,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "score-compose"
+    ],
+    "description": "A working score installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-05-26T07:33:36.445Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: score — [BUG] resources.limits.memory regex rejects valid values like 1.5Gi and larger unit suffixes

**Type:** troubleshoot | **Source:** https://github.com/score-spec/spec/issues/195 (0 reactions)
**Fix PR:** https://github.com/score-spec/spec/pull/199
**File:** `fixes/cncf-generated/score/score-195-bug-resources-limits-memory-regex-rejects-valid-values-like-1-5gi-and-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*