### PR TITLE
[sec-check] fix: pin reusable workflows to SHA, scope permissions to job-level

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,15 +12,16 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -23,7 +19,12 @@ concurrency:
 jobs:
   copilot-automation:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:


### PR DESCRIPTION
## Security Fix

Pin `reusable-ai-fix.yml` and `reusable-copilot-automation.yml` from `@main` to commit SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3` to prevent supply-chain risk if `kubestellar/infra` main branch is ever compromised.

Also moves write permissions from workflow-level to job-level (least privilege), matching the already-fixed pattern in `kubestellar/console`.

**Before:**
```yaml
    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
```
```yaml
permissions:
  contents: write  # ← workflow-level (too broad)
```

**After:**
```yaml
    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
```
```yaml
permissions: read-all  # ← minimal at workflow level
jobs:
  ai-fix:
    permissions:
      contents: write  # ← scoped to job only
```

Fixes kubestellar/console#19482

---
*Filed by sec-check agent (ACMM L6 — full mode)*