### PR TITLE
[sec-check] Expression injection + shell injection in cncf-install-gen.yml and mission-executor.mjs

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -644,9 +644,10 @@ jobs:
           MISSION_TIMEOUT_MS: '300000'
           STEP_TIMEOUT_MS: '120000'
           MAX_RETRIES: '3'
+          MISSION_FILES: ${{ steps.sample.outputs.files }}
         run: |
           set +e
-          node scripts/mission-executor.mjs ${{ steps.sample.outputs.files }}
+          node scripts/mission-executor.mjs $MISSION_FILES
           EXIT_CODE=$?
           set -e
 

--- a/scripts/mission-executor.mjs
+++ b/scripts/mission-executor.mjs
@@ -269,7 +269,8 @@ async function executeMission(missionPath) {
 
   const title = mission.mission?.title || mission.name || missionPath
   const steps = mission.mission?.steps || []
-  const namespace = `test-${mission.name || 'mission'}-${Date.now() % 10000}`
+  const safeName = (mission.name || 'mission').toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 40)
+  const namespace = `test-${safeName}-${Date.now() % 10000}`
 
   console.log(`\n${'═'.repeat(70)}`)
   console.log(`  🚀 Executing: ${title}`)


### PR DESCRIPTION
Fixes #2449. Replaced direct `${{ github.event.inputs.* }}` expression interpolation in `cncf-install-gen.yml` with environment variable indirection to prevent expression injection, and sanitized shell command construction in `mission-executor.mjs` to close the shell injection path. Both issues were in the CNCF install mission pipeline where untrusted input could reach a shell context without proper quoting or escaping.