### PR TITLE
🌱 cilium: CFP: Support TCPRoute and UDPRoute in Cilium Gateway API

### DIFF
--- a/fixes/cncf-generated/cilium/cilium-21929-cfp-support-tcproute-and-udproute-in-cilium-gateway-api.json
+++ b/fixes/cncf-generated/cilium/cilium-21929-cfp-support-tcproute-and-udproute-in-cilium-gateway-api.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "cilium-21929-cfp-support-tcproute-and-udproute-in-cilium-gateway-api",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "cilium: CFP: Support TCPRoute and UDPRoute in Cilium Gateway API",
+    "description": "CFP: Support TCPRoute and UDPRoute in Cilium Gateway API. Requested by 114+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current cilium deployment",
+        "description": "Verify your cilium version and configuration:\n```bash\nkubectl get pods -n cilium -l app.kubernetes.io/name=cilium\nhelm list -n cilium 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working cilium installation."
+      },
+      {
+        "title": "Review cilium configuration",
+        "description": "Inspect the relevant cilium configuration:\n```bash\nkubectl get all -n cilium -l app.kubernetes.io/name=cilium\nkubectl get configmap -n cilium -l app.kubernetes.io/part-of=cilium\n```\nWhen talking about supporting TCPRoute and UDPRoute in Cilium, there are some important things to note:\n- The functionality is basically equivalent to creating a Loadbalancer type Service\n- Because of that, theoretically, Cilium's LB-IPAM feature,"
+      },
+      {
+        "title": "Apply the fix for CFP: Support TCPRoute and UDPRoute in Cilium Gateway API",
+        "description": "This is a note from https://github.com/cilium/cilium/pull/30089#issuecomment-2088449659\n\nFor our organization, the proxy protocol is not needed.\nWe would like cilium to terminate TLS for the stream and then forward packets to backend.\n\nFor now, since cilium doesn't support TCPRoute, I had to use\n```yaml\nGitea GW definition that's relevant:\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n cilium -l app.kubernetes.io/name=cilium\nkubectl get events -n cilium --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"CFP: Support TCPRoute and UDPRoute in Cilium Gateway API\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "This is a note from https://github.com/cilium/cilium/pull/30089#issuecomment-2088449659\n\nFor our organization, the proxy protocol is not needed.\nWe would like cilium to terminate TLS for the stream and then forward packets to backend.\n\nFor now, since cilium doesn't support TCPRoute, I had to use SNI and make my pods supports TLS so that I can use TLS passthrough.",
+      "codeSnippets": [
+        "Gitea GW definition that's relevant:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "cilium",
+      "graduated",
+      "networking",
+      "feature"
+    ],
+    "cncfProjects": [
+      "cilium"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Deployment",
+      "Node"
+    ],
+    "difficulty": "expert",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/cilium/cilium/issues/21929",
+      "repo": "https://github.com/cilium/cilium"
+    },
+    "reactions": 114,
+    "comments": 112,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with cilium installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-11T07:43:53.397Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: cilium — CFP: Support TCPRoute and UDPRoute in Cilium Gateway API

**Type:** feature | **Source:** https://github.com/cilium/cilium/issues/21929 (114 reactions)
**File:** `fixes/cncf-generated/cilium/cilium-21929-cfp-support-tcproute-and-udproute-in-cilium-gateway-api.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*