### PR TITLE
[scanner] test: unit tests for security guards (#2856)

### DIFF
--- a/scripts/__tests__/security-guards.test.mjs
+++ b/scripts/__tests__/security-guards.test.mjs
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest'
+import { join } from 'path'
+import {
+  assertSafeSlug,
+  assertSafePath,
+  slugify,
+} from '../generate-cncf-install-missions.mjs'
+import {
+  assertSafeSlug as assertSafeSlugPlatform,
+  assertSafePath as assertSafePathPlatform,
+  slugify as slugifyPlatform,
+} from '../generate-platform-missions.mjs'
+import {
+  assertTrustedEndpoint,
+  ALLOWED_ENDPOINT_PREFIXES,
+} from '../enrich-install-missions.mjs'
+
+// ─── assertSafeSlug (generate-cncf-install-missions) ────────────────
+
+describe('assertSafeSlug (cncf-install)', () => {
+  describe('happy path — safe slugs', () => {
+    it('accepts a simple lowercase slug', () => {
+      expect(() => assertSafeSlug('my-project')).not.toThrow()
+    })
+
+    it('accepts a slug with digits', () => {
+      expect(() => assertSafeSlug('project-v2')).not.toThrow()
+    })
+
+    it('accepts a single word', () => {
+      expect(() => assertSafeSlug('argo')).not.toThrow()
+    })
+
+    it('accepts a long but valid slug', () => {
+      expect(() => assertSafeSlug('a'.repeat(80))).not.toThrow()
+    })
+  })
+
+  describe('rejects path separators', () => {
+    it('throws on forward slash', () => {
+      expect(() => assertSafeSlug('../../etc/passwd')).toThrow('Unsafe slug')
+    })
+
+    it('throws on backslash', () => {
+      expect(() => assertSafeSlug('project\\evil')).toThrow('Unsafe slug')
+    })
+  })
+
+  describe('rejects dot notation', () => {
+    it('throws on a slug with a dot', () => {
+      expect(() => assertSafeSlug('project.json')).toThrow('Unsafe slug')
+    })
+
+    it('throws on double-dot traversal attempt', () => {
+      expect(() => assertSafeSlug('..evil')).toThrow('Unsafe slug')
+    })
+  })
+
+  describe('rejects leading dash', () => {
+    it('throws on slug starting with dash', () => {
+      expect(() => assertSafeSlug('-bad-slug')).toThrow('Unsafe slug')
+    })
+  })
+
+  describe('rejects empty / falsy values', () => {
+    it('throws on empty string', () => {
+      expect(() => assertSafeSlug('')).toThrow('Unsafe slug')
+    })
+
+    it('throws on null', () => {
+      expect(() => assertSafeSlug(null)).toThrow('Unsafe slug')
+    })
+
+    it('throws on undefined', () => {
+      expect(() => assertSafeSlug(undefined)).toThrow('Unsafe slug')
+    })
+  })
+
+  it('includes the source name in the error message', () => {
+    expect(() => assertSafeSlug('bad/slug', 'project.name'))
+      .toThrow('project.name')
+  })
+})
+
+// ─── assertSafePath (generate-cncf-install-missions) ─────────────────
+
+describe('assertSafePath (cncf-install)', () => {
+  const root = '/workspace/solutions'
+
+  describe('happy path — safe paths', () => {
+    it('accepts a direct child file', () => {
+      expect(() => assertSafePath(`${root}/install-argo.json`, root)).not.toThrow()
+    })
+
+    it('accepts a nested child file', () => {
+      expect(() => assertSafePath(`${root}/subdir/file.json`, root)).not.toThrow()
+    })
+
+    it('accepts exact match to the allowed dir', () => {
+      expect(() => assertSafePath(root, root)).not.toThrow()
+    })
+  })
+
+  describe('rejects path traversal', () => {
+    it('throws when resolved path escapes the allowed dir', () => {
+      const traversal = join(root, '../..', 'etc', 'passwd')
+      expect(() => assertSafePath(traversal, root)).toThrow('Path traversal detected')
+    })
+
+    it('throws for a completely different directory', () => {
+      expect(() => assertSafePath('/etc/passwd', root)).toThrow('Path traversal detected')
+    })
+
+    it('throws for a sibling directory that shares the prefix', () => {
+      // /workspace/solutions-evil should NOT match /workspace/solutions
+      expect(() => assertSafePath(`${root}-evil/file.json`, root)).toThrow('Path traversal detected')
+    })
+
+    it('throws for root path', () => {
+      expect(() => assertSafePath('/', root)).toThrow('Path traversal detected')
+    })
+  })
+})
+
+// ─── assertSafeSlug (generate-platform-missions) ─────────────────────
+
+describe('assertSafeSlug (platform-missions)', () => {
+  it('accepts a valid platform slug', () => {
+    expect(() => assertSafeSlugPlatform('eks-managed')).not.toThrow()
+  })
+
+  it('throws on forward slash in slug', () => {
+    expect(() => assertSafeSlugPlatform('eks/evil')).toThrow('Unsafe slug')
+  })
+
+  it('throws on backslash in slug', () => {
+    expect(() => assertSafeSlugPlatform('eks\\evil')).toThrow('Unsafe slug')
+  })
+
+  it('throws on dot in slug', () => {
+    expect(() => assertSafeSlugPlatform('eks.json')).toThrow('Unsafe slug')
+  })
+
+  it('throws on leading dash', () => {
+    expect(() => assertSafeSlugPlatform('-eks')).toThrow('Unsafe slug')
+  })
+
+  it('throws on empty string', () => {
+    expect(() => assertSafeSlugPlatform('')).toThrow('Unsafe slug')
+  })
+
+  it('includes source in error when provided', () => {
+    expect(() => assertSafeSlugPlatform('', 'platform.name'))
+      .toThrow('platform.name')
+  })
+})
+
+// ─── assertSafePath (generate-platform-missions) ─────────────────────
+
+describe('assertSafePath (platform-missions)', () => {
+  const root = '/workspace/platform-solutions'
+
+  it('accepts a valid child path', () => {
+    expect(() => assertSafePathPlatform(`${root}/platform-eks.json`, root)).not.toThrow()
+  })
+
+  it('throws on path traversal escape', () => {
+    const traversal = join(root, '../../etc/shadow')
+    expect(() => assertSafePathPlatform(traversal, root)).toThrow('Path traversal detected')
+  })
+
+  it('throws on sibling-prefix path', () => {
+    expect(() => assertSafePathPlatform(`${root}-other/file`, root)).toThrow('Path traversal detected')
+  })
+})
+
+// ─── slugify (generate-cncf-install-missions) ────────────────────────
+
+describe('slugify (cncf-install)', () => {
+  it('lowercases and replaces non-alphanumeric chars', () => {
+    expect(slugify('My Project 2.0!')).toBe('my-project-2-0')
+  })
+
+  it('strips leading and trailing dashes', () => {
+    expect(slugify('  argo  ')).toBe('argo')
+  })
+
+  it('collapses consecutive separators', () => {
+    expect(slugify('foo---bar')).toBe('foo-bar')
+  })
+
+  it('truncates to 80 characters', () => {
+    const long = 'a'.repeat(100)
+    expect(slugify(long).length).toBeLessThanOrEqual(80)
+  })
+})
+
+// ─── slugify (generate-platform-missions) ────────────────────────────
+
+describe('slugify (platform-missions)', () => {
+  it('lowercases input', () => {
+    expect(slugifyPlatform('EKS')).toBe('eks')
+  })
+
+  it('replaces spaces and symbols with dashes', () => {
+    expect(slugifyPlatform('GKE Autopilot 2.0')).toBe('gke-autopilot-2-0')
+  })
+
+  it('strips leading and trailing dashes', () => {
+    expect(slugifyPlatform('-platform-')).toBe('platform')
+  })
+
+  it('collapses consecutive dashes', () => {
+    expect(slugifyPlatform('a--b---c')).toBe('a-b-c')
+  })
+})
+
+// ─── assertTrustedEndpoint (enrich-install-missions) ─────────────────
+
+describe('assertTrustedEndpoint', () => {
+  describe('happy path — allowed prefixes', () => {
+    it('accepts azure inference endpoint', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://models.inference.ai.azure.com/chat/completions')
+      ).not.toThrow()
+    })
+
+    it('accepts openai endpoint', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://api.openai.com/v1/chat/completions')
+      ).not.toThrow()
+    })
+
+    it('accepts github copilot endpoint', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://api.githubcopilot.com/chat/completions')
+      ).not.toThrow()
+    })
+
+    it('accepts any path under an allowed prefix', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://api.openai.com/v1/embeddings')
+      ).not.toThrow()
+    })
+  })
+
+  describe('rejects untrusted endpoints', () => {
+    it('throws for an arbitrary HTTP endpoint', () => {
+      expect(() =>
+        assertTrustedEndpoint('http://evil.com/steal')
+      ).toThrow('Untrusted LLM_ENDPOINT')
+    })
+
+    it('throws for an HTTPS endpoint not in the allowlist', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://attacker.example.com/api')
+      ).toThrow('Untrusted LLM_ENDPOINT')
+    })
+
+    it('throws for a localhost endpoint', () => {
+      expect(() =>
+        assertTrustedEndpoint('http://localhost:1234/inject')
+      ).toThrow('Untrusted LLM_ENDPOINT')
+    })
+
+    it('throws for an endpoint that only starts like a valid prefix', () => {
+      // Prefix spoofing: starts with allowed string but uses different host
+      expect(() =>
+        assertTrustedEndpoint('https://api.openai.com.evil.com/steal')
+      ).toThrow('Untrusted LLM_ENDPOINT')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('throws for an empty string', () => {
+      expect(() => assertTrustedEndpoint('')).toThrow('Untrusted LLM_ENDPOINT')
+    })
+
+    it('throws for a whitespace-only string', () => {
+      expect(() => assertTrustedEndpoint('   ')).toThrow('Untrusted LLM_ENDPOINT')
+    })
+
+    it('includes allowed prefixes in the error message', () => {
+      let msg = ''
+      try { assertTrustedEndpoint('https://evil.com') } catch (e) { msg = e.message }
+      expect(msg).toContain('https://models.inference.ai.azure.com/')
+      expect(msg).toContain('https://api.openai.com/')
+      expect(msg).toContain('https://api.githubcopilot.com/')
+    })
+
+    it('accepts a custom allowlist', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://custom.internal.corp/llm', ['https://custom.internal.corp/'])
+      ).not.toThrow()
+    })
+
+    it('rejects when custom allowlist does not match', () => {
+      expect(() =>
+        assertTrustedEndpoint('https://api.openai.com/v1', ['https://custom.internal.corp/'])
+      ).toThrow('Untrusted LLM_ENDPOINT')
+    })
+  })
+
+  it('ALLOWED_ENDPOINT_PREFIXES contains exactly 3 entries', () => {
+    expect(ALLOWED_ENDPOINT_PREFIXES).toHaveLength(3)
+  })
+
+  it('ALLOWED_ENDPOINT_PREFIXES all use HTTPS', () => {
+    for (const prefix of ALLOWED_ENDPOINT_PREFIXES) {
+      expect(prefix.startsWith('https://')).toBe(true)
+    }
+  })
+})

