### PR TITLE
🌱 prometheus: Support Unix socket for metrics address

### DIFF
--- a/fixes/cncf-generated/prometheus/prometheus-12024-support-unix-socket-for-metrics-address.json
+++ b/fixes/cncf-generated/prometheus/prometheus-12024-support-unix-socket-for-metrics-address.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "prometheus-12024-support-unix-socket-for-metrics-address",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "prometheus: Support Unix socket for metrics address",
+    "description": "Support Unix socket for metrics address. Requested by 47+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current prometheus deployment",
+        "description": "Verify your prometheus version and configuration:\n```bash\nkubectl get pods -n prometheus -l app.kubernetes.io/name=prometheus\nhelm list -n prometheus 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working prometheus installation."
+      },
+      {
+        "title": "Review prometheus configuration",
+        "description": "Inspect the relevant prometheus configuration:\n```bash\nkubectl get all -n prometheus -l app.kubernetes.io/name=prometheus\nkubectl get configmap -n prometheus -l app.kubernetes.io/part-of=prometheus\n```\n### Proposal\n\nFor current Prometheus, it seems that the metrics address to be pulled must be a valid TCP hostname. If Prometheus supports to pull from HTTP over Unix socket, each metrics server won't use a dedicated port to serve for Prometheus."
+      },
+      {
+        "title": "Apply the fix for Support Unix socket for metrics address",
+        "description": "Did you try the systemd socket that we have in the latest releases?\n\nLe lun. 24 juil. 2023, 13:26, Øystein Tveit ***@***.***> a\nécrit :\n```yaml\nhttp://my-host.xyz:80/metrics\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n prometheus -l app.kubernetes.io/name=prometheus\nkubectl get events -n prometheus --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Support Unix socket for metrics address\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Did you try the systemd socket that we have in the latest releases?\n\nLe lun. 24 juil. 2023, 13:26, Øystein Tveit ***@***.***> a\nécrit :",
+      "codeSnippets": [
+        "http://my-host.xyz:80/metrics"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "prometheus",
+      "graduated",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "prometheus"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/prometheus/prometheus/issues/12024",
+      "repo": "https://github.com/prometheus/prometheus"
+    },
+    "reactions": 47,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with prometheus installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-07T06:30:09.663Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: prometheus — Support Unix socket for metrics address

**Type:** feature | **Source:** https://github.com/prometheus/prometheus/issues/12024 (47 reactions)
**File:** `fixes/cncf-generated/prometheus/prometheus-12024-support-unix-socket-for-metrics-address.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*