### PR TITLE
fix: restore write permissions in cncf-install-gen job

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -725,7 +725,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════
   auto-review:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     needs: [plan, collect, integration-test]
     if: |


### PR DESCRIPTION
Fixes #2747

The auto-review job in cncf-install-gen.yml performs git operations
(checkout, add, commit, push) but only had read permissions on contents.
This causes the workflow to fail with permission escalation errors.

Changed permissions from contents:read to contents:write to allow
the job to push generated missions to a new branch.