--- a/scripts/enrich-install-missions.mjs
+++ b/scripts/enrich-install-missions.mjs
@@ -31,15 +31,24 @@ const LLM_ENDPOINT = process.env.LLM_ENDPOINT || 'https://models.inference.ai.az
 const LLM_MODEL = process.env.LLM_MODEL || 'gpt-4o-mini'
 const LLM_TIMEOUT_MS = 60_000
 
-// Validate LLM_ENDPOINT at module load time (CWE-441: prevent SSRF)
-const ALLOWED_ENDPOINT_PREFIXES = [
+export const ALLOWED_ENDPOINT_PREFIXES = [
   'https://models.inference.ai.azure.com/',
   'https://api.openai.com/',
   'https://api.githubcopilot.com/',
 ]
-if (!ALLOWED_ENDPOINT_PREFIXES.some(prefix => LLM_ENDPOINT.startsWith(prefix))) {
-  throw new Error(`Untrusted LLM_ENDPOINT: ${LLM_ENDPOINT}. Must start with one of: ${ALLOWED_ENDPOINT_PREFIXES.join(', ')}`)
+
+/**
+ * Asserts that an LLM endpoint URL starts with an approved prefix (CWE-441: prevent SSRF).
+ * Throws if the endpoint is not trusted.
+ */
+export function assertTrustedEndpoint(endpoint, allowedPrefixes = ALLOWED_ENDPOINT_PREFIXES) {
+  if (!allowedPrefixes.some(prefix => endpoint.startsWith(prefix))) {
+    throw new Error(`Untrusted LLM_ENDPOINT: ${endpoint}. Must start with one of: ${allowedPrefixes.join(', ')}`)
+  }
 }
+
+// Validate LLM_ENDPOINT at module load time (CWE-441: prevent SSRF)
+assertTrustedEndpoint(LLM_ENDPOINT)
 
 const sleep = (ms) => new Promise(r => setTimeout(r, ms))
 
@@ -297,7 +306,9 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('Fatal:', err)
-  process.exit(1)
-})
+if (process.argv[1]?.endsWith('enrich-install-missions.mjs')) {
+  main().catch(err => {
+    console.error('Fatal:', err)
+    process.exit(1)
+  })
+}

