### PR TITLE
[scanner] fix: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -9,4 +9,8 @@ permissions:
 
 jobs:
   copilot-dco:
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  id-token: write
 
 jobs:
   analysis:


### PR DESCRIPTION
Fixes #2924

## Changes

**`scorecard.yml`** — removed `id-token: write` and `actions: read` from the top-level `permissions:` block. Both were redundant with the identical job-level grants on the `analysis` job and violated the least-privilege principle: a top-level `id-token: write` grants OIDC token generation to every job and step in the workflow, not just the one that needs it. Top-level is now `contents: read` only.

**`copilot-dco.yml`** — added an explicit job-level `permissions:` block (`contents: read`, `pull-requests: read`, `statuses: write`) instead of silently inheriting the workflow-level grant. This makes the token scope visible and auditable at the job level, which is what Scorecard alert #52 flags.

All other workflows listed in the issue already carry a top-level `permissions: contents: read` block and explicit job-level grants on every job; no further changes needed for them.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>