### PR TITLE
🌱 cilium: Add documentation for Clustermesh setup through Helm Chart

### DIFF
--- a/fixes/cncf-generated/cilium/cilium-19057-add-documentation-for-clustermesh-setup-through-helm-chart.json
+++ b/fixes/cncf-generated/cilium/cilium-19057-add-documentation-for-clustermesh-setup-through-helm-chart.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "cilium-19057-add-documentation-for-clustermesh-setup-through-helm-chart",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "cilium: Add documentation for Clustermesh setup through Helm Chart",
+    "description": "Add documentation for Clustermesh setup through Helm Chart. Requested by 36+ users.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current cilium deployment",
+        "description": "Verify your cilium version and configuration:\n```bash\nkubectl get pods -n cilium -l app.kubernetes.io/name=cilium\nhelm list -n cilium 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working cilium installation."
+      },
+      {
+        "title": "Review cilium configuration",
+        "description": "Inspect the relevant cilium configuration:\n```bash\nkubectl get all -n cilium -l app.kubernetes.io/name=cilium\nkubectl get configmap -n cilium -l app.kubernetes.io/part-of=cilium\n```\nFollow-up issue of https://github.com/cilium/cilium/pull/17851 which introduced support to connect multiple Clustermesh clusters using the Helm Chart."
+      },
+      {
+        "title": "Apply the fix for Add documentation for Clustermesh setup through Helm Chart",
+        "description": "This PR aims to add support to connect multiple Clustermesh clusters using the Helm Chart, instead of doing it manually / using the cilium-cli.\n\nFixes: #[17811](https://github.com/cilium/cilium/issues/17811)\n```yaml\nUsing helm they should be set in the array:\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n cilium -l app.kubernetes.io/name=cilium\nkubectl get events -n cilium --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Add documentation for Clustermesh setup through Helm Chart\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "This PR aims to add support to connect multiple Clustermesh clusters using the Helm Chart, instead of doing it manually / using the cilium-cli.\n\nFixes: #[17811](https://github.com/cilium/cilium/issues/17811)",
+      "codeSnippets": [
+        "Using helm they should be set in the array:",
+        "Keep in mind that I did only test it using HelmChartConfig!\n@dgiebert thanks a lot\nAnother questions:\n 1. where is secret `clustermesh-apiserver-client-cert` being used?\n 2. Can I curl clustermesh-apiserver?\nI tried to follow [cilium/clustermesh-apiserver/README.md#deploy-using-helm](https://github.com/cilium/cilium/blob/master/clustermesh-apiserver/README.md#deploy-using-helm) steps, but my clustermesh can't initialize:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "cilium",
+      "graduated",
+      "networking",
+      "deploy"
+    ],
+    "cncfProjects": [
+      "cilium"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "deploy"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/cilium/cilium/issues/19057",
+      "repo": "https://github.com/cilium/cilium",
+      "pr": "https://github.com/cilium/cilium/pull/17851"
+    },
+    "reactions": 36,
+    "comments": 49,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with cilium installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-07-31T07:01:27.605Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: cilium — Add documentation for Clustermesh setup through Helm Chart

**Type:** deploy | **Source:** https://github.com/cilium/cilium/issues/19057 (36 reactions)
**Fix PR:** https://github.com/cilium/cilium/pull/17851
**File:** `fixes/cncf-generated/cilium/cilium-19057-add-documentation-for-clustermesh-setup-through-helm-chart.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*