### PR TITLE
🌱 localai: v3.5.0 MacOS installer is broken on Apple M series

### DIFF
--- a/fixes/cncf-generated/localai/localai-6268-v3-5-0-macos-installer-is-broken-on-apple-m-series.json
+++ b/fixes/cncf-generated/localai/localai-6268-v3-5-0-macos-installer-is-broken-on-apple-m-series.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "localai-6268-v3-5-0-macos-installer-is-broken-on-apple-m-series",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "localai: v3.5.0 MacOS installer is broken on Apple M series",
+    "description": "v3.5.0 MacOS installer is broken on Apple M series. This issue affects 8+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify localai troubleshoot symptoms",
+        "description": "Check for the issue in your localai deployment:\n```bash\nkubectl get pods -n localai -l app.kubernetes.io/name=localai\nkubectl logs -l app.kubernetes.io/name=localai -n localai --tail=100 | grep -i error\n```\nLook for error: ``\"LocalAI\" is damaged and can't be opened.``"
+      },
+      {
+        "title": "Review localai configuration",
+        "description": "Inspect the relevant localai configuration:\n```bash\nkubectl get all -n localai -l app.kubernetes.io/name=localai\nkubectl get configmap -n localai -l app.kubernetes.io/part-of=localai\n```\n**LocalAI version:**\n\n3.5.0 MacOS dmg\n\nApple M3 Ultra\n\n```\n% uname -a\nDarwin redacted 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 1155 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6031 arm64\n```\n\nThe LocalAI executable provided in the v3.5.0"
+      },
+      {
+        "title": "Apply the fix for v3.5.0 MacOS installer is broken on Apple M series",
+        "description": "## Background / the issue\n\nUntil now LocalAI's macOS artifacts shipped\n- `LocalAI.dmg` and the `LocalAI.app` inside it had no Developer ID signature.\n- The bare `local-ai-<tag>-darwin-arm64` server binary (the one the launcher downloads at runtime) was also unsigned.\n\nBecause of that, macOS\n```yaml\n% uname -a\nDarwin redacted 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:30:55 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6031 arm64\n```"
+      },
+      {
+        "title": "Confirm v3.5.0 MacOS installer is broken on Apple M series is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=localai -n localai --tail=50 --since=5m\nkubectl get events -n localai --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that ``\"LocalAI\" is damaged and can't be opened.`` no longer appears in logs."
+      }
+    ],
+    "resolution": {
+      "summary": "## Background / the issue\n\nUntil now LocalAI's macOS artifacts shipped\n- `LocalAI.dmg` and the `LocalAI.app` inside it had no Developer ID signature.\n- The bare `local-ai-<tag>-darwin-arm64` server binary (the one the launcher downloads at runtime) was also unsigned.",
+      "codeSnippets": [
+        "% uname -a\nDarwin redacted 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:30:55 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6031 arm64"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "localai",
+      "community",
+      "llm-serving",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "localai"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/mudler/LocalAI/issues/6268",
+      "repo": "https://github.com/mudler/LocalAI",
+      "pr": "https://github.com/mudler/LocalAI/pull/10510"
+    },
+    "reactions": 8,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with localai installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-06-29T08:07:07.424Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: localai — v3.5.0 MacOS installer is broken on Apple M series

**Type:** troubleshoot | **Source:** https://github.com/mudler/LocalAI/issues/6268 (8 reactions)
**Fix PR:** https://github.com/mudler/LocalAI/pull/10510
**File:** `fixes/cncf-generated/localai/localai-6268-v3-5-0-macos-installer-is-broken-on-apple-m-series.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*