### PR TITLE
[scanner] fix: resolve Generate Platform Install Missions workflow failure

### DIFF
--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -40,6 +40,12 @@ jobs:
       force_regenerate: ${{ steps.sanitize.outputs.force_regenerate }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '20'
+      
       - name: Sanitize workflow inputs
         id: sanitize
         env:


### PR DESCRIPTION
Fixes #2825

## Problem

The `Generate Platform Install Missions` workflow failed because the `plan` job attempted to run `npm ci` without first setting up Node.js. The job has a `Plan batches` step that executes `cd scripts && npm ci --silent` and then runs Node.js commands, but unlike the `generate` and `collect` jobs, the `plan` job was missing the `setup-node` action.

## Solution

Added the `Setup Node.js` step to the `plan` job, matching the pattern used in the other jobs. This ensures Node.js v20 is available before attempting to install npm dependencies and execute Node.js scripts.

## Changes

- Added `actions/setup-node@v6.4.0` step to the `plan` job in `.github/workflows/platform-install-gen.yml`