### PR TITLE
[scanner] fix: address Scorecard supply-chain findings

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fixes #2932

## Summary

Addresses the 5 OSSF Scorecard supply-chain findings reported in #2932.

## Findings & Actions

| Alert # | Rule | Action |
|---------|------|--------|
| 61 | SAST | ✅ Fixed indirectly — CodeQL already runs on `master` push + PRs; root cause was the Scorecard workflow itself not running (see below) |
| 59 | Fuzzing | ⚠️ Not fixable in code — `fuzz.yml` exists with property-based tests but Scorecard only recognizes OSS-Fuzz or ClusterFuzzLite, which are not practical for a docs/KB repo |
| 58 | Code-Review | ❌ Requires admin — needs branch-protection ruleset requiring ≥1 approval before merge |
| 57 | CII-Best-Practices | ❌ Requires maintainer action — project must be registered at https://www.bestpractices.dev to obtain a badge ID |
| 1  | Branch-Protection | ❌ Requires admin — needs org ruleset on `master`: block force-push, require status checks |

## Code Change

**`scorecard.yml` push trigger: `main` → `master`**

The Scorecard workflow was configured to trigger on push to `main`, but this repository's default branch is `master`. This meant Scorecard **never ran automatically on commits to the actual default branch**, producing stale/inaccurate results in the security dashboard and preventing the SAST finding from resolving.

Fix: corrected the `push.branches` filter from `"main"` to `"master"`.

## Non-Code Actions Required

For the remaining findings, repository admins/maintainers should:

1. **Code-Review + Branch-Protection**: Enable a branch ruleset on `master` requiring 1 reviewer, blocking force-pushes, blocking deletion, and requiring status checks to pass.
2. **CII-Best-Practices**: Register the project at https://www.bestpractices.dev and add the badge URL to `README.md`.
3. **Fuzzing**: Consider registering with [OSS-Fuzz](https://github.com/google/oss-fuzz) or adding [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) if deeper fuzzing coverage is desired.