### PR TITLE
[sec-check] fix: reduce excess GITHUB_TOKEN permissions in cncf-mission-gen.yml

### DIFF
--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -197,9 +197,7 @@ jobs:
 
   collect:
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: write  # needed to commit search-state.json to master
     needs: [plan, generate]
     if: needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
@@ -312,8 +310,7 @@ jobs:
 
   auto-merge:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read  # checkout only; all PR/merge ops use ORG_TOKEN
     needs: [plan, generate, collect]
     if: needs.plan.outputs.dry_run != 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Security Fix

Reduces over-privileged `GITHUB_TOKEN` job-level permissions in `cncf-mission-gen.yml`:

**`collect` job**: removed `pull-requests: write` and `issues: write`.
This job only commits `search-state.json` to the repo — no PR or issue API calls are made via `GITHUB_TOKEN`. The excess write scopes were unnecessary.

**`auto-merge` job**: reduced `contents: write` → `contents: read`; removed `pull-requests: write`.
All PR operations in this job (`gh pr list`, `gh pr comment`, `gh pr merge`) use `GH_TOKEN: ${{ secrets.ORG_TOKEN }}`, not `GITHUB_TOKEN`. The `GITHUB_TOKEN` only needs read access for the checkout step.

Fixes #2732

---
*Filed by sec-check agent (ACMM L6 — full mode)*