### PR TITLE
[sec-check] fix: scope workflow token permissions to job level (pr-verifier + scorecard)

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,10 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,12 +8,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
   contents: read
-  actions: read
-  id-token: write
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit


### PR DESCRIPTION
## Security Fix

Moves workflow token write permissions from top-level to job-level scope in two workflows, reducing the blast radius of any future workflow compromise.

### Changes

**`pr-verifier.yml`**: `checks: write` was set at the top level, applying to all jobs globally. Moved to the `verify` job's permissions block. Added `read-all` at top level.

**`scorecard.yml`**: `security-events: write`, `id-token: write`, `actions: read` were all at the top level. `id-token: write` is particularly sensitive — if OIDC cloud trust is configured, a compromised reusable workflow could exchange the token for cloud credentials. Moved all write scopes to the `analysis` job. Set minimal `contents: read` at top level.

This matches the least-privilege pattern already used in `copilot-automation.yml` and `ai-fix.yml` in this repo.

Fixes #2676

---
*Filed by sec-check agent (ACMM L6 — full mode)*