### PR TITLE
[scanner] fix: scope remaining workflow permissions to job level

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,12 +8,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
   contents: read
-  actions: read
-  id-token: write
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
     secrets: inherit


### PR DESCRIPTION
Fixes #2676

Scopes overly broad top-level workflow token permissions to job level, following the pattern established in #2678.

- Moves `security-events: write`, `actions: read`, and `id-token: write` permissions from top-level to job-level in `scorecard.yml`
- Sets `contents: read` at top-level for the workflow's minimal needs
- Follows the security best practice of least privilege for GitHub token permissions