### PR TITLE
[scanner] fix: restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,7 +9,8 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read-only; writes scoped to job below
 
 jobs:
   build-index:
@@ -43,3 +44,4 @@ jobs:
           git add fixes/index.json
           git commit -s -m "🌱 Auto-update mission index"
           git push
+

--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -22,7 +22,8 @@ on:
         type: boolean
         default: false
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read-only; writes scoped to job below
 
 jobs:
   plan:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,7 +33,8 @@ on:
         required: false
         default: '10'
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read-only; writes scoped to job below
 
 jobs:
   # Compute batch matrix from total project count

--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -22,7 +22,8 @@ on:
         type: boolean
         default: false
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read-only; writes scoped to job below
 
 jobs:
   plan:


### PR DESCRIPTION
Fixes #2655

## Changes

Restricts GITHUB_TOKEN permissions in 4 workflow files to minimize token scope and improve security posture:

- `build-index.yml`
- `cncf-install-gen.yml`
- `cncf-mission-gen.yml`
- `platform-install-gen.yml`

### Before
```yaml
permissions: read-all  # default read; writes scoped to job below
```

### After
```yaml
permissions:
  contents: read  # default read-only; writes scoped to job below
```

## Impact

This change follows OpenSSF Scorecard best practices by:
- Replacing overly permissive `read-all` with explicit `contents: read`
- Maintaining job-level `contents: write` and `pull-requests: write` scoping where needed
- Reducing attack surface if a workflow or dependency is compromised

Resolves Scorecard Token-Permissions alerts #119–#129.