### PR TITLE
🌱 containerd: config_path is treated inconsistently between local client pull mode and

### DIFF
--- a/fixes/cncf-generated/containerd/containerd-12415-config-path-is-treated-inconsistently-between-local-client-pull.json
+++ b/fixes/cncf-generated/containerd/containerd-12415-config-path-is-treated-inconsistently-between-local-client-pull.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "containerd-12415-config-path-is-treated-inconsistently-between-local-client-pull",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "containerd: config_path is treated inconsistently between local client pull mode and transfer service mode",
+    "description": "config_path is treated inconsistently between local client pull mode and transfer service mode. This issue affects 8+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify containerd troubleshoot symptoms",
+        "description": "Check for the issue in your containerd deployment:\n```bash\nkubectl get pods -n containerd -l app.kubernetes.io/name=containerd\nkubectl logs -l app.kubernetes.io/name=containerd -n containerd --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review containerd configuration",
+        "description": "Inspect the relevant containerd configuration:\n```bash\nkubectl get all -n containerd -l app.kubernetes.io/name=containerd\nkubectl get configmap -n containerd -l app.kubernetes.io/part-of=containerd\n```\n`config_path` is treated [as a list when in local pull mode](https://github.com/containerd/containerd/blob/af6e6482b37556911fa09dde0119f5f09a5b8598/internal/cri/server/images/image_pull.go#L491), and as a single host directory path [when in transfer"
+      },
+      {
+        "title": "Apply the fix for config_path is treated inconsistently between local client…",
+        "description": "Apply the configuration change to resolve the issue:\n```yaml\nThis one does (changed `config_path`):\n```"
+      },
+      {
+        "title": "Confirm config_path is treated inconsistently between… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=containerd -n containerd --tail=50 --since=5m\nkubectl get events -n containerd --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "See the source issue for the community-verified solution: https://github.com/containerd/containerd/issues/12415",
+      "codeSnippets": [
+        "This one does (changed `config_path`):",
+        "(Or this one does, by changing `discard_unpacked_layers` to `true`):"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "containerd",
+      "graduated",
+      "runtime",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "containerd"
+    ],
+    "targetResourceKinds": [
+      "Service"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/containerd/containerd/issues/12415",
+      "repo": "https://github.com/containerd/containerd"
+    },
+    "reactions": 8,
+    "comments": 3,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with containerd installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-17T06:13:59.420Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: containerd — config_path is treated inconsistently between local client pull mode and transfer service mode

**Type:** troubleshoot | **Source:** https://github.com/containerd/containerd/issues/12415 (8 reactions)
**File:** `fixes/cncf-generated/containerd/containerd-12415-config-path-is-treated-inconsistently-between-local-client-pull.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*