### PR TITLE
🌱 flux: HelmRelease valuesFrom kind secret with comma separated values (cannot end with

### DIFF
--- a/fixes/cncf-generated/flux/flux-2625-helmrelease-valuesfrom-kind-secret-with-comma-separated-values-cannot-.json
+++ b/fixes/cncf-generated/flux/flux-2625-helmrelease-valuesfrom-kind-secret-with-comma-separated-values-cannot-.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "flux-2625-helmrelease-valuesfrom-kind-secret-with-comma-separated-values-cannot-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "flux: HelmRelease valuesFrom kind secret with comma separated values (cannot end with ,)",
+    "description": "HelmRelease valuesFrom kind secret with comma separated values (cannot end with ,). This issue affects 7+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify flux troubleshoot symptoms",
+        "description": "Check for the issue in your flux deployment:\n```bash\nkubectl get pods -n flux -l app.kubernetes.io/name=flux\nkubectl logs -l app.kubernetes.io/name=flux -n flux --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review flux configuration",
+        "description": "Inspect the relevant flux configuration:\n```bash\nkubectl get all -n flux -l app.kubernetes.io/name=flux\nkubectl get configmap -n flux -l app.kubernetes.io/part-of=flux\n```\n### Describe the bug\n\nHi,\nin case that the secret value contains a comma character we receive the following error message:\n\n```text\n helm-controller  unable to merge value from key 'brokers' in Secret 'default/kafka' into target path"
+      },
+      {
+        "title": "Apply the fix for HelmRelease valuesFrom kind secret with comma separated…",
+        "description": "You need to escape the comma, as otherwise the parsing logic (which equals `--set` as `helm` itself has when `targetPath` is used) will trip over the value. See also: https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set\n\nThe correct value would be:\n```yaml\nbrokers value:\n```"
+      },
+      {
+        "title": "Confirm HelmRelease valuesFrom kind secret with comma… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=flux -n flux --tail=50 --since=5m\nkubectl get events -n flux --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "You need to escape the comma, as otherwise the parsing logic (which equals `--set` as `helm` itself has when `targetPath` is used) will trip over the value. See also: https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set\n\nThe correct value would be: `kafka01.net:9092\\,kafka02.net:9092\\,kafka03.net:9092`",
+      "codeSnippets": [
+        "brokers value:",
+        "Example HelmRelease yaml:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "flux",
+      "graduated",
+      "app-definition",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "flux"
+    ],
+    "targetResourceKinds": [
+      "Namespace",
+      "Secret"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/fluxcd/flux2/issues/2625",
+      "repo": "https://github.com/fluxcd/flux2"
+    },
+    "reactions": 7,
+    "comments": 6,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with flux installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-05T07:30:40.316Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: flux — HelmRelease valuesFrom kind secret with comma separated values (cannot end with ,)

**Type:** troubleshoot | **Source:** https://github.com/fluxcd/flux2/issues/2625 (7 reactions)
**File:** `fixes/cncf-generated/flux/flux-2625-helmrelease-valuesfrom-kind-secret-with-comma-separated-values-cannot-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*