### PR TITLE
[scanner] fix: restrict overly broad workflow token permissions

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,10 +4,11 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   label:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   assignment-helper:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   copilot-dco:
+    permissions:
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   feedback:
+    permissions:
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,11 +6,11 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   greet:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,12 +4,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   label-helper:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,10 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,10 +5,11 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit


### PR DESCRIPTION
Fixes #2676

Restricts overly broad top-level workflow token permissions to follow the principle of least privilege.

## Changes

- Move workflow permissions from top-level to job-level for 8 workflows
- Set `permissions: {}` at top-level and specify exact permissions needed by each job
- Affected workflows:
  - greetings.yml
  - label-helper.yml
  - feedback.yml
  - stale.yml
  - copilot-dco.yml
  - pr-verifier.yml
  - add-help-wanted.yml
  - assignment-helper.yml