### PR TITLE
🌱 litellm: [Feature]: Support OpenAI frontier models (gpt-5.5 / gpt-5.4) on bedrock-mantle

### DIFF
--- a/fixes/cncf-generated/litellm/litellm-29463-feature-support-openai-frontier-models-gpt-5-5-gpt-5-4-on-bedrock-.json
+++ b/fixes/cncf-generated/litellm/litellm-29463-feature-support-openai-frontier-models-gpt-5-5-gpt-5-4-on-bedrock-.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "litellm-29463-feature-support-openai-frontier-models-gpt-5-5-gpt-5-4-on-bedrock-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "litellm: [Feature]: Support OpenAI frontier models (gpt-5.5 / gpt-5.4) on bedrock-mantle via the /openai/v1/responses path",
+    "description": "[Feature]: Support OpenAI frontier models (gpt-5.5 / gpt-5.4) on bedrock-mantle via the /openai/v1/responses path. Requested by 29+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current litellm deployment",
+        "description": "Verify your litellm version and configuration:\n```bash\nkubectl get pods -n litellm -l app.kubernetes.io/name=litellm\nhelm list -n litellm 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working litellm installation."
+      },
+      {
+        "title": "Review litellm configuration",
+        "description": "Inspect the relevant litellm configuration:\n```bash\nkubectl get all -n litellm -l app.kubernetes.io/name=litellm\nkubectl get configmap -n litellm -l app.kubernetes.io/part-of=litellm\n```\n### The Feature\n\nAWS launched OpenAI frontier models (`openai.gpt-5.5`, `openai.gpt-5.4`) on the Bedrock `bedrock-mantle` endpoint on 2026-06-01."
+      },
+      {
+        "title": "Apply the fix for [Feature]: Support OpenAI frontier models (gpt-5.5 /…",
+        "description": "I got it working with those settings:\n```\n      - model_name: \"gpt_model_beta\"\n        litellm_params:\n          model: \"openai/openai.gpt-5.5\"\n          api_base: \"https://bedrock-mantle.us-east-2.api.aws/openai/v1\"\n          drop_params: true\n          additional_drop_params: [\"output_config\"]\n  \n```yaml\n- model_name: \"gpt_model_beta\"\n        litellm_params:\n          model: \"openai/openai.gpt-5.5\"\n          api_base: \"https://bedrock-mantle.us-east-2.api.aws/openai/v1\"\n          drop_params: true\n          additional_drop_params: [\"output_config\"]\n          api_key: XXXX==\n\n    litellm_settings:\n      route_all_chat_openai_to_responses: true\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n litellm -l app.kubernetes.io/name=litellm\nkubectl get events -n litellm --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"[Feature]: Support OpenAI frontier models (gpt-5.5 /…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "I got it working with those settings:\n```\n      - model_name: \"gpt_model_beta\"\n        litellm_params:\n          model: \"openai/openai.gpt-5.5\"\n          api_base: \"https://bedrock-mantle.us-east-2.api.aws/openai/v1\"\n          drop_params: true\n          additional_drop_params: [\"output_config\"]\n          api_key: XXXX==\n\n    litellm_settings:\n      route_all_chat_openai_to_responses:",
+      "codeSnippets": [
+        "- model_name: \"gpt_model_beta\"\n        litellm_params:\n          model: \"openai/openai.gpt-5.5\"\n          api_base: \"https://bedrock-mantle.us-east-2.api.aws/openai/v1\"\n          drop_params: true\n          additional_drop_params: [\"output_config\"]\n          api_key: XXXX==\n\n    litellm_settings:\n      route_all_chat_openai_to_responses: true"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "litellm",
+      "community",
+      "llm-gateway",
+      "feature"
+    ],
+    "cncfProjects": [
+      "litellm"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/BerriAI/litellm/issues/29463",
+      "repo": "https://github.com/BerriAI/litellm"
+    },
+    "reactions": 29,
+    "comments": 11,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with litellm installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-05T07:53:51.163Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: litellm — [Feature]: Support OpenAI frontier models (gpt-5.5 / gpt-5.4) on bedrock-mantle via the /openai/v1/responses path

**Type:** feature | **Source:** https://github.com/BerriAI/litellm/issues/29463 (29 reactions)
**File:** `fixes/cncf-generated/litellm/litellm-29463-feature-support-openai-frontier-models-gpt-5-5-gpt-5-4-on-bedrock-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*