### PR TITLE
🌱 hami: feat: Add AMD Instinct GPU isolation (GPU memory limiting + Computing unit (CU)

### DIFF
--- a/fixes/cncf-generated/hami/hami-1707-feat-add-amd-instinct-gpu-isolation-gpu-memory-limiting-computing-unit.json
+++ b/fixes/cncf-generated/hami/hami-1707-feat-add-amd-instinct-gpu-isolation-gpu-memory-limiting-computing-unit.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "hami-1707-feat-add-amd-instinct-gpu-isolation-gpu-memory-limiting-computing-unit",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "hami: feat: Add AMD Instinct GPU isolation (GPU memory limiting + Computing unit (CU) partitioning)",
+    "description": "feat: Add AMD Instinct GPU isolation (GPU memory limiting + Computing unit (CU) partitioning). Community-requested feature.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current hami deployment",
+        "description": "Verify your hami version and configuration:\n```bash\nkubectl get pods -n hami -l app.kubernetes.io/name=hami\nhelm list -n hami 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working hami installation."
+      },
+      {
+        "title": "Review hami configuration",
+        "description": "Inspect the relevant hami configuration:\n```bash\nkubectl get all -n hami -l app.kubernetes.io/name=hami\nkubectl get configmap -n hami -l app.kubernetes.io/part-of=hami\n```\n**What would you like to be added**:\nAMD Instinct GPU isolation support — per-pod memory limiting and compute unit (CU) partitioning for AMD ROCm GPUs. \n\nAfter discussion, I will prepare for the code contribution."
+      },
+      {
+        "title": "Apply the fix for feat: Add AMD Instinct GPU isolation (GPU memory limiting +…",
+        "description": "Adds a design document (`docs/develop/amd-vgpu.md`) for AMD Instinct GPU isolation\n(per-pod memory limiting + CU partitioning) on ROCm. It covers the scheduler<->device-plugin protocol\n(node/pod annotations), the CU-count -> ROC_GLOBAL_CU_MASK model, and open discussion points.\n\nSubmitted as a design draft per the discussion in #1707\n(https://github.com/Project-HAMi/HAMi/issues/1707#issuecomment-4160136477).\nAI assistance disclosure: I used Claude Code to (double) fact-check claims against the\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n hami -l app.kubernetes.io/name=hami\nkubectl get events -n hami --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"feat: Add AMD Instinct GPU isolation (GPU memory limiting +…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Adds a design document (`docs/develop/amd-vgpu.md`) for AMD Instinct GPU isolation\n(per-pod memory limiting + CU partitioning) on ROCm. It covers the scheduler<->device-plugin protocol\n(node/pod annotations), the CU-count -> ROC_GLOBAL_CU_MASK model, and open discussion points.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "hami",
+      "sandbox",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "hami"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Node"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "sandbox",
+    "sourceUrls": {
+      "issue": "https://github.com/Project-HAMi/HAMi/issues/1707",
+      "repo": "https://github.com/Project-HAMi/HAMi",
+      "pr": "https://github.com/Project-HAMi/HAMi/pull/1985"
+    },
+    "reactions": 4,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with hami installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-02T07:06:37.203Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: hami — feat: Add AMD Instinct GPU isolation (GPU memory limiting + Computing unit (CU) partitioning)

**Type:** feature | **Source:** https://github.com/Project-HAMi/HAMi/issues/1707 (4 reactions)
**Fix PR:** https://github.com/Project-HAMi/HAMi/pull/1985
**File:** `fixes/cncf-generated/hami/hami-1707-feat-add-amd-instinct-gpu-isolation-gpu-memory-limiting-computing-unit.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*