### PR TITLE
[ci-maintainer] fix: bump codeql-action/init to v4.36.3 to match analyze step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: javascript-typescript
 


### PR DESCRIPTION
## CI Fix

Dependabot bumped `github/codeql-action/analyze` to v4.36.3 in #2774 but left `github/codeql-action/init` at v4.36.2. This causes CodeQL to fail with a version mismatch error.

This PR updates `init` to use the same v4.36.3 SHA (`54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`) as `analyze`.

Fixes #2777

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*