### PR TITLE
fix: repair ESM import and arg splitting in CI scripts

### DIFF
--- a/scripts/scan-pr.mjs
+++ b/scripts/scan-pr.mjs
@@ -37,7 +37,7 @@ if (args.includes('--all')) {
   files = discoverMissionFiles('fixes');
   console.log(`Discovered ${files.length} mission files to scan.\n`);
 } else {
-  files = args;
+  files = args.flatMap(a => a.split(/\s+/)).filter(Boolean);
 }
 
 if (files.length === 0) {

--- a/scripts/validate-schema.mjs
+++ b/scripts/validate-schema.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { validateMissionExport } from './scanner.mjs';
 
 /** Valid mission file extensions */
@@ -38,7 +38,7 @@ if (args.includes('--all')) {
   files = discoverMissionFiles('fixes');
   console.log(`Discovered ${files.length} mission files to validate.\n`);
 } else {
-  files = args;
+  files = args.flatMap(a => a.split(/\s+/)).filter(Boolean);
 }
 
 if (files.length === 0) {


### PR DESCRIPTION
Fixes CI failures on PRs that touch fixes/ directory.

Two bugs:
1. `validate-schema.mjs` uses `import yaml from 'js-yaml'` but js-yaml has no default ESM export → changed to `import * as yaml from 'js-yaml'`
2. Both scripts receive CHANGED_FILES as a single quoted arg with trailing space from `tr '\n' ' '`. Scripts now split on whitespace and filter empty strings.

Unblocks PR #2724 and all future mission-file PRs.