### PR TITLE
🌱 kepler: getKernelVersion doesn't work at all

### DIFF
--- a/fixes/cncf-generated/kepler/kepler-179-getkernelversion-doesn-t-work-at-all.json
+++ b/fixes/cncf-generated/kepler/kepler-179-getkernelversion-doesn-t-work-at-all.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kepler-179-getkernelversion-doesn-t-work-at-all",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kepler: getKernelVersion doesn't work at all",
+    "description": "getKernelVersion doesn't work at all. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify kepler troubleshoot symptoms",
+        "description": "Check for the issue in your kepler deployment:\n```bash\nkubectl get pods -n kepler -l app.kubernetes.io/name=kepler\nkubectl logs -l app.kubernetes.io/name=kepler -n kepler --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review kepler configuration",
+        "description": "Inspect the relevant kepler configuration:\n```bash\nkubectl get all -n kepler -l app.kubernetes.io/name=kepler\nkubectl get configmap -n kepler -l app.kubernetes.io/part-of=kepler\n```\nA clear and concise description of what the bug is."
+      },
+      {
+        "title": "Apply the fix for getKernelVersion doesn't work at all",
+        "description": "will wait for merge this then follow up with https://github.com/sustainable-computing-io/kepler/issues/179\n```yaml\npackage main\n\nimport (\n\t\"encoding/json\"\n\t\"fmt\"\n\n\t\"github.com/zcalusic/sysinfo\"\n)\n\nfunc main() {\n\n\tvar si sysinfo.SysInfo\n\n\tsi.GetSysInfo()\n\n\tdata, err := json.MarshalIndent(&si, \"\", \"  \")\n\tif err == nil {\n\t\tvar result map[string]map[string]string\n\t\tif err = json.Unmarshal(data, &result); err != nil {\n\t\t\tfmt.Println(\"----\")\n\t\t\tfmt.Println(err)\n\t\t\tfmt.Println(\"----\")\n\t\t}\n\t}\n\tfmt.Println(\"done\")\n}\n```"
+      },
+      {
+        "title": "Confirm getKernelVersion doesn't work at all is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=kepler -n kepler --tail=50 --since=5m\nkubectl get events -n kepler --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "will wait for merge this then follow up with https://github.com/sustainable-computing-io/kepler/issues/179",
+      "codeSnippets": [
+        "package main\n\nimport (\n\t\"encoding/json\"\n\t\"fmt\"\n\n\t\"github.com/zcalusic/sysinfo\"\n)\n\nfunc main() {\n\n\tvar si sysinfo.SysInfo\n\n\tsi.GetSysInfo()\n\n\tdata, err := json.MarshalIndent(&si, \"\", \"  \")\n\tif err == nil {\n\t\tvar result map[string]map[string]string\n\t\tif err = json.Unmarshal(data, &result); err != nil {\n\t\t\tfmt.Println(\"----\")\n\t\t\tfmt.Println(err)\n\t\t\tfmt.Println(\"----\")\n\t\t}\n\t}\n\tfmt.Println(\"done\")\n}",
+        "----\njson: cannot unmarshal number into Go value of type string\n----\ndone",
+        "package main\n\nimport (\n\t\"encoding/json\"\n\t\"fmt\"\n\n\t\"github.com/zcalusic/sysinfo\"\n)\n\nfunc main() {\n\n\tvar si sysinfo.SysInfo\n\n\tsi.GetSysInfo()\n\n\tdata, err := json.MarshalIndent(&si, \"\", \"  \")\n\tfmt.Println(data)\n\tfmt.Println(si)\n\tfmt.Println(si.Kernel.Version)\n\tif err == nil {\n\t\tvar result map[string]map[string]string\n\t\tif err = json.Unmarshal(data, &result); err != nil {\n\t\t\tfmt.Println(\"----\")\n\t\t\tfmt.Println(err)\n\t\t\tfmt.Println(\"----\")\n\t\t}\n\t}\n\tfmt.Println(\"done\")\n}"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kepler",
+      "sandbox",
+      "observability",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "kepler"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/sustainable-computing-io/kepler/issues/179",
+      "repo": "https://github.com/sustainable-computing-io/kepler",
+      "pr": "https://github.com/sustainable-computing-io/kepler/pull/180"
+    },
+    "reactions": 0,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kepler installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-07T07:37:53.553Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kepler — getKernelVersion doesn't work at all

**Type:** troubleshoot | **Source:** https://github.com/sustainable-computing-io/kepler/issues/179 (0 reactions)
**Fix PR:** https://github.com/sustainable-computing-io/kepler/pull/180
**File:** `fixes/cncf-generated/kepler/kepler-179-getkernelversion-doesn-t-work-at-all.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*