### PR TITLE
[scanner] fix(security): add Token-Permissions to mission workflows

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,8 +9,7 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build-index:

--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -22,8 +22,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   plan:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,8 +33,7 @@ on:
         required: false
         default: '10'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   # Compute batch matrix from total project count

--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -22,8 +22,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   plan:


### PR DESCRIPTION
Fixes #2903

Adds `permissions: read-all` at the workflow top level to 4 mission-generated workflow files, aligning with OpenSSF Scorecard Token-Permissions best practices.

Modified:
- .github/workflows/build-index.yml
- .github/workflows/cncf-mission-gen.yml
- .github/workflows/cncf-install-gen.yml
- .github/workflows/platform-install-gen.yml