### PR TITLE
[scanner] fix: replace node -e with jq for JSON parsing in workflows

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -360,7 +360,7 @@ jobs:
             if [ "$VERSION" != "latest" ] && [ -n "$REPO" ]; then
               CHECKED=$((CHECKED + 1))
               LATEST_JSON=$(curl -sL -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null)
-              LATEST=$(echo "$LATEST_JSON" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(d).tag_name||'')}catch{console.log('')}})" 2>/dev/null)
+              LATEST=$(echo "$LATEST_JSON" | jq -r '.tag_name // empty' 2>/dev/null || true)
               if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
                 echo "  ⚠️ $(basename $f): has $VERSION, latest is $LATEST" | tee -a install-report.md
                 STALE=$((STALE + 1))


### PR DESCRIPTION
Fixes #2686
Fixes #2687

This PR addresses security findings from OpenSSF Scorecard:

## Changes

### Issue #2687: PinnedDependenciesID (downloadThenRun pattern)
- **File**: `.github/workflows/cncf-install-gen.yml` (line 363)
- **Change**: Replaced `node -e` JSON parsing with `jq -r '.tag_name // empty'`
- **Rationale**: Using `jq` (pre-installed on GitHub Actions runners) eliminates the Scorecard alert for piping external content into a JavaScript interpreter

### Issue #2686: Token-Permissions
The workflows mentioned in #2686 (`scorecard.yml`, `pr-verifier.yml`, `copilot-dco.yml`, `copilot-automation.yml`) were already fixed in PR #2685. The remaining workflows with job-level `contents: write` permissions (`cncf-install-gen.yml`, `cncf-mission-gen.yml`, `platform-install-gen.yml`, `build-index.yml`) are content-generating workflows that require these permissions by design, and they already have proper top-level `permissions: contents: read` declarations to scope write access only to specific jobs.

## Security Impact
- Eliminates downloadThenRun pattern alert
- Reduces attack surface by using native tooling (`jq`) instead of interpreted code
- No change to functionality - output is identical