### PR TITLE
🌱 woodpecker-ci: Slow authorization if user has many orgs/repos

### DIFF
--- a/fixes/cncf-generated/woodpecker-ci/woodpecker-ci-2502-slow-authorization-if-user-has-many-orgs-repos.json
+++ b/fixes/cncf-generated/woodpecker-ci/woodpecker-ci-2502-slow-authorization-if-user-has-many-orgs-repos.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "woodpecker-ci-2502-slow-authorization-if-user-has-many-orgs-repos",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "woodpecker-ci: Slow authorization if user has many orgs/repos",
+    "description": "Slow authorization if user has many orgs/repos. This issue affects 8+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify woodpecker-ci troubleshoot symptoms",
+        "description": "Check for the issue in your woodpecker-ci deployment:\n```bash\nkubectl get pods -n woodpecker-ci -l app.kubernetes.io/name=woodpecker-ci\nkubectl logs -l app.kubernetes.io/name=woodpecker-ci -n woodpecker-ci --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review woodpecker-ci configuration",
+        "description": "Inspect the relevant woodpecker-ci configuration:\n```bash\nkubectl get all -n woodpecker-ci -l app.kubernetes.io/name=woodpecker-ci\nkubectl get configmap -n woodpecker-ci -l app.kubernetes.io/part-of=woodpecker-ci\n```\n### Component\n\nserver\n\n### Describe the bug\n\nSlow authorization if user has many orgs/repos."
+      },
+      {
+        "title": "Apply the fix for Slow authorization if user has many orgs/repos",
+        "description": "This PR is a solution for #2502.\n\nTo resolve the issue a configuration option `WOODPECKER_ASYNC_REPOSITORY_UPDATE` has been added to allow administrators to decide how Woodpecker should deal with the repository update call that is part of the login flow. It can be either sync/async.\nSync is do-able for smaller organisations with few repositories, but larger organisations might opt for async to improve login speed at the cost of consistency. The repository list will be eventually consistent\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Confirm Slow authorization if user has many orgs/repos is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=woodpecker-ci -n woodpecker-ci --tail=50 --since=5m\nkubectl get events -n woodpecker-ci --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "This PR is a solution for #2502.\n\nTo resolve the issue a configuration option `WOODPECKER_ASYNC_REPOSITORY_UPDATE` has been added to allow administrators to decide how Woodpecker should deal with the repository update call that is part of the login flow. It can be either sync/async.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "woodpecker-ci",
+      "community",
+      "ci-cd",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "woodpecker-ci"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/woodpecker-ci/woodpecker/issues/2502",
+      "repo": "https://github.com/woodpecker-ci/woodpecker",
+      "pr": "https://github.com/woodpecker-ci/woodpecker/pull/5665"
+    },
+    "reactions": 8,
+    "comments": 16,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with woodpecker-ci installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-02T08:09:56.000Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: woodpecker-ci — Slow authorization if user has many orgs/repos

**Type:** troubleshoot | **Source:** https://github.com/woodpecker-ci/woodpecker/issues/2502 (8 reactions)
**Fix PR:** https://github.com/woodpecker-ci/woodpecker/pull/5665
**File:** `fixes/cncf-generated/woodpecker-ci/woodpecker-ci-2502-slow-authorization-if-user-has-many-orgs-repos.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*