### PR TITLE
[scanner] fix: security hardening - XSS, HTML sanitization, and command injection

### DIFF
--- a/scripts/mission-executor.mjs
+++ b/scripts/mission-executor.mjs
@@ -40,8 +40,9 @@ function getToken() {
 
 // Allowlist of permitted base commands for Kubernetes installation missions.
 // Every pipeline segment in LLM-provided commands must start with one of these.
+// NOTE: bash/sh removed to prevent shell -c injection bypass.
 const ALLOWED_BASE_COMMANDS = new Set([
-  'kubectl', 'helm', 'curl', 'bash', 'sh', 'cat', 'echo', 'grep',
+  'kubectl', 'helm', 'curl', 'cat', 'echo', 'grep',
   'awk', 'sed', 'jq', 'yq', 'kustomize', 'istioctl', 'date', 'ls',
   'sleep', 'timeout', 'base64', 'tr', 'cut', 'wc', 'head', 'tail',
   'printf', 'test', 'true', 'false', 'mkdir', 'rm', 'cp', 'mv',
@@ -56,6 +57,19 @@ const ALLOWED_BASE_COMMANDS = new Set([
  * child_process.execSync (CWE-078, CWE-088).
  */
 function validateCommand(cmd) {
+  // Block subshell expansion patterns
+  if (/\$\(/.test(cmd)) {
+    return { safe: false, reason: 'Subshell expansion $() is not allowed' }
+  }
+  if (/`/.test(cmd)) {
+    return { safe: false, reason: 'Backtick command substitution is not allowed' }
+  }
+
+  // Block bash/sh -c invocations
+  if (/\b(?:bash|sh)\b.*\s+-c\b/.test(cmd)) {
+    return { safe: false, reason: 'Shell -c execution is not allowed' }
+  }
+
   // Split on all shell delimiters to check each pipeline segment individually
   const segments = cmd.split(/\s*(?:;|&&|\|\||\|(?!\|)|\(|\))\s*/).filter(Boolean)
   for (const seg of segments) {

--- a/scripts/sources/llm-synthesizer.mjs
+++ b/scripts/sources/llm-synthesizer.mjs
@@ -341,7 +341,9 @@ function cleanInput(text) {
     .replace(/## \[?Codecov[\s\S]*?(?=\n## |\n---|\Z)/gi, '')
     .replace(/\|[^|]*coverage[^|]*\|[\s\S]*?\n\n/gi, '')
     .replace(/!\[[^\]]*\]\([^)]+\)/g, '[image removed]')
-    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')   // Remove well-formed comments
+    .replace(/<!-->/g, '')              // Remove malformed <!--> opener
+    .replace(/-->/g, '')                // Remove any orphaned --> closers
     .replace(/#{1,3}\s*(?:What this PR does|Release note|Changelog|Special notes)[\s\S]*?(?=\n#{1,3} |\n---|\Z)/gi, '')
     .replace(/\n{3,}/g, '\n\n')
     .trim()

--- a/scripts/sources/stackoverflow.mjs
+++ b/scripts/sources/stackoverflow.mjs
@@ -169,12 +169,13 @@ export class StackOverflowSource extends BaseSource {
 function stripHtml(html) {
   return html
     .replace(/<pre><code[^>]*>[\s\S]*?<\/code><\/pre>/g, '[code block]')
-    .replace(/<[^>]+>/g, '')
+    .replace(/<[^>]+>/g, '')          // First pass: remove real HTML tags
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&amp;/g, '&')
+    .replace(/<[^>]+>/g, '')          // Second pass: remove tags revealed by entity decoding
     .replace(/\s+/g, ' ')
     .trim()
 }


### PR DESCRIPTION
## Summary

This PR fixes three critical security vulnerabilities found by CodeQL security scanning:

### Fixes

1. **#2643 — XSS via HTML entity decoding after tag stripping** (`stackoverflow.mjs`)
   - Added second tag-stripping pass after entity decoding
   - Prevents entity-encoded tags like `&lt;script&gt;` from becoming executable after decoding

2. **#2644 — Incomplete HTML comment sanitization** (`llm-synthesizer.mjs`)
   - Added removal of malformed comment patterns (`<!-->`, orphaned `-->`)
   - Hardens against adversarial HTML comment edge cases

3. **#2645 — Command-line injection via shell bypass** (`mission-executor.mjs`)
   - Removed `bash` and `sh` from allowed commands list
   - Added detection for subshell expansion (`$()`, backticks)
   - Blocks `shell -c` invocation patterns
   - Prevents LLM-generated commands from executing arbitrary code

### Impact

All three issues are high/critical severity and could allow:
- XSS attacks in rendered knowledge base content
- HTML injection via malformed comments
- Arbitrary command execution from compromised/adversarial LLM output

### Testing

- [x] Code compiles
- [x] Applied recommended fixes from security team
- [x] Verified regex patterns match expected attack vectors

---

Fixes #2643  
Fixes #2644  
Fixes #2645

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>