### PR TITLE
[scanner] fix: harden workflow security (3 workflows)

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -14,4 +14,3 @@ permissions:
 jobs:
   greet:
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
-    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -11,4 +11,3 @@ permissions:
 jobs:
   verify:
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit


### PR DESCRIPTION
Fixes #2624, Fixes #2625, Fixes #2626

Hardens pull_request_target workflows by adding fork guards and removing unnecessary secrets exposure.

- **ai-fix.yml**: Added fork guard to prevent fork PRs from running with write permissions
- **greetings.yml**: Removed `secrets: inherit` (github.token provided automatically)
- **pr-verifier.yml**: Removed `secrets: inherit` (github.token provided automatically)