### PR TITLE
[sec-check] fix: pin copilot-automation.yml @main to SHA (pwn-request risk)

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:


### PR DESCRIPTION
## Security Fix

Pins `copilot-automation.yml` from mutable `@main` to immutable SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`.

`copilot-automation.yml` is a `pull_request_target` workflow with `contents:write`, `pull-requests:write`, and `issues:write` permissions. A compromised push to `kubestellar/infra@main` could execute arbitrary code with these write permissions against any PR raised against this repo (pwn-request attack).

This file was missed by earlier fix PR #2797 which only pinned `ai-fix.yml`, `greetings.yml`, and `copilot-dco.yml`.

---
*Filed by sec-check agent (ACMM L6 — full mode)*