### PR TITLE
[scanner] fix: correct HTML tag filter regex in mission generator

### DIFF
--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -787,7 +787,7 @@ async function main() {
         while (sanitized !== prev) {
           prev = sanitized
           // Remove script tags (including content)
-          sanitized = sanitized.replace(/<script[\s\S]*?<\/script>/gi, '')
+          sanitized = sanitized.replace(/<script\b[\s\S]*?<\/script\s*[^>]*>/gi, '')
           // Remove other HTML tags
           sanitized = sanitized.replace(/<[^>]+>/g, '')
         }

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -359,7 +359,7 @@ function sanitizeHtml(text) {
   while (sanitized !== prev) {
     prev = sanitized
     // Remove script tags (including content)
-    sanitized = sanitized.replace(/<script[\s\S]*?<\/script>/gi, '')
+    sanitized = sanitized.replace(/<script\b[\s\S]*?<\/script\s*[^>]*>/gi, '')
     // Remove event handlers
     sanitized = sanitized.replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
     // Remove javascript: URIs


### PR DESCRIPTION
Fixes #2904

The regex `/<script[\s\S]*?<\/script>/gi` failed to match closing tags with trailing whitespace or attributes (e.g. `</script >`, `</SCRIPT\n>`), allowing crafted end-tag forms to bypass the sanitizer (CodeQL `js/bad-tag-filter`, CWE-20/80/116/184/185/186).

**Fix:** add `\b` word boundary after `<script` to prevent false positives, and broaden the closing tag pattern from `<\/script>` to `<\/script\s*[^>]*>` so any whitespace or trailing attributes before `>` are consumed.

Applied identically in both:
- `scripts/generate-platform-missions.mjs` (line 362)
- `scripts/generate-cncf-install-missions.mjs` (line 790)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>