### PR TITLE
🌱 [scanner] fix: add fork guard to pull_request_target workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
Fixes #2572
Fixes #2578

Adds fork guard (`github.event.pull_request.head.repo.full_name == github.repository`) to pull_request_target workflows to prevent write-permission exploitation from forks.

Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>