### PR TITLE
🌱 opentelemetry-operator: APIs package should not import `github.com/goccy/go-yaml`

### DIFF
--- a/fixes/cncf-generated/opentelemetry-operator/opentelemetry-operator-4362-apis-package-should-not-import-github-com-goccy-go-y.json
+++ b/fixes/cncf-generated/opentelemetry-operator/opentelemetry-operator-4362-apis-package-should-not-import-github-com-goccy-go-y.json
@@ -1,0 +1,79 @@
+{
+  "version": "kc-mission-v1",
+  "name": "opentelemetry-operator-4362-apis-package-should-not-import-github-com-goccy-go-y",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "opentelemetry-operator: APIs package should not import `github.com/goccy/go-yaml`",
+    "description": "APIs package should not import `github.com/goccy/go-yaml`. Requested by 5+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current opentelemetry-operator deployment",
+        "description": "Verify your opentelemetry-operator version and configuration:\n```bash\nkubectl get pods -n opentelemetry-operator -l app.kubernetes.io/name=opentelemetry-operator\nhelm list -n opentelemetry-operator 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working opentelemetry-operator installation."
+      },
+      {
+        "title": "Review opentelemetry-operator configuration",
+        "description": "Inspect the relevant opentelemetry-operator configuration:\n```bash\nkubectl get all -n opentelemetry-operator -l app.kubernetes.io/name=opentelemetry-operator\nkubectl get configmap -n opentelemetry-operator -l app.kubernetes.io/part-of=opentelemetry-operator\n```\n### Component(s)\n\n_No response_\n\n### Is your feature request related to a problem? Please describe."
+      },
+      {
+        "title": "Apply the fix for APIs package should not import `github.com/goccy/go-yaml`",
+        "description": "- Replace `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` with `k8s.io/apimachinery/pkg/runtime.SchemeBuilder` in both `groupversion_info.go` files.\n- This removes the controller-runtime dependency from the apis packages, preparing them for extraction into a standalone Go sub-module.\n\n- `make\n```yaml\n### Describe the solution you'd like\n\nImport types package such as `github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1` should not bring indirect dependencies such as `github.com/goccy/go-yaml`.\n\n\n\n### Describe alternatives you've considered\n\n_No response_\n\n### Additional context\n\n_No response_\n\n### Tip\n\n<sub>[React](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/) with 👍 to help prioritize this issue. Please use comments to provide useful context, avoiding `+1` or `me too`, to help us triage it. Learn more [here](https://opentele\n```"
+      },
+      {
+        "title": "Upgrade opentelemetry-operator to include the fix",
+        "description": "If the fix is included in a newer release, upgrade opentelemetry-operator:\n```bash\nhelm repo update\nhelm upgrade opentelemetry-operator opentelemetry-operator/opentelemetry-operator --namespace opentelemetry-operator\n```\nVerify the upgrade:\n```bash\nkubectl get pods -n opentelemetry-operator\nhelm list -n opentelemetry-operator\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n opentelemetry-operator -l app.kubernetes.io/name=opentelemetry-operator\nkubectl get events -n opentelemetry-operator --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"APIs package should not import `github.com/goccy/go-yaml`\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "- Replace `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` with `k8s.io/apimachinery/pkg/runtime.SchemeBuilder` in both `groupversion_info.go` files.\n- This removes the controller-runtime dependency from the apis packages, preparing them for extraction into a standalone Go sub-module.\n\n- `make test` — all 1947 tests pass, 0 failures.",
+      "codeSnippets": [
+        "### Describe the solution you'd like\n\nImport types package such as `github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1` should not bring indirect dependencies such as `github.com/goccy/go-yaml`.\n\n\n\n### Describe alternatives you've considered\n\n_No response_\n\n### Additional context\n\n_No response_\n\n### Tip\n\n<sub>[React](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/) with 👍 to help prioritize this issue. Please use comments to provide useful context, avoiding `+1` or `me too`, to help us triage it. Learn more [here](https://opentelemetry.io/community/end-user/issue-participation/).</sub>\n**Description:** \n- Replace `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` with `k8s.io/apimachinery/pkg/runtime.SchemeBuilder` in both `g"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "opentelemetry-operator",
+      "incubating",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "opentelemetry-operator"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/open-telemetry/opentelemetry-operator/issues/4362",
+      "repo": "https://github.com/open-telemetry/opentelemetry-operator",
+      "pr": "https://github.com/open-telemetry/opentelemetry-operator/pull/4793"
+    },
+    "reactions": 5,
+    "comments": 20,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with opentelemetry-operator installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-02T07:51:01.596Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: opentelemetry-operator — APIs package should not import `github.com/goccy/go-yaml`

**Type:** feature | **Source:** https://github.com/open-telemetry/opentelemetry-operator/issues/4362 (5 reactions)
**Fix PR:** https://github.com/open-telemetry/opentelemetry-operator/pull/4793
**File:** `fixes/cncf-generated/opentelemetry-operator/opentelemetry-operator-4362-apis-package-should-not-import-github-com-goccy-go-y.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*