### PR TITLE
[scanner] fix: reduce excess GITHUB_TOKEN permissions in cncf-mission-gen workflow

### DIFF
--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -157,9 +157,7 @@ jobs:
 
   generate:
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read  # script uses ORG_TOKEN for issue/PR operations
     needs: plan
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Reduces overly broad permissions in the `cncf-mission-gen.yml` generate job.

## Changes

Reduced `generate` job permissions from:
- `contents: write`
- `pull-requests: write`
- `issues: write`

To:
- `contents: read`

## Rationale

The generate job uses `ORG_TOKEN` secret for all write operations (creating issues/PRs). The GITHUB_TOKEN doesn't need write permissions.

## Related

Fixes #2731

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>