### PR TITLE
[scanner] fix: scope GITHUB_TOKEN permissions in 15 console-kb workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,10 +4,11 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   assignment-helper:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,11 +9,12 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   build-index:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -22,12 +22,13 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   plan:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.calc.outputs.matrix }}
@@ -120,6 +121,9 @@ jobs:
           fi
 
   generate:
+    permissions:
+      contents: write
+      pull-requests: write
     needs: plan
     runs-on: ubuntu-latest
     strategy:
@@ -153,6 +157,9 @@ jobs:
           if-no-files-found: ignore
 
   collect:
+    permissions:
+      contents: write
+      pull-requests: write
     needs: [plan, generate]
     if: needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
@@ -571,6 +578,9 @@ jobs:
   # each step, diagnoses failures, and retries — full end-to-end.
   # ════════════════════════════════════════════════════════════════
   integration-test:
+    permissions:
+      contents: read
+      pull-requests: read
     needs: [plan, collect]
     if: |
       needs.plan.outputs.dry_run != 'true' &&
@@ -712,6 +722,9 @@ jobs:
   # quality checks + integration test results. No human needed.
   # ════════════════════════════════════════════════════════════════
   auto-review:
+    permissions:
+      contents: read
+      pull-requests: write
     needs: [plan, collect, integration-test]
     if: |
       always() &&

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,14 +33,15 @@ on:
         required: false
         default: '10'
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   # Compute batch matrix from total project count
   plan:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.calc.outputs.matrix }}
@@ -154,6 +155,10 @@ jobs:
           fi
 
   generate:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     needs: plan
     runs-on: ubuntu-latest
     strategy:
@@ -190,6 +195,10 @@ jobs:
           if-no-files-found: ignore
 
   collect:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     needs: [plan, generate]
     if: needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
@@ -301,6 +310,9 @@ jobs:
           echo "Auto-merge will score and merge passing missions." >> $GITHUB_STEP_SUMMARY
 
   auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     needs: [plan, generate, collect]
     if: needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   feedback:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,13 +6,14 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   greet:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,12 +4,13 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label-helper:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
     secrets: inherit

--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -22,12 +22,13 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   plan:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -137,6 +138,9 @@ jobs:
           echo "Planning: $COUNT platforms in $BATCHES batch(es) of $BATCH_SIZE"
 
   generate:
+    permissions:
+      contents: write
+      pull-requests: write
     needs: plan
     runs-on: ubuntu-latest
     strategy:
@@ -179,6 +183,9 @@ jobs:
             platform-report-*.md
 
   collect:
+    permissions:
+      contents: write
+      pull-requests: write
     needs: [plan, generate]
     if: ${{ needs.plan.outputs.dry_run != 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,9 +4,7 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   verify:

--- a/.github/workflows/scan-missions.yml
+++ b/.github/workflows/scan-missions.yml
@@ -15,12 +15,13 @@ on:
     - cron: '0 6 * * 1'  # Weekly Monday 6:00am UTC
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   scan:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,10 +5,11 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
     secrets: inherit


### PR DESCRIPTION
## Fix

Moves write-level `GITHUB_TOKEN` permissions from workflow top-level to per-job blocks for 15 workflows, adding `permissions: read-all` at the top level as the default.

### Single-job workflows hardened
`ai-fix.yml`, `add-help-wanted.yml`, `assignment-helper.yml`, `build-index.yml`, `copilot-automation.yml`, `feedback.yml`, `greetings.yml`, `label-helper.yml`, `pr-verifier.yml`, `scan-missions.yml`, `scorecard.yml`, `stale.yml`

### Multi-job workflows hardened (per-job scoping)
- **`cncf-install-gen.yml`** — `plan`, `generate`, `collect` get `contents+pull-requests: write`; `auto-review` gets `pull-requests: write`; `integration-test` gets read-only
- **`cncf-mission-gen.yml`** — `plan`, `generate`, `collect` get `contents+pull-requests+issues: write`; `auto-merge` gets `contents+pull-requests: write`
- **`platform-install-gen.yml`** — `plan`, `generate`, `collect` get `contents+pull-requests: write`

Fixes #2439

---
*Filed by scanner agent (ACMM L6 — automerge mode)*