### PR TITLE
[scanner] fix: add path traversal and endpoint validation guards

### DIFF
--- a/scripts/enrich-install-missions.mjs
+++ b/scripts/enrich-install-missions.mjs
@@ -100,6 +100,16 @@ async function callLLM(mission) {
   const token = process.env.LLM_TOKEN || GITHUB_TOKEN
   if (!token) return null
 
+  // Endpoint validation guard (CWE-441)
+  const ALLOWED_ENDPOINT_PREFIXES = [
+    'https://models.inference.ai.azure.com/',
+    'https://api.openai.com/',
+    'https://api.githubcopilot.com/',
+  ]
+  if (!ALLOWED_ENDPOINT_PREFIXES.some(prefix => LLM_ENDPOINT.startsWith(prefix))) {
+    throw new Error(`Untrusted LLM_ENDPOINT: ${LLM_ENDPOINT}`)
+  }
+
   const prompt = buildEnrichPrompt(mission)
 
   for (let attempt = 0; attempt <= 2; attempt++) {

--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -958,6 +958,14 @@ async function main() {
         console.log(`  [DRY RUN] Would write: ${gateResult.tier === 'draft' ? draftPath : outPath}`)
       } else {
         const targetPath = gateResult.tier === 'draft' ? draftPath : outPath
+        
+        // Path traversal guard (CWE-22)
+        const resolvedPath = join(process.cwd(), targetPath)
+        const resolvedSolutionsDir = join(process.cwd(), SOLUTIONS_DIR)
+        if (!resolvedPath.startsWith(resolvedSolutionsDir + '/') && resolvedPath !== resolvedSolutionsDir) {
+          throw new Error(`Path traversal detected: ${targetPath}`)
+        }
+        
         writeFileSync(targetPath, JSON.stringify(mission, null, 2) + '\n')
         console.log(`  ✅ Written: ${targetPath.split('/').pop()} (${methods})`)
       }

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -899,6 +899,13 @@ async function main() {
     const isDraft = gateResult.verdict === 'draft'
     const outPath = join(SOLUTIONS_DIR, isDraft ? filename.replace('.json', '.draft.json') : filename)
 
+    // Path traversal guard (CWE-22)
+    const resolvedPath = join(process.cwd(), outPath)
+    const resolvedSolutionsDir = join(process.cwd(), SOLUTIONS_DIR)
+    if (!resolvedPath.startsWith(resolvedSolutionsDir + '/') && resolvedPath !== resolvedSolutionsDir) {
+      throw new Error(`Path traversal detected: ${outPath}`)
+    }
+
     if (!DRY_RUN) {
       writeFileSync(outPath, JSON.stringify(mission, null, 2))
       console.log(`  Wrote: ${outPath}`)


### PR DESCRIPTION
Fixes #2846

Adds path traversal protection to file-write operations and endpoint allowlist validation for LLM requests in batch processing scripts.

- generate-platform-missions.mjs: validate output path stays within SOLUTIONS_DIR
- generate-cncf-install-missions.mjs: same path traversal guard
- enrich-install-missions.mjs: validate LLM_ENDPOINT against allowlist