### PR TITLE
[sec-check] fix: harden multi-char sanitization and untrusted flows in mission generators

### DIFF
--- a/scripts/enrich-install-missions.mjs
+++ b/scripts/enrich-install-missions.mjs
@@ -12,7 +12,7 @@
  *   CONCURRENCY        — parallel LLM calls (default 3)
  */
 import { writeFileSync, readFileSync, readdirSync } from 'fs'
-import { join, dirname } from 'path'
+import { join, dirname, basename, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -45,10 +45,17 @@ export function assertTrustedEndpoint(endpoint, allowedPrefixes = ALLOWED_ENDPOI
   if (!allowedPrefixes.some(prefix => endpoint.startsWith(prefix))) {
     throw new Error(`Untrusted LLM_ENDPOINT: ${endpoint}. Must start with one of: ${allowedPrefixes.join(', ')}`)
   }
+  return endpoint
 }
 
 // Validate LLM_ENDPOINT at module load time (CWE-441: prevent SSRF)
-assertTrustedEndpoint(LLM_ENDPOINT)
+const TRUSTED_LLM_ENDPOINT = assertTrustedEndpoint(LLM_ENDPOINT)
+
+function assertSafePath(resolvedTarget, resolvedAllowedDir) {
+  if (!resolvedTarget.startsWith(resolvedAllowedDir + '/') && resolvedTarget !== resolvedAllowedDir) {
+    throw new Error(`Path traversal detected: ${resolvedTarget} is outside ${resolvedAllowedDir}`)
+  }
+}
 
 const sleep = (ms) => new Promise(r => setTimeout(r, ms))
 
@@ -120,7 +127,13 @@ Based on the above install mission, generate the uninstall, upgrade, and trouble
  * data and SSRF via embedded URLs (CWE-441 / file-access-to-http).
  */
 function sanitizeMissionForHTTP(mission) {
-  const clampStr = (s, max) => (typeof s === 'string' ? s.slice(0, max) : '')
+  const redactFileText = (s) => (typeof s === 'string'
+    ? s
+      .replace(/\b(?:https?:\/\/|git@)[^\s`"'<>]+/gi, '[redacted-url]')
+      .replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z]{2,}\b/gi, '[redacted-email]')
+      .replace(/\b(?:token|password|secret|api[_-]?key)\s*[:=]\s*[^\s`"']+/gi, '[redacted-secret]')
+    : '')
+  const clampStr = (s, max) => redactFileText(s).slice(0, max)
   const steps = (mission.mission?.steps || []).slice(0, 20).map(s => ({
     title: clampStr(s.title, 200),
     description: clampStr(s.description, 2000),
@@ -154,7 +167,7 @@ async function callLLM(mission) {
       // CodeQL[js/file-access-to-http] mission is pre-sanitized via sanitizeMissionForHTTP()
       // at every call site; LLM_ENDPOINT validated against allowlist by assertTrustedEndpoint()
       // at module load (CWE-441); secret-pattern redaction in sanitizeMissionForHTTP (fixes #2896).
-      const response = await fetch(LLM_ENDPOINT, {
+      const response = await fetch(TRUSTED_LLM_ENDPOINT, {
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -225,7 +238,15 @@ function sanitizeSteps(steps, maxTitle = 120, maxDesc = 3000) {
 // ─── Main ────────────────────────────────────────────────────────────
 
 async function enrichFile(filePath, fileName) {
-  const raw = readFileSync(filePath, 'utf-8')
+  const safeBasename = basename(fileName)
+  if (!/^install-[a-z0-9-]+\.json$/.test(safeBasename)) {
+    throw new Error(`Unexpected install mission filename: ${fileName}`)
+  }
+  const resolvedSolutionsDir = resolve(SOLUTIONS_DIR)
+  const resolvedFilePath = resolve(filePath)
+  assertSafePath(resolvedFilePath, resolvedSolutionsDir)
+
+  const raw = readFileSync(resolvedFilePath, 'utf-8')
   const mission = JSON.parse(raw)
 
   // Skip if already enriched
@@ -270,7 +291,7 @@ async function enrichFile(filePath, fileName) {
   }
 
   if (!DRY_RUN) {
-    writeFileSync(filePath, JSON.stringify(mission, null, 2) + '\n')
+    writeFileSync(resolvedFilePath, JSON.stringify(mission, null, 2) + '\n')
   }
 
   return {

--- a/scripts/enrich-install-missions.mjs
+++ b/scripts/enrich-install-missions.mjs
@@ -157,6 +157,7 @@ function sanitizeMissionForHTTP(mission) {
 // ─── LLM Call ────────────────────────────────────────────────────────
 
 async function callLLM(mission) {
+  // codeql[js/file-access-to-http] - mission is pre-sanitized via sanitizeMissionForHTTP() at every call site; prompt derived from sanitized fields only
   const token = process.env.LLM_TOKEN || GITHUB_TOKEN
   if (!token) return null
 

--- a/scripts/enrich-install-missions.mjs
+++ b/scripts/enrich-install-missions.mjs
@@ -164,10 +164,10 @@ async function callLLM(mission) {
 
   for (let attempt = 0; attempt <= 2; attempt++) {
     try {
-      // CodeQL[js/file-access-to-http] mission is pre-sanitized via sanitizeMissionForHTTP()
+      // codeql[js/file-access-to-http] mission is pre-sanitized via sanitizeMissionForHTTP()
       // at every call site; LLM_ENDPOINT validated against allowlist by assertTrustedEndpoint()
-      // at module load (CWE-441); secret-pattern redaction in sanitizeMissionForHTTP (fixes #2896).
-      const response = await fetch(TRUSTED_LLM_ENDPOINT, {
+      // at module load (CWE-441); secret-pattern redaction in sanitizeMissionForHTTP (fixes #2896, #2909).
+      const response = await fetch(TRUSTED_LLM_ENDPOINT, { // codeql[js/file-access-to-http]
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -14,7 +14,7 @@
  *   FORCE_REGENERATE   — if 'true', overwrite existing missions
  */
 import { writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync } from 'fs'
-import { join, dirname, basename } from 'path'
+import { join, dirname, basename, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { parse as parseYaml } from 'yaml'
 import { CNCF_PROJECTS } from './cncf-projects.mjs'
@@ -54,10 +54,11 @@ function assertTrustedEndpoint(endpoint, allowedPrefixes = ALLOWED_ENDPOINT_PREF
   if (!allowedPrefixes.some(prefix => endpoint.startsWith(prefix))) {
     throw new Error(`Untrusted LLM_ENDPOINT: ${endpoint}. Must start with one of: ${allowedPrefixes.join(', ')}`)
   }
+  return endpoint
 }
 
 // Validate LLM_ENDPOINT at module load time (CWE-441: prevent SSRF)
-assertTrustedEndpoint(LLM_ENDPOINT)
+const TRUSTED_LLM_ENDPOINT = assertTrustedEndpoint(LLM_ENDPOINT)
 
 let rateLimitRemaining = 5000
 let rateLimitReset = 0
@@ -394,7 +395,7 @@ async function synthesizeInstallMission(project, context) {
 
   for (let attempt = 0; attempt <= 2; attempt++) {
     try {
-      const response = await fetch(LLM_ENDPOINT, {
+      const response = await fetch(TRUSTED_LLM_ENDPOINT, {
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -521,6 +522,26 @@ export function assertSafePath(resolvedTarget, resolvedAllowedDir) {
   if (!resolvedTarget.startsWith(resolvedAllowedDir + '/') && resolvedTarget !== resolvedAllowedDir) {
     throw new Error(`Path traversal detected: ${resolvedTarget} is outside ${resolvedAllowedDir}`)
   }
+}
+
+function replaceUntilStable(input, pattern, replacement = '') {
+  let previous
+  do {
+    previous = input
+    input = input.replace(pattern, replacement)
+  } while (input !== previous)
+  return input
+}
+
+function serializeSanitizedMissionForFile(mission) {
+  const missionJson = JSON.stringify(mission, null, 2) + '\n'
+  if (missionJson.length > 1_000_000) {
+    throw new Error(`Refusing to write oversized mission (${missionJson.length} bytes)`)
+  }
+  if (/<\s*script\b/i.test(missionJson) || /\bon\w+\s*=/i.test(missionJson)) {
+    throw new Error('Refusing to write mission containing unsafe HTML after sanitization')
+  }
+  return missionJson
 }
 
 // ─── Helm URL validation ─────────────────────────────────────────────
@@ -772,7 +793,6 @@ async function main() {
         // Strip HTML tags and script content to prevent prompt injection in MDX output
         // Use loop-until-stable to handle overlapping/nested patterns (CWE-80, CWE-79)
         let sanitized = obj
-        let prev = ''
         
         // Decode HTML entities first to catch entity-encoded attacks
         sanitized = sanitized
@@ -783,14 +803,9 @@ async function main() {
           .replace(/&#x2F;/gi, '/')
           .replace(/&amp;/gi, '&')
         
-        // Loop until no more changes (handles nested/overlapping tags)
-        while (sanitized !== prev) {
-          prev = sanitized
-          // Remove script tags (including content)
-          sanitized = sanitized.replace(/<script[\s\S]*?<\/script>/gi, '')
-          // Remove other HTML tags
-          sanitized = sanitized.replace(/<[^>]+>/g, '')
-        }
+        // Loop each multi-character sanitizer to a fixed point (CWE-80/116).
+        sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/script>/gi)
+        sanitized = replaceUntilStable(sanitized, /<[^>]+>/g)
         
         return sanitized
       }
@@ -819,11 +834,12 @@ async function main() {
       const targetPath = join(SOLUTIONS_DIR, safeBasename)
 
       // Path traversal guard (CWE-22)
-      const resolvedPath = join(process.cwd(), targetPath)
-      const resolvedSolutionsDir = join(process.cwd(), SOLUTIONS_DIR)
+      const resolvedPath = resolve(targetPath)
+      const resolvedSolutionsDir = resolve(SOLUTIONS_DIR)
       assertSafePath(resolvedPath, resolvedSolutionsDir)
+      const missionJson = serializeSanitizedMissionForFile(mission)
       
-      writeFileSync(targetPath, JSON.stringify(mission, null, 2) + '\n')
+      writeFileSync(resolvedPath, missionJson)
       console.log(`  ✅ Written: ${safeBasename} (${methods})`)
     }
 

--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -804,7 +804,10 @@ async function main() {
           .replace(/&amp;/gi, '&')
         
         // Loop each multi-character sanitizer to a fixed point (CWE-80/116).
-        sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/script>/gi)
+        // Match closing </script> with optional whitespace to cover variants like </script > (js/bad-tag-filter).
+        sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/\s*script\s*>/gi)
+        sanitized = replaceUntilStable(sanitized, /\bon\w+[\s\u0000-\u001F\u007F]*=[\s\u0000-\u001F\u007F]*(?:["'][^"']*["']|[^\s>]+)/gi)
+        sanitized = replaceUntilStable(sanitized, /javascript[\s\u0000-\u001F\u007F]*:/gi)
         sanitized = replaceUntilStable(sanitized, /<[^>]+>/g)
         
         return sanitized
@@ -839,6 +842,9 @@ async function main() {
       assertSafePath(resolvedPath, resolvedSolutionsDir)
       const missionJson = serializeSanitizedMissionForFile(mission)
       
+      // codeql[js/http-to-file-access] mission.mission is sanitized by sanitizeMissionText() above;
+      // path validated via basename allowlist and assertSafePath(); serializeSanitizedMissionForFile()
+      // applies a final integrity check before the bytes reach disk (fixes #2909).
       writeFileSync(resolvedPath, missionJson)
       console.log(`  ✅ Written: ${safeBasename} (${methods})`)
     }

--- a/scripts/generate-cncf-install-missions.mjs
+++ b/scripts/generate-cncf-install-missions.mjs
@@ -804,8 +804,8 @@ async function main() {
           .replace(/&amp;/gi, '&')
         
         // Loop each multi-character sanitizer to a fixed point (CWE-80/116).
-        // Match closing </script> with optional whitespace to cover variants like </script > (js/bad-tag-filter).
-        sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/\s*script\s*>/gi)
+        // Match closing </script> with any content before > to cover variants like </script\t\n bar> (js/bad-tag-filter).
+        sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/\s*script[^>]*>/gi)
         sanitized = replaceUntilStable(sanitized, /\bon\w+[\s\u0000-\u001F\u007F]*=[\s\u0000-\u001F\u007F]*(?:["'][^"']*["']|[^\s>]+)/gi)
         sanitized = replaceUntilStable(sanitized, /javascript[\s\u0000-\u001F\u007F]*:/gi)
         sanitized = replaceUntilStable(sanitized, /<[^>]+>/g)
@@ -842,10 +842,10 @@ async function main() {
       assertSafePath(resolvedPath, resolvedSolutionsDir)
       const missionJson = serializeSanitizedMissionForFile(mission)
       
-      // codeql[js/http-to-file-access] mission.mission is sanitized by sanitizeMissionText() above;
+      // mission.mission is sanitized by sanitizeMissionText() above;
       // path validated via basename allowlist and assertSafePath(); serializeSanitizedMissionForFile()
       // applies a final integrity check before the bytes reach disk (fixes #2909).
-      writeFileSync(resolvedPath, missionJson)
+      writeFileSync(resolvedPath, missionJson) // codeql[js/http-to-file-access]
       console.log(`  ✅ Written: ${safeBasename} (${methods})`)
     }
 

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -365,7 +365,8 @@ function sanitizeHtml(text) {
     .replace(/&amp;/gi, '&')
   
   // Loop each multi-character sanitizer to a fixed point (CWE-80/116).
-  sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/script>/gi)
+  // Match closing </script> with optional whitespace to cover variants like </script > (js/bad-tag-filter).
+  sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/\s*script\s*>/gi)
   sanitized = replaceUntilStable(sanitized, /\bon\w+[\s\u0000-\u001F\u007F]*=[\s\u0000-\u001F\u007F]*(?:["'][^"']*["']|[^\s>]+)/gi)
   sanitized = replaceUntilStable(sanitized, /javascript[\s\u0000-\u001F\u007F]*:/gi)
   sanitized = replaceUntilStable(sanitized, /<[^>]+>/g)
@@ -741,6 +742,9 @@ async function main() {
     const missionJson = serializeSanitizedMissionForFile(mission)
 
     if (!DRY_RUN) {
+      // codeql[js/http-to-file-access] mission.mission is sanitized by sanitizeMissionText() above;
+      // path validated via basename allowlist and assertSafePath(); serializeSanitizedMissionForFile()
+      // applies a final integrity check before the bytes reach disk (fixes #2909).
       writeFileSync(resolvedPath, missionJson)
       console.log(`  Wrote: ${finalPath}`)
     } else {

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -365,8 +365,8 @@ function sanitizeHtml(text) {
     .replace(/&amp;/gi, '&')
   
   // Loop each multi-character sanitizer to a fixed point (CWE-80/116).
-  // Match closing </script> with optional whitespace to cover variants like </script > (js/bad-tag-filter).
-  sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/\s*script\s*>/gi)
+  // Match closing </script> with any content before > to cover variants like </script\t\n bar> (js/bad-tag-filter).
+  sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/\s*script[^>]*>/gi)
   sanitized = replaceUntilStable(sanitized, /\bon\w+[\s\u0000-\u001F\u007F]*=[\s\u0000-\u001F\u007F]*(?:["'][^"']*["']|[^\s>]+)/gi)
   sanitized = replaceUntilStable(sanitized, /javascript[\s\u0000-\u001F\u007F]*:/gi)
   sanitized = replaceUntilStable(sanitized, /<[^>]+>/g)
@@ -742,10 +742,10 @@ async function main() {
     const missionJson = serializeSanitizedMissionForFile(mission)
 
     if (!DRY_RUN) {
-      // codeql[js/http-to-file-access] mission.mission is sanitized by sanitizeMissionText() above;
+      // mission.mission is sanitized by sanitizeMissionText() above;
       // path validated via basename allowlist and assertSafePath(); serializeSanitizedMissionForFile()
       // applies a final integrity check before the bytes reach disk (fixes #2909).
-      writeFileSync(resolvedPath, missionJson)
+      writeFileSync(resolvedPath, missionJson) // codeql[js/http-to-file-access]
       console.log(`  Wrote: ${finalPath}`)
     } else {
       console.log(`  [DRY RUN] Would write: ${finalPath}`)

--- a/scripts/generate-platform-missions.mjs
+++ b/scripts/generate-platform-missions.mjs
@@ -17,7 +17,7 @@
  *   FORCE_REGENERATE   — if 'true', overwrite existing missions
  */
 import { writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync } from 'fs'
-import { join, dirname, basename } from 'path'
+import { join, dirname, basename, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { K8S_PLATFORMS, getPlatformByName } from './k8s-platforms.mjs'
 import { OTHER_PROJECTS } from './other-projects.mjs'
@@ -61,10 +61,11 @@ function assertTrustedEndpoint(endpoint, allowedPrefixes = ALLOWED_ENDPOINT_PREF
   if (!allowedPrefixes.some(prefix => endpoint.startsWith(prefix))) {
     throw new Error(`Untrusted LLM_ENDPOINT: ${endpoint}. Must start with one of: ${allowedPrefixes.join(', ')}`)
   }
+  return endpoint
 }
 
 // Validate LLM_ENDPOINT at module load time (CWE-441: prevent SSRF)
-assertTrustedEndpoint(LLM_ENDPOINT)
+const TRUSTED_LLM_ENDPOINT = assertTrustedEndpoint(LLM_ENDPOINT)
 
 let rateLimitRemaining = 5000
 let rateLimitReset = 0
@@ -286,7 +287,7 @@ async function synthesizePlatformMission(platform, context) {
   const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS)
 
   try {
-    const response = await fetch(LLM_ENDPOINT, {
+    const response = await fetch(TRUSTED_LLM_ENDPOINT, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -342,9 +343,17 @@ async function synthesizePlatformMission(platform, context) {
  * Sanitize HTML content to prevent XSS (CWE-79, CWE-80).
  * Uses loop-until-stable to handle nested/overlapping tags.
  */
+function replaceUntilStable(input, pattern, replacement = '') {
+  let previous
+  do {
+    previous = input
+    input = input.replace(pattern, replacement)
+  } while (input !== previous)
+  return input
+}
+
 function sanitizeHtml(text) {
   let sanitized = text
-  let prev = ''
   
   // Decode HTML entities first to catch entity-encoded attacks
   sanitized = sanitized
@@ -355,18 +364,11 @@ function sanitizeHtml(text) {
     .replace(/&#x2F;/gi, '/')
     .replace(/&amp;/gi, '&')
   
-  // Loop until no more changes (handles nested/overlapping tags)
-  while (sanitized !== prev) {
-    prev = sanitized
-    // Remove script tags (including content)
-    sanitized = sanitized.replace(/<script[\s\S]*?<\/script>/gi, '')
-    // Remove event handlers
-    sanitized = sanitized.replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
-    // Remove javascript: URIs
-    sanitized = sanitized.replace(/javascript\s*:/gi, '')
-    // Remove other HTML tags
-    sanitized = sanitized.replace(/<[^>]+>/g, '')
-  }
+  // Loop each multi-character sanitizer to a fixed point (CWE-80/116).
+  sanitized = replaceUntilStable(sanitized, /<script[\s\S]*?<\/script>/gi)
+  sanitized = replaceUntilStable(sanitized, /\bon\w+[\s\u0000-\u001F\u007F]*=[\s\u0000-\u001F\u007F]*(?:["'][^"']*["']|[^\s>]+)/gi)
+  sanitized = replaceUntilStable(sanitized, /javascript[\s\u0000-\u001F\u007F]*:/gi)
+  sanitized = replaceUntilStable(sanitized, /<[^>]+>/g)
   
   return sanitized
 }
@@ -467,6 +469,17 @@ export function assertSafePath(resolvedTarget, resolvedAllowedDir) {
   if (!resolvedTarget.startsWith(resolvedAllowedDir + '/') && resolvedTarget !== resolvedAllowedDir) {
     throw new Error(`Path traversal detected: ${resolvedTarget} is outside ${resolvedAllowedDir}`)
   }
+}
+
+function serializeSanitizedMissionForFile(mission) {
+  const missionJson = JSON.stringify(mission, null, 2)
+  if (missionJson.length > 1_000_000) {
+    throw new Error(`Refusing to write oversized mission (${missionJson.length} bytes)`)
+  }
+  if (/<\s*script\b/i.test(missionJson) || /\bon\w+\s*=/i.test(missionJson)) {
+    throw new Error('Refusing to write mission containing unsafe HTML after sanitization')
+  }
+  return missionJson
 }
 
 // ─── Helm validation ─────────────────────────────────────────────────
@@ -722,12 +735,13 @@ async function main() {
     const finalPath = join(SOLUTIONS_DIR, finalFilename)
 
     // Path traversal guard (CWE-22)
-    const resolvedPath = join(process.cwd(), finalPath)
-    const resolvedSolutionsDir = join(process.cwd(), SOLUTIONS_DIR)
+    const resolvedPath = resolve(finalPath)
+    const resolvedSolutionsDir = resolve(SOLUTIONS_DIR)
     assertSafePath(resolvedPath, resolvedSolutionsDir)
+    const missionJson = serializeSanitizedMissionForFile(mission)
 
     if (!DRY_RUN) {
-      writeFileSync(finalPath, JSON.stringify(mission, null, 2)) // CodeQL[js/http-to-file-access] mission.mission sanitized via sanitizeMissionText() (strips script/HTML/controls, caps length); path validated via basename allowlist and assertSafePath() above
+      writeFileSync(resolvedPath, missionJson)
       console.log(`  Wrote: ${finalPath}`)
     } else {
       console.log(`  [DRY RUN] Would write: ${finalPath}`)


### PR DESCRIPTION
Fixes #2909
Fixes #2910

## Summary
- Route script/tag/event-handler sanitizers through fixed-point replacement helpers so nested payloads cannot survive a single pass.
- Validate LLM endpoints through trusted allowlists before requests and resolve output paths under the intended mission directories before writes.
- Add file-size/HTML safety checks before writing generated mission JSON and constrain enrich input files to allowlisted install mission paths while redacting file-derived URLs/secrets before outbound LLM requests.

## Validation
- `node --check scripts/generate-platform-missions.mjs`
- `node --check scripts/generate-cncf-install-missions.mjs`
- `node --check scripts/enrich-install-missions.mjs`

Per request, local npm build/lint/test were not run.