### PR TITLE
🌱 fluent-bit: Watch TLS certificates and reload on changes

### DIFF
--- a/fixes/cncf-generated/fluent-bit/fluent-bit-10692-watch-tls-certificates-and-reload-on-changes.json
+++ b/fixes/cncf-generated/fluent-bit/fluent-bit-10692-watch-tls-certificates-and-reload-on-changes.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "fluent-bit-10692-watch-tls-certificates-and-reload-on-changes",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "fluent-bit: Watch TLS certificates and reload on changes",
+    "description": "Watch TLS certificates and reload on changes. Requested by 10+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current fluent-bit deployment",
+        "description": "Verify your fluent-bit version and configuration:\n```bash\nkubectl get pods -n fluent-bit -l app.kubernetes.io/name=fluent-bit\nhelm list -n fluent-bit 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working fluent-bit installation."
+      },
+      {
+        "title": "Review fluent-bit configuration",
+        "description": "Inspect the relevant fluent-bit configuration:\n```bash\nkubectl get all -n fluent-bit -l app.kubernetes.io/name=fluent-bit\nkubectl get configmap -n fluent-bit -l app.kubernetes.io/part-of=fluent-bit\n```\nSee #9718 and #1678\nShort lived client certificates are the norm. fluent-bit does not reload TLS certificates when they are renewed and simply fails at shipping logs."
+      },
+      {
+        "title": "Apply the fix for Watch TLS certificates and reload on changes",
+        "description": "On the current shorter validness of certificates proposals, we need to handle reloading certificates on Linux.\nThis is because shorter period of certificates\" validness requests us to relaunching Fluent Bit executable before reaching the expire date of the certificates.\nHowever, there is needed to take care of the possibility to care buffered chunks before flushing/terminating Fluent Bit executable.\nInstead, if we had a capability to handle reloading certificates on changes, it'll be quite\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n fluent-bit -l app.kubernetes.io/name=fluent-bit\nkubectl get events -n fluent-bit --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Watch TLS certificates and reload on changes\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "On the current shorter validness of certificates proposals, we need to handle reloading certificates on Linux.\nThis is because shorter period of certificates\" validness requests us to relaunching Fluent Bit executable before reaching the expire date of the certificates.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "fluent-bit",
+      "graduated",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "fluent-bit"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/fluent/fluent-bit/issues/10692",
+      "repo": "https://github.com/fluent/fluent-bit",
+      "pr": "https://github.com/fluent/fluent-bit/pull/11950"
+    },
+    "reactions": 10,
+    "comments": 8,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with fluent-bit installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-07-30T07:00:40.539Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: fluent-bit — Watch TLS certificates and reload on changes

**Type:** feature | **Source:** https://github.com/fluent/fluent-bit/issues/10692 (10 reactions)
**Fix PR:** https://github.com/fluent/fluent-bit/pull/11950
**File:** `fixes/cncf-generated/fluent-bit/fluent-bit-10692-watch-tls-certificates-and-reload-on-changes.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*