### PR TITLE
[scanner] fix: prevent Build Mission Index workflow recurring pushes

### DIFF
--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -132,7 +132,6 @@ export async function buildIndex(targetDir = SOLUTIONS_DIR) {
 
   const index = {
     version: 1,
-    generatedAt: new Date().toISOString(),
     count: missions.length,
     missions: missions.sort((a, b) => a.title.localeCompare(b.title)),
   };


### PR DESCRIPTION
Fixes #2921

**Root cause:** The Build Mission Index workflow generated a new `generatedAt` timestamp on every run in `index.json`, causing the file to always differ and trigger recurring pushes.

**Fix:** Removed the non-deterministic `generatedAt` field from `scripts/build-index.mjs`, making the generated output deterministic.