### PR TITLE
🌱 headlamp: Disable refresh of Home > All Clusters on startup

### DIFF
--- a/fixes/cncf-generated/headlamp/headlamp-2165-disable-refresh-of-home-all-clusters-on-startup.json
+++ b/fixes/cncf-generated/headlamp/headlamp-2165-disable-refresh-of-home-all-clusters-on-startup.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "headlamp-2165-disable-refresh-of-home-all-clusters-on-startup",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "headlamp: Disable refresh of Home > All Clusters on startup",
+    "description": "Disable refresh of Home > All Clusters on startup. Requested by 11+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current headlamp deployment",
+        "description": "Verify your headlamp version and configuration:\n```bash\nkubectl get pods -n headlamp -l app.kubernetes.io/name=headlamp\nhelm list -n headlamp 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working headlamp installation."
+      },
+      {
+        "title": "Review headlamp configuration",
+        "description": "Inspect the relevant headlamp configuration:\n```bash\nkubectl get all -n headlamp -l app.kubernetes.io/name=headlamp\nkubectl get configmap -n headlamp -l app.kubernetes.io/part-of=headlamp\n```\nI have a huge amount of clusters defined in `.kube/config` which are auto-detected on startup and refreshed by spawning background processes. Would be great if this could be disabled/optimized somehow."
+      },
+      {
+        "title": "Apply the fix for Disable refresh of Home > All Clusters on startup",
+        "description": "There's some discussion in https://github.com/kubernetes-sigs/headlamp/issues/2623 which was a duplicate issue.\n\nA snippet from there about a proposed solution:\n\n>In any case, I think a global setting like this would work:\n\n>>  wrote:\n>> Your proposed solution would be ideal - in my case I'd probably always default it to 'None', and then connect to them as needed and intentionally. I would also suggest that be the default behavior, as there are a number of reasons to not automatically query\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n headlamp -l app.kubernetes.io/name=headlamp\nkubectl get events -n headlamp --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Disable refresh of Home > All Clusters on startup\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "There's some discussion in https://github.com/kubernetes-sigs/headlamp/issues/2623 which was a duplicate issue.\n\nA snippet from there about a proposed solution:\n\n>In any case, I think a global setting like this would work:\n\n>>  wrote:\n>> Your proposed solution would be ideal - in my case I'd probably always default it to 'None', and then connect to them as needed and intentionally.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "headlamp",
+      "sandbox",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "headlamp"
+    ],
+    "targetResourceKinds": [
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/kubernetes-sigs/headlamp/issues/2165",
+      "repo": "https://github.com/kubernetes-sigs/headlamp"
+    },
+    "reactions": 11,
+    "comments": 11,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with headlamp installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-07-01T07:44:11.679Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: headlamp — Disable refresh of Home > All Clusters on startup

**Type:** feature | **Source:** https://github.com/kubernetes-sigs/headlamp/issues/2165 (11 reactions)
**File:** `fixes/cncf-generated/headlamp/headlamp-2165-disable-refresh-of-home-all-clusters-on-startup.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*