### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,11 +4,10 @@ on:
   issues:
     types: [labeled]
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   label:
-    permissions:
-      issues: write
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,16 +13,13 @@ on:
     types: [opened]
 
 permissions:
-  contents: read
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,10 +4,9 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   assignment-helper:
-    permissions:
-      issues: write
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,7 +11,10 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -19,13 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      statuses: write
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: {}
-
 jobs:
   copilot-dco:
-    permissions:
-      pull-requests: read
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   feedback:
-    permissions:
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,11 +6,12 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   greet:
-    permissions:
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,12 +4,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   label-helper:
-    permissions:
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,11 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions: {}
+permissions:
+  checks: write
+  pull-requests: read
 
 jobs:
   verify:
-    permissions:
-      checks: write
-      pull-requests: read
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-19
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,14 +8,12 @@ on:
   workflow_dispatch:
 
 permissions:
+  security-events: write
   contents: read
+  actions: read
+  id-token: write
 
 jobs:
   analysis:
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-      id-token: write
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,11 +5,10 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   stale:
-    permissions:
-      issues: write
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3  # main@2026-06-24
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:

**Standard Workflows:**
- `add-help-wanted.yml` - Add help-wanted label to issues
- `assignment-helper.yml` - Handle issue assignments
- `feedback.yml` - Collect feedback
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - Security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Assign Copilot to issues with `ai-fix-requested` label
- `copilot-automation.yml` - Automate Copilot PR processing (DCO, labels)
- `copilot-dco.yml` - Override DCO for Copilot PRs

Auto-generated by workflow sync