### PR TITLE
[scanner] fix: skip PR creation when 0 platform missions generated

### DIFF
--- a/.github/workflows/platform-install-gen.yml
+++ b/.github/workflows/platform-install-gen.yml
@@ -292,8 +292,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEW_COUNT=$(ls fixes/platform-install/platform-*.json 2>/dev/null | wc -l | tr -d ' ')
-          [ "$NEW_COUNT" -eq 0 ] && echo "No new missions, skipping PR" && exit 0
+          MISSION_COUNT=$(ls fixes/platform-install/platform-*.json 2>/dev/null | wc -l)
+          if [ "$MISSION_COUNT" -eq 0 ]; then
+            echo "No missions generated; skipping PR"
+            exit 0
+          fi
 
           BRANCH="platform-install-gen-$(date +%Y%m%d)-$((RANDOM % 10000))"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
Fixes #2926

Use explicit guard to exit successfully (code 0) when no platform-mission files are produced, preventing workflow failure from 'git commit' having nothing to commit under set -e.