### PR TITLE
[scanner] fix: pin kubestellar/infra workflow refs to SHA

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   greet:
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19

--- a/scripts/lib/text-utils.mjs
+++ b/scripts/lib/text-utils.mjs
@@ -17,8 +17,10 @@ const MIN_ENGLISH_STOPWORD_RATIO = 0.08
  * headers, emoji shortcodes, and other non-content noise from issue/PR text.
  */
 export function cleanText(text) {
-  return text
-    .replace(/<!--[\s\S]*?-->/g, '')
+  let t = text
+  let prev
+  do { prev = t; t = t.replace(/<!--[\s\S]*?-->/g, '') } while (t !== prev)
+  return t
     .replace(/# \[?Codecov\]?[\s\S]*?(?=\n#{1,4}\s|\n---|\n\n\n|$)/gi, '')
     .replace(/!\[.*?\]\(https?:\/\/[^)]+\)/g, '')
     .replace(/<img\s+[^>]*>/gi, '')
@@ -71,7 +73,8 @@ export function isGarbageSnippet(snippet) {
   if (lower.includes('for first time contributors') || lower.includes('please ensure your pull request')) return true
   if (lower.includes('query performance') && lower.includes('![image]')) return true
   if (lower.includes('"tag_name"') || lower.includes('"html_url"') || lower.includes('"created_at"')) return true
-  if (lower.includes('api.github.com')) return true
+  const urlMatches = snippet.match(/https?:\/\/[^\s"')>]+/g) || []
+  if (urlMatches.some(u => { try { return new URL(u).hostname === 'api.github.com' } catch { return false } })) return true
   const words = snippet.split(/\s+/)
   const englishWords = words.filter(w => ENGLISH_STOPWORDS.has(w.toLowerCase()))
   const PROSE_THRESHOLD = 0.25
@@ -160,7 +163,8 @@ export function extractFromBoldTemplate(text) {
 export function stripPRTemplate(text) {
   if (!text) return ''
   let cleaned = text
-  cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, '')
+  let prev
+  do { prev = cleaned; cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, '') } while (cleaned !== prev)
   const templateHeaders = [
     /#{1,4}\s*What type of PR[\s\S]*?(?=\n#{1,4}\s|\n---|\Z)/gi,
     /#{1,4}\s*What this PR does[\s\S]*?(?=\n#{1,4}\s|\n---|\Z)/gi,

--- a/scripts/scanner.mjs
+++ b/scripts/scanner.mjs
@@ -340,7 +340,7 @@ export function formatScanResultAsMarkdown(filename, result) {
     lines.push('| Type | Value |');
     lines.push('|------|-------|');
     for (const f of result.scan.sensitive.findings) {
-      const escapedValue = f.value.replace(/\|/g, '\\|').replace(/`/g, '\\`');
+      const escapedValue = f.value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/`/g, '\\`');
       lines.push(`| ${f.type} | \`${escapedValue}\` |`);
     }
   }
@@ -356,7 +356,7 @@ export function formatScanResultAsMarkdown(filename, result) {
     lines.push('| Type | Match |');
     lines.push('|------|-------|');
     for (const f of result.scan.malicious.findings) {
-      const escapedValue = f.value.replace(/\|/g, '\\|').replace(/`/g, '\\`');
+      const escapedValue = f.value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/`/g, '\\`');
       lines.push(`| ${f.type} | \`${escapedValue}\` |`);
     }
   }

--- a/scripts/sources/stackoverflow.mjs
+++ b/scripts/sources/stackoverflow.mjs
@@ -170,22 +170,22 @@ function stripHtml(html) {
   return html
     .replace(/<pre><code[^>]*>[\s\S]*?<\/code><\/pre>/g, '[code block]')
     .replace(/<[^>]+>/g, '')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .trim()
 }
 
 function cleanHtmlEntities(text) {
   return text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
 }
 
 function extractHtmlCodeBlocks(html) {


### PR DESCRIPTION
Fixes kubestellar/console#19472

Pins reusable workflow references from `@main` to specific commit SHA to prevent supply-chain attacks via pull_request_target.

Signed-off-by: scanner <scanner@kubestellar.io>