### PR TITLE
[ci-maintainer] fix: replace permissions: read-all with explicit write scopes in 6 console-kb workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,7 +12,10 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:

--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,7 +9,8 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions: read-all  # default read-only; writes scoped to job below
+permissions:
+  contents: write
 
 jobs:
   build-index:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,7 +33,10 @@ on:
         required: false
         default: '10'
 
-permissions: read-all  # default read-only; writes scoped to job below
+permissions:
+  contents: write
+  pull-requests: read
+  issues: read
 
 jobs:
   # Compute batch matrix from total project count

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all
+permissions:
+  statuses: write
+  pull-requests: read
 
 jobs:
   copilot-dco:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,11 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+  id-token: write
 
 jobs:
   analysis:


### PR DESCRIPTION
## CI Fix

Scanner commit #2752 ("add read-all top-level permissions to 7 workflows") applied `permissions: read-all` to 6 workflows that need write access. This causes `startup_failure` for reusable workflow calls and write-blocked failures for inline jobs.

### startup_failure (reusable calls — affects every PR/issue event)

| Workflow | Trigger | Fix applied |
|---------|---------|-------------|
| `copilot-automation.yml` | `pull_request_target` (every PR) | `permissions: {contents: write, pull-requests: write, issues: write, statuses: write}` |
| `copilot-dco.yml` | `pull_request` (every PR) | `permissions: {statuses: write, pull-requests: read}` |
| `ai-fix.yml` | `issues: labeled`, `pull_request_target` | `permissions: {contents: write, issues: write, pull-requests: write}` |
| `scorecard.yml` | weekly schedule | `permissions: {security-events: write, contents: read, actions: read, id-token: write}` |

### Write-blocked step failures (inline jobs)

| Workflow | Trigger | Fix applied |
|---------|---------|-------------|
| `build-index.yml` | push to master (`fixes/**`, `runbooks/**`) | `permissions: {contents: write}` |
| `cncf-mission-gen.yml` | daily schedule 6am UTC | `permissions: {contents: write, pull-requests: read, issues: read}` |

`pr-verifier.yml` (disabled, `workflow_dispatch` only) is not changed.

Fixes #2753

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*