### PR TITLE
🌱 fix: add minimal top-level permissions blocks to workflows (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
Fixes #2885

Adds `permissions: contents: read` top-level block to `copilot-dco.yml`, the only workflow in the repo still missing a top-level `permissions:` block. All other workflows flagged by the Scorecard alert (cncf-mission-gen, cncf-install-gen, platform-install-gen, build-index, scorecard, pr-verifier, copilot-automation, ai-fix) already have top-level permissions blocks in master.

This satisfies the OpenSSF Scorecard `Token-Permissions` check by ensuring `GITHUB_TOKEN` is issued with least-privilege scope by default.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>