### PR TITLE
[scanner] fix: add fork guard to copilot-automation.yml

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
Fixes #2623

Adds fork guard condition to pull_request_target triggered jobs to prevent unauthorized access from fork PRs.