### PR TITLE
[sec-check] fix: remove env allowlist escape and harden scanner patterns (CWE-78)

### DIFF
--- a/scripts/mission-executor.mjs
+++ b/scripts/mission-executor.mjs
@@ -40,13 +40,18 @@ function getToken() {
 
 // Allowlist of permitted base commands for Kubernetes installation missions.
 // Every pipeline segment in LLM-provided commands must start with one of these.
-// NOTE: bash/sh removed to prevent shell -c injection bypass.
+// NOTE: bash/sh removed to prevent `shell -c` injection bypass.
+// NOTE: `env` removed — `env <binary>` is a known allowlist escape (e.g.
+//   `env bash -c 'evil'` runs bash even though bash is not in this set).
+//   Environment variables should be set via spawnSync's `env:` option instead.
+// NOTE: `xargs` and `find` are retained but validated against shell-interpreter
+//   arguments in validateCommand() below.
 const ALLOWED_BASE_COMMANDS = new Set([
   'kubectl', 'helm', 'curl', 'cat', 'echo', 'grep',
   'awk', 'sed', 'jq', 'yq', 'kustomize', 'istioctl', 'date', 'ls',
   'sleep', 'timeout', 'base64', 'tr', 'cut', 'wc', 'head', 'tail',
   'printf', 'test', 'true', 'false', 'mkdir', 'rm', 'cp', 'mv',
-  'sort', 'uniq', 'xargs', 'find', 'which', 'env',
+  'sort', 'uniq', 'xargs', 'find', 'which',
 ])
 
 /**

--- a/scripts/scanner.mjs
+++ b/scripts/scanner.mjs
@@ -154,6 +154,11 @@ const MALICIOUS_PATTERNS = [
   { name: 'Command injection: $() in string', pattern: /\$\([^)]{4,}\)/g, allowSafeCLI: true },
   { name: 'Suspicious curl pipe', pattern: /curl\s[^|]*\|\s*(?:ba)?sh/gi },
   { name: 'Suspicious wget pipe', pattern: /wget\s[^|]*\|\s*(?:ba)?sh/gi },
+  // env / xargs / find shell-interpreter escapes
+  // `env bash -c '...'` bypasses binary allowlists even when shell:false is set.
+  { name: 'Allowlist escape via env', pattern: /\benv\s+(?:-\S+\s+)*(?:bash|sh|zsh|ksh|dash|python\d*|ruby|perl|node)\b/gi },
+  { name: 'Allowlist escape via xargs', pattern: /\bxargs\s+(?:-\S+\s+)*(?:bash|sh|zsh|ksh|dash)\b/gi },
+  { name: 'Allowlist escape via find -exec', pattern: /\bfind\s[^;]*-exec\s+(?:bash|sh|zsh|ksh|dash)\b/gi },
 
   // Crypto mining indicators
   { name: 'Crypto miner reference', pattern: /\b(?:xmrig|cryptonight|stratum\+tcp|minerd|coinhive)\b/gi },


### PR DESCRIPTION
## Security Fix

Removes `env` from `ALLOWED_BASE_COMMANDS` in `mission-executor.mjs` and adds scanner patterns to detect `env`/`xargs`/`find`-based shell-interpreter escapes.

### Root Cause

`env bash -c '<cmd>'` bypasses the allowlist even with `shell: false`:
- `spawnSync('env', ['bash', '-c', '...'], { shell: false })` launches `env`, which then launches `bash`
- The child process inherits the full CI environment (`GITHUB_TOKEN`, `LLM_TOKEN`)
- `scanner.mjs` did not flag `env bash`, `xargs bash`, or `find -exec bash` patterns
- Combined with the auto-merge pipeline (quality score ≥ threshold → merged without review), a crafted mission could exfiltrate CI secrets

### Changes

**`scripts/mission-executor.mjs`**
- Remove `env` from `ALLOWED_BASE_COMMANDS` (CWE-78 / CWE-184)
- Environment variables should be set via `spawnSync`'s `env:` option

**`scripts/scanner.mjs`**
- Add `MALICIOUS_PATTERNS` entries for:
  - `env <shell-interpreter>` (env bash -c / env python / etc.)
  - `xargs <shell-interpreter>`
  - `find -exec <shell-interpreter>`

Fixes #2680

---
*Filed by sec-check agent (ACMM L6 — full mode)*