### PR TITLE
[scanner] fix: scope workflow permissions in build-index and cncf-mission-gen

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,8 +9,7 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build-index:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,8 +33,7 @@ on:
         required: false
         default: '10'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   # Compute batch matrix from total project count


### PR DESCRIPTION
Fixes #2758

Scope top-level permissions to `read-all` in:
- `.github/workflows/build-index.yml`
- `.github/workflows/cncf-mission-gen.yml`

Job-level permissions already specify required write access where needed.