--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -718,6 +718,26 @@ function slugify(text) {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 80)
 }
 
+/**
+ * Asserts that a slug is safe for use in file-path construction (CWE-20).
+ * Throws if the slug contains path separators, dots, or starts with a dash.
+ */
+export function assertSafeSlug(slug, source = 'unknown') {
+  if (!slug || slug.includes('/') || slug.includes('\\') || slug.includes('.') || slug.startsWith('-')) {
+    throw new Error(`Unsafe slug generated from ${source}: ${slug}`)
+  }
+}
+
+/**
+ * Asserts that a resolved file path stays within the allowed directory (CWE-22).
+ * Throws if the path escapes the allowed directory root.
+ */
+export function assertSafePath(resolvedTarget, resolvedAllowedDir) {
+  if (!resolvedTarget.startsWith(resolvedAllowedDir + '/') && resolvedTarget !== resolvedAllowedDir) {
+    throw new Error(`Path traversal detected: ${resolvedTarget}`)
+  }
+}
+
 // ─── Report ──────────────────────────────────────────────────────────
 
 function formatReport(report) {
@@ -811,10 +831,7 @@ async function main() {
 
     // Skip if already exists (unless FORCE_REGENERATE)
     const slug = slugify(project.name)
-    // Validate slug is safe (CWE-20: no path separators, no dots)
-    if (!slug || slug.includes('/') || slug.includes('\\') || slug.includes('.') || slug.startsWith('-')) {
-      throw new Error(`Unsafe slug generated from project.name: ${slug}`)
-    }
+    assertSafeSlug(slug, 'project.name')
     const outPath = join(SOLUTIONS_DIR, `install-${slug}.json`)
     const draftPath = join(SOLUTIONS_DIR, `install-${slug}.draft.json`)
     if (!FORCE_REGENERATE && (existsSync(outPath) || existsSync(draftPath))) {
@@ -967,9 +984,7 @@ async function main() {
         // Path traversal guard (CWE-22)
         const resolvedPath = join(process.cwd(), targetPath)
         const resolvedSolutionsDir = join(process.cwd(), SOLUTIONS_DIR)
-        if (!resolvedPath.startsWith(resolvedSolutionsDir + '/') && resolvedPath !== resolvedSolutionsDir) {
-          throw new Error(`Path traversal detected: ${targetPath}`)
-        }
+        assertSafePath(resolvedPath, resolvedSolutionsDir)
         
         writeFileSync(targetPath, JSON.stringify(mission, null, 2) + '\n')
         console.log(`  ✅ Written: ${targetPath.split('/').pop()} (${methods})`)

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -375,8 +375,28 @@ async function checkVersionFreshness(helmRepoUrl, chartName, currentVersion) {
 }
 
 // ─── Slug / Title helpers ────────────────────────────────────────────
-function slugify(s) { return s.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') }
+export function slugify(s) { return s.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') }
 function titleCase(s) { return s.replace(/(^|[\s-])(\w)/g, (_, p, c) => p + c.toUpperCase()) }
+
+/**
+ * Asserts that a slug is safe for use in file-path construction (CWE-20).
+ * Throws if the slug contains path separators, dots, or starts with a dash.
+ */
+export function assertSafeSlug(slug, source = 'unknown') {
+  if (!slug || slug.includes('/') || slug.includes('\\') || slug.includes('.') || slug.startsWith('-')) {
+    throw new Error(`Unsafe slug generated from ${source}: ${slug}`)
+  }
+}
+
+/**
+ * Asserts that a resolved file path stays within the allowed directory (CWE-22).
+ * Throws if the path escapes the allowed directory root.
+ */
+export function assertSafePath(resolvedTarget, resolvedAllowedDir) {
+  if (!resolvedTarget.startsWith(resolvedAllowedDir + '/') && resolvedTarget !== resolvedAllowedDir) {
+    throw new Error(`Path traversal detected: ${resolvedTarget}`)
+  }
+}
 
 // ─── Quality Gate ────────────────────────────────────────────────────
 const SAFE_CLI_COMMANDS = /\b(kubectl|helm|gcloud|eksctl|az|oci|aws|doctl|linode-cli|vkectl|oc|k3s|k0s|microk8s|snap|curl|wget|apt|yum|dnf|brew)\b/
@@ -895,10 +915,7 @@ async function main() {
 
     // 5. Write mission file
     const slug = slugify(platform.name)
-    // Validate slug is safe (CWE-20: no path separators, no dots)
-    if (!slug || slug.includes('/') || slug.includes('\\') || slug.includes('.') || slug.startsWith('-')) {
-      throw new Error(`Unsafe slug generated from platform.name: ${slug}`)
-    }
+    assertSafeSlug(slug, 'platform.name')
     const filename = `platform-${slug}.json`
     const isDraft = gateResult.verdict === 'draft'
     const outPath = join(SOLUTIONS_DIR, isDraft ? filename.replace('.json', '.draft.json') : filename)
@@ -906,9 +923,7 @@ async function main() {
     // Path traversal guard (CWE-22)
     const resolvedPath = join(process.cwd(), outPath)
     const resolvedSolutionsDir = join(process.cwd(), SOLUTIONS_DIR)
-    if (!resolvedPath.startsWith(resolvedSolutionsDir + '/') && resolvedPath !== resolvedSolutionsDir) {
-      throw new Error(`Path traversal detected: ${outPath}`)
-    }
+    assertSafePath(resolvedPath, resolvedSolutionsDir)
 
     if (!DRY_RUN) {
       writeFileSync(outPath, JSON.stringify(mission, null, 2))


### PR DESCRIPTION
Fixes #2856

Extract `assertSafeSlug`, `assertSafePath` (CWE-20/CWE-22), and `assertTrustedEndpoint` (CWE-441) as named exported functions and add 53 focused unit tests covering happy path, each guard rejection branch, and edge cases (empty, null, prefix spoofing, sibling-dir bypass).