### PR TITLE
[sec-check] fix: restrict GITHUB_TOKEN permissions to least privilege

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,7 +5,8 @@ on:
     paths:
       - '.github/workflows/**'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   actionlint:

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,7 +12,8 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   ai-fix:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,8 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/scan-missions.yml
+++ b/.github/workflows/scan-missions.yml
@@ -15,7 +15,8 @@ on:
     - cron: '0 6 * * 1'  # Weekly Monday 6:00am UTC
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
 
 jobs:
   scan:

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -15,7 +15,8 @@ on:
     - cron: '30 5 * * 1'  # Weekly Monday 5:30am UTC
   workflow_dispatch:
 
-permissions: read-all  # default read; no writes needed
+permissions:
+  contents: read
 
 jobs:
   validate:


### PR DESCRIPTION
Fixes #2665

Restricts GITHUB_TOKEN permissions to least privilege across 5 workflows that previously used `permissions: read-all`:
- `actionlint.yml` → `contents: read`
- `validate-schema.yml` → `contents: read`
- `scan-missions.yml` → `contents: read`
- `ai-fix.yml` → `contents: read`
- `copilot-automation.yml` → `contents: read`