### PR TITLE
[scanner] fix: PR Verifier Dependabot compatibility

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -10,5 +10,7 @@ permissions:
 
 jobs:
   verify:
+    # Skip Dependabot PRs - reusable workflow doesn't support pull_request_target from forks
+    if: github.actor != 'dependabot[bot]'
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
     secrets: inherit


### PR DESCRIPTION
Fixes #2883

## Summary

Fixes PR Verifier workflow failing on Dependabot pull_request_target events.

## Changes

- Added `if: github.actor != 'dependabot[bot]'` condition to skip Dependabot PRs
- This prevents the reusable workflow call from failing when triggered by Dependabot

## Root Cause

The reusable workflow at kubestellar/infra doesn't support pull_request_target from forks (like Dependabot's read-only token). The workflow would dispatch zero jobs and immediately fail.

## Note on #2885

Issue #2885 (Scorecard Token-Permissions alerts) was already resolved in PR #2886. All workflows now have appropriate permissions blocks.