### PR TITLE
[scanner] fix: raise postcss override to >=8.5.18 for GHSA-r28c-9q8g-f849

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1143,9 +1143,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -22,7 +22,7 @@
   },
   "overrides": {
     "esbuild": ">=0.25.0",
-    "postcss": ">=8.5.10",
+    "postcss": ">=8.5.18",
     "vite": ">=8.0.5"
   }
 }


### PR DESCRIPTION
Fixes #2961

Raises the `overrides.postcss` constraint in `scripts/package.json` from `>=8.5.10` to `>=8.5.18` to remediate GHSA-r28c-9q8g-f849 — Path traversal in PostCSS's `sourceMappingURL` auto-loader enabling disclosure of arbitrary `.map` files.

**Note:** The `scripts/package-lock.json` should be regenerated after merge by running `cd scripts && npm install` to resolve postcss to 8.5.18+