### PR TITLE
[scanner] fix: add read-all top-level permissions to 7 workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,8 +9,7 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions:
-  contents: read  # default read-only; writes scoped to job below
+permissions: read-all  # default read-only; writes scoped to job below
 
 jobs:
   build-index:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,8 +33,7 @@ on:
         required: false
         default: '10'
 
-permissions:
-  contents: read  # default read-only; writes scoped to job below
+permissions: read-all  # default read-only; writes scoped to job below
 
 jobs:
   # Compute batch matrix from total project count

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  statuses: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   copilot-dco:
+    permissions:
+      statuses: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,11 +6,12 @@ name: PR Verifier
 on:
   workflow_dispatch: {}
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
Fixes #2751

Adds `permissions: read-all` at the top level of 7 workflows and moves write permissions to job level where needed, following Scorecard Token-Permissions best practices.

**Workflows fixed:**
- `copilot-automation.yml` — moved `contents/pull-requests/issues/statuses: write` to job level
- `ai-fix.yml` — moved `contents/issues/pull-requests: write` to job level
- `pr-verifier.yml` — moved `checks: write` to job level
- `scorecard.yml` — moved `security-events/id-token: write` to job level
- `copilot-dco.yml` — moved `statuses: write` to job level
- `build-index.yml` — changed top-level from `contents: read` to `read-all`
- `cncf-mission-gen.yml` — changed top-level from `contents: read` to `read-all`