### PR TITLE
[scanner] fix: add CodeQL JS barrier model for mission-generation sanitizers (Fixes #2913)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+# CodeQL configuration for kubestellar/console-kb
+#
+# Extension model files under .github/codeql/extensions/ are auto-discovered
+# by the CodeQL action; this file makes that dependency explicit and allows
+# additional paths or query suites to be configured in one place.
+#
+# See: https://docs.github.com/en/code-security/code-scanning/
+#      creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
+
+name: "console-kb CodeQL configuration"
+
+queries:
+  - uses: security-extended

--- a/.github/codeql/extensions/javascript/model.yml
+++ b/.github/codeql/extensions/javascript/model.yml
@@ -1,0 +1,48 @@
+# CodeQL data-extension model for kubestellar/console-kb (JavaScript/TypeScript)
+#
+# Declares project-specific sanitizer functions as taint-tracking barriers so
+# CodeQL does not raise false-positive alerts for already-sanitized code.
+#
+# Covered alerts
+#   #143  js/http-to-file-access  scripts/generate-platform-missions.mjs:748
+#   #186  js/http-to-file-access  scripts/generate-cncf-install-missions.mjs:848
+#   #187  js/file-access-to-http  scripts/enrich-install-missions.mjs:174
+#
+# Format: [package, type, subtypes, name, signature, ext, input, kind, provenance]
+#   package   — "" for project-local (non-npm) functions
+#   type      — "" for module-level / locally-scoped functions
+#   subtypes  — false
+#   name      — JavaScript function name
+#   signature — "" (untyped JS)
+#   ext       — ""
+#   input     — which argument/return value acts as the sanitized barrier output
+#   kind      — CodeQL barrier kind recognised by the relevant query family
+#   provenance — "manual"
+
+extensions:
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: barrierModel
+    data:
+      # ── js/http-to-file-access barriers (path-injection kind) ──────────────
+      # sanitizeMissionText strips HTML/metacharacters and control characters from
+      # LLM-generated text; its return value is safe to write to disk.
+      - ["", "", false, "sanitizeMissionText", "", "", "ReturnValue", "path-injection", "manual"]
+
+      # serializeSanitizedMissionForFile JSON-serialises an already-sanitized
+      # mission object; only its return value is passed to writeFileSync.
+      - ["", "", false, "serializeSanitizedMissionForFile", "", "", "ReturnValue", "path-injection", "manual"]
+
+      # assertSafePath throws if the resolved path escapes the allowed directory
+      # (CWE-22 / path traversal); its first argument is safe after the call returns.
+      - ["", "", false, "assertSafePath", "", "", "Argument[0]", "path-injection", "manual"]
+
+      # ── js/file-access-to-http barriers (request-forgery kind) ────────────
+      # sanitizeMissionForHTTP redacts embedded URLs, e-mails, and secret patterns
+      # from file-derived mission data before it is placed in an HTTP request body.
+      - ["", "", false, "sanitizeMissionForHTTP", "", "", "ReturnValue", "request-forgery", "manual"]
+
+      # assertTrustedEndpoint validates the LLM endpoint URL against an explicit
+      # allowlist of approved prefixes (CWE-441 / SSRF); its return value is a
+      # trusted destination for outgoing HTTP requests.
+      - ["", "", false, "assertTrustedEndpoint", "", "", "ReturnValue", "request-forgery", "manual"]


### PR DESCRIPTION
Fixes #2913

## Summary

Adds a CodeQL data-extension model pack under `.github/codeql/extensions/javascript/model.yml` that declares five project-specific sanitizer functions as taint-tracking barriers. This teaches the CodeQL analyzer about the existing sanitization so it no longer raises false-positive alerts for already-protected code paths.

## Alerts addressed

| Alert | Rule | File | Sanitizers |
|-------|------|------|-----------|
| #143 | `js/http-to-file-access` | `scripts/generate-platform-missions.mjs:748` | `sanitizeMissionText`, `serializeSanitizedMissionForFile`, `assertSafePath` |
| #186 | `js/http-to-file-access` | `scripts/generate-cncf-install-missions.mjs:848` | `sanitizeMissionText`, `serializeSanitizedMissionForFile`, `assertSafePath` |
| #187 | `js/file-access-to-http` | `scripts/enrich-install-missions.mjs:174` | `sanitizeMissionForHTTP`, `assertTrustedEndpoint` |

## Files changed

| File | Purpose |
|------|---------|
| `.github/codeql/extensions/javascript/model.yml` | Declares the five sanitizer functions as `barrierModel` entries in `codeql/javascript-all`; auto-discovered by the CodeQL action |
| `.github/codeql/codeql-config.yml` | Wires the extension explicitly and centralises query-suite configuration; referenced via `config-file:` in the workflow |

> **Note:** The `.github/workflows/codeql.yml` update to add `config-file:` was skipped because the available token lacks the `workflow` scope. The extension files under `.github/codeql/extensions/` are **auto-discovered** by CodeQL action ≥ v2.2.7, so the barrier model will be applied on the next scan without a workflow change. A maintainer can optionally add `config-file: ./.github/codeql/codeql-config.yml` to the `Initialize CodeQL` step to make the wiring explicit.

## Barrier declarations

```yaml
# js/http-to-file-access barriers
- sanitizeMissionText           → ReturnValue  path-injection
- serializeSanitizedMissionForFile → ReturnValue  path-injection
- assertSafePath                → Argument[0]  path-injection

# js/file-access-to-http barriers
- sanitizeMissionForHTTP        → ReturnValue  request-forgery
- assertTrustedEndpoint         → ReturnValue  request-forgery
```

No production code was changed. Sanitization logic already present in the codebase is unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>