### PR TITLE
🌱 external-secrets: AWS Certificate manager provider for exportable certificates

### DIFF
--- a/fixes/cncf-generated/external-secrets/external-secrets-4936-aws-certificate-manager-provider-for-exportable-certificat.json
+++ b/fixes/cncf-generated/external-secrets/external-secrets-4936-aws-certificate-manager-provider-for-exportable-certificat.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "external-secrets-4936-aws-certificate-manager-provider-for-exportable-certificat",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "external-secrets: AWS Certificate manager provider for exportable certificates",
+    "description": "AWS Certificate manager provider for exportable certificates. Requested by 20+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current external-secrets deployment",
+        "description": "Verify your external-secrets version and configuration:\n```bash\nkubectl get pods -n external-secrets -l app.kubernetes.io/name=external-secrets\nhelm list -n external-secrets 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working external-secrets installation."
+      },
+      {
+        "title": "Review external-secrets configuration",
+        "description": "Inspect the relevant external-secrets configuration:\n```bash\nkubectl get all -n external-secrets -l app.kubernetes.io/name=external-secrets\nkubectl get configmap -n external-secrets -l app.kubernetes.io/part-of=external-secrets\n```\nRecently, AWS announced that AWS Certificate Manager (ACM) now supports exporting public certificates. It would be great to have a provider that can sync certificates directly from AWS ACM to Kubernetes."
+      },
+      {
+        "title": "Apply the fix for AWS Certificate manager provider for exportable certificates",
+        "description": "We do have an AWS Account for e2e Testing which we'll wire up in CI.\n\nWill you be able to manage to set up you Account? LMK If you need help. I guess issuing a cert costs $15, maybe localstack may be an alternative. ACM seems to be available in the free tier:\n\nhttps://docs.localstack.cloud/aws/services/acm/\n\nLocalstack is largely API compatible, but there are slight differences. We can Figuren them out from CI :)\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n external-secrets -l app.kubernetes.io/name=external-secrets\nkubectl get events -n external-secrets --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"AWS Certificate manager provider for exportable certificates\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "We do have an AWS Account for e2e Testing which we'll wire up in CI.\n\nWill you be able to manage to set up you Account? LMK If you need help. I guess issuing a cert costs $15, maybe localstack may be an alternative. ACM seems to be available in the free tier:\n\nhttps://docs.localstack.cloud/aws/services/acm/\n\nLocalstack is largely API compatible, but there are slight differences.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "external-secrets",
+      "sandbox",
+      "security",
+      "feature"
+    ],
+    "cncfProjects": [
+      "external-secrets"
+    ],
+    "targetResourceKinds": [
+      "Service",
+      "Secret"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/external-secrets/external-secrets/issues/4936",
+      "repo": "https://github.com/external-secrets/external-secrets"
+    },
+    "reactions": 20,
+    "comments": 13,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with external-secrets installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-07-17T07:01:03.302Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: external-secrets — AWS Certificate manager provider for exportable certificates

**Type:** feature | **Source:** https://github.com/external-secrets/external-secrets/issues/4936 (20 reactions)
**File:** `fixes/cncf-generated/external-secrets/external-secrets-4936-aws-certificate-manager-provider-for-exportable-certificat.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*