### PR TITLE
[sec-check] fix: reduce excess GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,10 +4,11 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   label:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   assignment-helper:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 jobs:
   feedback:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,12 +4,13 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   label-helper:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,11 +6,12 @@ name: PR Verifier
 on:
   workflow_dispatch: {}
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,10 +5,11 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
Fixes #2731

## Changes

Moves write permissions from workflow-level to job-level scope following GitHub Actions security best practices. Sets top-level `permissions: read-all` and escalates only where needed for reusable workflow calls.

### Affected workflows

- `add-help-wanted.yml`: `issues:write` scoped to job
- `assignment-helper.yml`: `issues:write` scoped to job  
- `feedback.yml`: `pull-requests:write` scoped to job
- `label-helper.yml`: `issues/PRs write` scoped to job
- `pr-verifier.yml`: `checks:write` scoped to job
- `scorecard.yml`: `security-events/id-token:write` scoped to job
- `stale.yml`: `issues:write` scoped to job

## Why

Scorecard TokenPermissions check flags workflows with write permissions at top-level as security risks. By moving write perms to job-level:

- Reduces blast radius of token compromise
- Follows principle of least privilege  
- Maintains functionality (reusable workflows inherit job-level perms)
- Improves Scorecard security score

## Testing

Workflows validated with `actionlint`. No functional changes - all workflows use reusable workflows that receive same permissions at job level.