### PR TITLE
[ci-maintainer] fix: grant collect job write permissions in platform-install-gen.yml

### DIFF
--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -185,8 +185,8 @@ jobs:
 
   collect:
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
     needs: [plan, generate]
     if: ${{ needs.plan.outputs.dry_run != 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## CI Fix

The `collect` job in `.github/workflows/platform-install-gen.yml` has `contents: read` and `pull-requests: read` permissions, but the "Create PR" step requires `contents: write` (to push a new branch) and `pull-requests: write` (to open a PR). This causes a `403 Permission denied` error on every scheduled run.

**Change:** `collect` job `permissions.contents: read → write` and `permissions.pull-requests: read → write`.

No other jobs are changed — `plan` and `generate` remain read-only as intended by the workflow author.

Fixes #2739

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*