### PR TITLE
[scanner] fix(security): complete HTML/regex sanitization and network->fs guards

### DIFF
--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -769,11 +769,14 @@ async function main() {
     // Sanitize mission text after LLM synthesis
     const sanitizeMissionText = (obj, maxLen = 5000) => {
       if (typeof obj === 'string') {
-        // Strip script/HTML, control chars, and cap length to prevent injection,
-        // exfiltration, and unbounded writes from HTTP-sourced content (CWE-434, fixes #2896).
+        // HTML-encode angle brackets to neutralize all tag-injection patterns
+        // (js/bad-tag-filter, js/incomplete-multi-character-sanitization — CWE-80/79).
+        // Encoding & first then < and > produces safe, non-executable HTML entities.
+        // Control chars and length cap prevent exfiltration (CWE-434, fixes #2896).
         return obj
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<[^>]+>/g, '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
           .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
           .slice(0, maxLen)
       }

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -434,7 +434,10 @@ async function checkVersionFreshness(helmRepoUrl, chartName, version) {
     const res = await fetch(`${helmRepoUrl}/index.yaml`, { signal: AbortSignal.timeout(HELM_VALIDATE_TIMEOUT_MS) })
     if (!res.ok) return true
     const text = await res.text()
-    const versionRe = new RegExp(`version:\\s+${version.replace(/\./g, '\\.')}`, 'm')
+    // Escape ALL regex metacharacters in the HTTP-derived version string before
+    // interpolating into a RegExp (js/incomplete-sanitization — CWE-116/20).
+    const escapeRegExpChars = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const versionRe = new RegExp(`version:\\s+${escapeRegExpChars(version)}`, 'm')
     return versionRe.test(text)
   } catch {
     return true
@@ -637,11 +640,13 @@ async function main() {
     // 4. Sanitize the mission text after LLM synthesis
     const sanitizeMissionText = (obj, maxLen = 5000) => {
       if (typeof obj === 'string') {
-        // Redact infra details, strip script/HTML, control chars, and cap length to prevent
-        // injection and exfiltration from HTTP-sourced content (CWE-434, fixes #2896).
+        // Redact infra details, HTML-encode angle brackets (js/bad-tag-filter,
+        // js/incomplete-multi-character-sanitization — CWE-80/79), strip control
+        // chars, and cap length (CWE-434, fixes #2896).
         return sanitizeInfraDetails(obj)
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<[^>]+>/g, '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
           .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
           .slice(0, maxLen)
       }


### PR DESCRIPTION
Fixes #2895
Fixes #2898
Fixes #2899

## Summary

Completes the security hardening started in #2897 and #2900.

### Changes

**`scripts/generate-cncf-install-missions.mjs`**
- Replace incomplete regex tag-stripping (`/<script...>/gi` + `/<[^>]+>/g`) with HTML entity encoding (`<` → `&lt;`, `>` → `&gt;`). This satisfies CodeQL `js/bad-tag-filter` (#150) and `js/incomplete-multi-character-sanitization` (#147/#148): entity-encoding is unconditional and cannot be bypassed via nested/overlapping patterns (CWE-80/79).

**`scripts/generate-platform-missions.mjs`**
- Same HTML entity-encoding fix applied to `sanitizeMissionText` (CodeQL #147/#148/#150).
- Fix `checkVersionFreshness`: replace the dots-only `.replace(/\./g, '\\.')` with a complete `escapeRegExpChars()` that escapes all regex metacharacters including backslash, `(`, `)`, `[`, `]`, `{`, `}`, `+`, `*`, `?`, `|`, `^`, `$` — satisfies CodeQL `js/incomplete-sanitization` (#149, CWE-116/20).

Network↔filesystem guards (issues #2898 — CodeQL #151/#152/#143) were already addressed by PR #2900 and remain intact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>