### PR TITLE
[ci-maintainer] fix: group github/codeql-action Dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,7 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## CI Fix

Dependabot currently bumps each `github/codeql-action/*` sub-action in a **separate PR**. Because CodeQL's init and analyze steps must run the same version, whichever PR merges first (or gets tested first) trips:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.37.0'
```

**Observed evidence:**
- Run [29221689931](https://github.com/kubestellar/console-kb/actions/runs/29221689931) — `Analyze JavaScript/TypeScript` failed on Dependabot PR bumping `github/codeql-action/analyze` 4.36.3 → 4.37.0.
- Run [29221685973](https://github.com/kubestellar/console-kb/actions/runs/29221685973) — same failure on the sibling PR bumping `github/codeql-action/init`.
- Both failures also flip `PR Verifier` runs (`.github/workflows/pr-verifier.yml`) to failure since the CodeQL check is a required status.

**Fix:** Add a Dependabot `groups:` clause under the `github-actions` ecosystem so all `github/codeql-action/*` bumps consolidate into a single PR, keeping init/analyze versions in sync.

Bead: `c4f91022-b7a`

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*