### PR TITLE
[scanner] fix: Scorecard Token-Permissions on workflows

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -9,7 +9,8 @@ on:
       - 'runbooks/**'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build-index:

--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -22,7 +22,8 @@ on:
         type: boolean
         default: false
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   plan:

--- a/.github/workflows/cncf-mission-gen.yml
+++ b/.github/workflows/cncf-mission-gen.yml
@@ -33,7 +33,8 @@ on:
         required: false
         default: '10'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   # Compute batch matrix from total project count

--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -22,7 +22,8 @@ on:
         type: boolean
         default: false
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   plan:


### PR DESCRIPTION
Fixes #2914

Replace top-level `permissions: read-all` with `permissions: contents: read` in four workflows where all jobs already define explicit job-level permissions. This reduces the default token scope to the minimum required, addressing the remaining open Scorecard Token-Permissions alerts.

Affected files:
- `.github/workflows/build-index.yml`
- `.github/workflows/cncf-install-gen.yml`
- `.github/workflows/cncf-mission-gen.yml`
- `.github/workflows/platform-install-gen.yml`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>