### PR TITLE
[ci-maintainer] fix: restore write permissions in workflow files (read-all escalation bug)

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,11 +4,10 @@ on:
   issues:
     types: [labeled]
 
-permissions: read-all
+permissions:
+  issues: write
 
 jobs:
   label:
-    permissions:
-      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,14 +12,13 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,10 +4,9 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all
+permissions:
+  issues: write
 
 jobs:
   assignment-helper:
-    permissions:
-      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -18,11 +22,6 @@ concurrency:
 
 jobs:
   copilot-automation:
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      statuses: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,11 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all
+permissions:
+  statuses: write
+  pull-requests: read
 
 jobs:
   copilot-dco:
-    permissions:
-      statuses: write
-      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,12 +4,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   feedback:
-    permissions:
-      contents: read
-      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,7 +6,9 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions: read-all
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   greet:
@@ -17,9 +19,6 @@ jobs:
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - name: Greet contributor
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,13 +4,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   label-helper:
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,12 +6,11 @@ name: PR Verifier
 on:
   workflow_dispatch: {}
 
-permissions: read-all
+permissions:
+  checks: write
+  pull-requests: read
 
 jobs:
   verify:
-    permissions:
-      checks: write
-      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,14 +7,13 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+  id-token: write
 
 jobs:
   analysis:
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,11 +5,10 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  issues: write
 
 jobs:
   stale:
-    permissions:
-      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
## CI Fix

Multiple workflow files were changed to use `permissions: read-all` at the workflow level while still specifying `write` access at the job level. GitHub Actions does not allow job-level permissions to exceed the workflow-level grant — `read-all` locks every permission to read-only, so attempting to set `issues: write` or other write permissions at the job level causes workflow startup failures.

This PR reverts to the pre-commit permissions model: explicit write permissions at the workflow level with no job-level escalation.

**Affected workflows (11 files):**
- add-help-wanted.yml
- assignment-helper.yml
- ai-fix.yml
- copilot-automation.yml
- copilot-dco.yml
- feedback.yml
- greetings.yml
- label-helper.yml
- pr-verifier.yml
- scorecard.yml
- stale.yml

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*