### PR TITLE
[scanner] fix: restrict copilot-dco.yml to minimum permissions

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,9 +6,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   copilot-dco:
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3


### PR DESCRIPTION
Fixes #2815

Restricts top-level pull-request write permissions in copilot-dco.yml to job-level minimum required permissions.

Moves `pull-requests: write` and `statuses: write` from workflow-level to job-level permissions block, following the pattern used in other workflows like copilot-automation.yml and ai-fix.yml.