### PR TITLE
🌱 dify: After upgrading to v1.0.0, it is unable to have normal conversations and

### DIFF
--- a/fixes/cncf-generated/dify/dify-14565-after-upgrading-to-v1-0-0-it-is-unable-to-have-normal-conversations-a.json
+++ b/fixes/cncf-generated/dify/dify-14565-after-upgrading-to-v1-0-0-it-is-unable-to-have-normal-conversations-a.json
@@ -1,0 +1,76 @@
+{
+  "version": "kc-mission-v1",
+  "name": "dify-14565-after-upgrading-to-v1-0-0-it-is-unable-to-have-normal-conversations-a",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "dify: After upgrading to v1.0.0, it is unable to have normal conversations and perform embeddings",
+    "description": "After upgrading to v1.0.0, it is unable to have normal conversations and perform embeddings. This issue affects 7+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify dify troubleshoot symptoms",
+        "description": "Check for the issue in your dify installation:\n```bash\ndocker compose version\ndocker compose ps\n```\nLook for error: `{\"args\": {}, \"error_type\":\"ConnectionError\", \"message\":\"HTTPSConnectionPool(host='openapublic.blob.core.windows.net', po`"
+      },
+      {
+        "title": "Review dify configuration",
+        "description": "Review the relevant dify configuration:\n### Dify version\n\nv1.0.0\n\n### Cloud or Self Hosted\n\nSelf Hosted (Docker)\n\n### Steps to reproduce\n\nDeployment method: Docker deployment\nModel provider: Xinference v1.3.0.post2\nLLM model: deepseek-r1-distill-qwen-32b, Int4\nEmbedding model:"
+      },
+      {
+        "title": "Apply the fix for After upgrading to v1.0.0, it is unable to have normal…",
+        "description": "this change will be release in plugin-daemon 0.0.6, thanks for your solution!\nPR: https://github.com/langgenius/dify-plugin-daemon/pull/127\n```yaml\napi-1  | 2025-03-01 19:15:16.708 ERROR [Thread-4 (_generate_worker)] [app_generator.py:243] - Unknown Error when generating\napi-1  | Traceback (most recent call last):\napi-1  |   File \"/app/api/core/app/apps/chat/app_generator.py\", line 223, in _generate_worker\napi-1  |     runner.run(\napi-1  |   File \"/app/api/core/app/apps/chat/app_runner.py\", line 58, in run\napi-1  |     self.get_pre_calculate_rest_tokens(\napi-1  |   File \"/app/api/core/app/apps/base_app_runner.py\", line 86, in get_pre_calculate_rest_tokens\napi-1  |     prompt_tokens = model_instance.get_llm_num_tokens(prompt_messages)\napi-\n```"
+      },
+      {
+        "title": "Confirm After upgrading to v1.0.0, it is unable to have… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest dify to confirm the issue is resolved.\nConfirm that `{\"args\": {}, \"error_type\":\"ConnectionError\", \"message\":\"HTTPSConnectionPool(host='openapublic.blob.core.windows.net', po` no longer appears."
+      }
+    ],
+    "resolution": {
+      "summary": "this change will be release in plugin-daemon 0.0.6, thanks for your solution!\nPR: https://github.com/langgenius/dify-plugin-daemon/pull/127",
+      "codeSnippets": [
+        "api-1  | 2025-03-01 19:15:16.708 ERROR [Thread-4 (_generate_worker)] [app_generator.py:243] - Unknown Error when generating\napi-1  | Traceback (most recent call last):\napi-1  |   File \"/app/api/core/app/apps/chat/app_generator.py\", line 223, in _generate_worker\napi-1  |     runner.run(\napi-1  |   File \"/app/api/core/app/apps/chat/app_runner.py\", line 58, in run\napi-1  |     self.get_pre_calculate_rest_tokens(\napi-1  |   File \"/app/api/core/app/apps/base_app_runner.py\", line 86, in get_pre_calculate_rest_tokens\napi-1  |     prompt_tokens = model_instance.get_llm_num_tokens(prompt_messages)\napi-1  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\napi-1  |   File \"/app/api/core/model_manager.py\", line 195, in get_llm_num_tokens\napi-1  |     self._round_robin_invoke(\napi",
+        "mkdir tiktoken\ncd tiktoken\nwget https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe\ncp vocab.bpe 6d1cbeee0f20b3d9449abfede4726ed8212e3aee\nwget https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json\ncp encoder.json 6c7ea1a7e38e3a7f062df639a5b80947f075ffe6",
+        "environment:\n      TIKTOKEN_CACHE_DIR: /app/api/.tiktoken/\n         ...\n    volumes:\n      - ./volumes/plugin_daemon:/app/storage\n      - ./tiktoken: <REDACTED>"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "dify",
+      "community",
+      "ai-app",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "dify"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/langgenius/dify/issues/14565",
+      "repo": "https://github.com/langgenius/dify"
+    },
+    "reactions": 7,
+    "comments": 16,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "docker",
+      "docker-compose"
+    ],
+    "description": "A working dify installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-08-18T06:35:13.929Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: dify — After upgrading to v1.0.0, it is unable to have normal conversations and perform embeddings

**Type:** troubleshoot | **Source:** https://github.com/langgenius/dify/issues/14565 (7 reactions)
**File:** `fixes/cncf-generated/dify/dify-14565-after-upgrading-to-v1-0-0-it-is-unable-to-have-normal-conversations-a.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*