### PR TITLE
🌱 kubevirt: vm terminates when a hostdevice or gpu is passed with `name` that does not meet

### DIFF
--- a/fixes/cncf-generated/kubevirt/kubevirt-16043-vm-terminates-when-a-hostdevice-or-gpu-is-passed-with-name-that-d.json
+++ b/fixes/cncf-generated/kubevirt/kubevirt-16043-vm-terminates-when-a-hostdevice-or-gpu-is-passed-with-name-that-d.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kubevirt-16043-vm-terminates-when-a-hostdevice-or-gpu-is-passed-with-name-that-d",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kubevirt: vm terminates when a hostdevice or gpu is passed with `name` that does not meet the libvirt hostdev alias format",
+    "description": "vm terminates when a hostdevice or gpu is passed with `name` that does not meet the libvirt hostdev alias format. Users encounter: \"runtime error: invalid memory address or\".",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify kubevirt troubleshoot symptoms",
+        "description": "Check for the issue in your kubevirt deployment:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl logs -l app.kubernetes.io/name=kubevirt -n kubevirt --tail=100 | grep -i error\n```\nLook for error: `runtime error: invalid memory address or nil pointer dereference`"
+      },
+      {
+        "title": "Review kubevirt configuration",
+        "description": "Inspect the relevant kubevirt configuration:\n```bash\nkubectl get all -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get configmap -n kubevirt -l app.kubernetes.io/part-of=kubevirt\n```\n**What happened**:\nCreate a VM with a hostdevice or gpu device passed to the VM with a name containing a special character such as `.`\n\nfor example\n\n```\n          gpus:\n          - deviceName: nvidia.com/GRID_A100-1-10C\n            name:"
+      },
+      {
+        "title": "Apply the fix for vm terminates when a hostdevice or gpu is passed with…",
+        "description": "Apply the configuration change to resolve the issue:\n```yaml\ngpus:\n          - deviceName: nvidia.com/GRID_A100-1-10C\n            name: nvidia.com-grid-a100-1-10c\n```"
+      },
+      {
+        "title": "Confirm vm terminates when a hostdevice or gpu is passed… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=kubevirt -n kubevirt --tail=50 --since=5m\nkubectl get events -n kubevirt --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that `runtime error: invalid memory address or nil pointer dereference` no longer appears in logs."
+      }
+    ],
+    "resolution": {
+      "summary": "See the source issue for the community-verified solution: https://github.com/kubevirt/kubevirt/issues/16043",
+      "codeSnippets": [
+        "gpus:\n          - deviceName: nvidia.com/GRID_A100-1-10C\n            name: nvidia.com-grid-a100-1-10c",
+        "virt-launcher-gpu-znjb8 compute panic: runtime error: invalid memory address or nil pointer dereference\nvirt-launcher-gpu-znjb8 compute [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x55c975ab617b]"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kubevirt",
+      "incubating",
+      "app-definition",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "kubevirt"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/kubevirt/kubevirt/issues/16043",
+      "repo": "https://github.com/kubevirt/kubevirt"
+    },
+    "reactions": 4,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kubevirt installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-01T07:54:22.547Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kubevirt — vm terminates when a hostdevice or gpu is passed with `name` that does not meet the libvirt hostdev alias format

**Type:** troubleshoot | **Source:** https://github.com/kubevirt/kubevirt/issues/16043 (4 reactions)
**File:** `fixes/cncf-generated/kubevirt/kubevirt-16043-vm-terminates-when-a-hostdevice-or-gpu-is-passed-with-name-that-d.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*