### PR TITLE
🐛 [scanner] fix: guard CNCF install-gen Create PR step

### DIFF
--- a/.github/workflows/cncf-install-gen.yml
+++ b/.github/workflows/cncf-install-gen.yml
@@ -816,13 +816,19 @@ jobs:
           BRANCH="cncf-install-gen-$(date +%Y%m%d)-$(date +%s | tail -c 5)"
           git checkout -b "$BRANCH"
           git add fixes/cncf-install/ fixes/index.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          NEW_COUNT=$(git diff --cached --name-only | wc -l)
           git commit -s -m "✨ Auto-generate CNCF install missions ($(date +%Y-%m-%d))
 
           Generated install & configure missions across ${{ needs.plan.outputs.batch_count }} batches.
           Published: ${{ needs.collect.outputs.published }}, Drafts: ${{ needs.collect.outputs.drafts }}
           Average quality score: ${{ needs.collect.outputs.avg_score }}
           Integration test: ${{ needs.integration-test.outputs.result }} (${{ needs.integration-test.outputs.passed }}/${{ needs.integration-test.outputs.total }} passed)
-          Final: ${{ steps.final.outputs.action }} — ${{ steps.final.outputs.reason }}"
+          Final: ${{ steps.final.outputs.action }} — ${{ steps.final.outputs.reason }}
+          Changed files: $NEW_COUNT"
           git push origin "$BRANCH"
 
           DRAFT_FLAG=""


### PR DESCRIPTION
Fixes #2944

Ports the fix from #2928 to cncf-install-gen.yml. Prevents intermittent CI failures when no new missions are generated by:

1. Running `git add fixes/cncf-install/ fixes/index.json` first (explicit staging)
2. Checking `git diff --cached --quiet` to detect if anything is actually staged
3. Skipping commit/push if no changes (exits early with `exit 0`)
4. Recomputing `NEW_COUNT` via `git diff --cached --name-only` for accurate commit message

Same fix pattern applied in #2928 for platform-install-gen.yml — the root cause was `git commit` running with nothing staged when no new missions were generated, causing "nothing added to commit but untracked files present" error.