### PR TITLE
[scanner] fix: scope workflow permissions to minimum required

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-index:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -34,9 +34,7 @@ on:
         default: '10'
 
 permissions:
-  contents: write
-  pull-requests: read
-  issues: read
+  contents: read
 
 jobs:
   # Compute batch matrix from total project count


### PR DESCRIPTION
Fixes #2758

Replaces overly broad top-level permissions in `build-index.yml` and `cncf-mission-gen.yml` with explicit, minimal job-level permissions. Top-level permissions restricted to `contents: read`, individual jobs declare only what they need.