### PR TITLE
🌱 kubevirt: Replace cirros  in the kubevirt E2E Tests.

### DIFF
--- a/fixes/cncf-generated/kubevirt/kubevirt-15043-replace-cirros-in-the-kubevirt-e2e-tests.json
+++ b/fixes/cncf-generated/kubevirt/kubevirt-15043-replace-cirros-in-the-kubevirt-e2e-tests.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kubevirt-15043-replace-cirros-in-the-kubevirt-e2e-tests",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kubevirt: Replace cirros  in the kubevirt E2E Tests.",
+    "description": "Replace cirros  in the kubevirt E2E Tests.. Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current kubevirt deployment",
+        "description": "Verify your kubevirt version and configuration:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nhelm list -n kubevirt 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working kubevirt installation."
+      },
+      {
+        "title": "Review kubevirt configuration",
+        "description": "Inspect the relevant kubevirt configuration:\n```bash\nkubectl get all -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get configmap -n kubevirt -l app.kubernetes.io/part-of=kubevirt\n```\nThe IBMZ (s390x) architecture does not support Cirros and due to this, We are not able to  run all the Kubevirt E2E Tests across various (compute,storage,network)."
+      },
+      {
+        "title": "Apply the fix for Replace cirros  in the kubevirt E2E Tests.",
+        "description": "I have raised this draft pr: https://github.com/kubevirt/kubevirt/pull/15090. Where i have replaced  some of the tests from cirros to alpine. I have ran the different sig lanes(compute,storage,network,operator etc.) I compared these test results  with one of the open pr from the existing open prs in kubevirt. What i have observed is that even after replacing the cirros to alpine. There is no increase in the test time run. \nThe test runs on the draft\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get events -n kubevirt --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Replace cirros  in the kubevirt E2E Tests.\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "I have raised this draft pr: https://github.com/kubevirt/kubevirt/pull/15090. Where i have replaced  some of the tests from cirros to alpine. I have ran the different sig lanes(compute,storage,network,operator etc.) I compared these test results  with one of the open pr from the existing open prs in kubevirt. What i have observed is that even after replacing the cirros to alpine.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kubevirt",
+      "incubating",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "kubevirt"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/kubevirt/kubevirt/issues/15043",
+      "repo": "https://github.com/kubevirt/kubevirt"
+    },
+    "reactions": 4,
+    "comments": 14,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kubevirt installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-09T07:22:37.367Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kubevirt — Replace cirros  in the kubevirt E2E Tests.

**Type:** feature | **Source:** https://github.com/kubevirt/kubevirt/issues/15043 (4 reactions)
**File:** `fixes/cncf-generated/kubevirt/kubevirt-15043-replace-cirros-in-the-kubevirt-e2e-tests.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*