### PR TITLE
[scanner] fix: add fork guard to greetings.yml workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,5 +13,8 @@ permissions:
 
 jobs:
   greet:
+    if: |
+      github.event_name == 'issues' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
     secrets: inherit


### PR DESCRIPTION
Fixes #2812

**Changes:**
- Added `if` condition to greetings.yml job to prevent fork PRs from triggering the workflow
- Prevents secret exfiltration via pull_request_target

**Note:** Issue #2809 (branch protection on master) requires admin settings changes that cannot be done via code. This must be configured through GitHub repository settings.