### PR TITLE
🌱 n8n: [Bug] DeepSeek AI Agent node fails with 400 "Missing reasoning_content" when

### DIFF
--- a/fixes/cncf-generated/n8n/n8n-29119-bug-deepseek-ai-agent-node-fails-with-400-missing-reasoning-content-wh.json
+++ b/fixes/cncf-generated/n8n/n8n-29119-bug-deepseek-ai-agent-node-fails-with-400-missing-reasoning-content-wh.json
@@ -1,0 +1,72 @@
+{
+  "version": "kc-mission-v1",
+  "name": "n8n-29119-bug-deepseek-ai-agent-node-fails-with-400-missing-reasoning-content-wh",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "n8n: [Bug] DeepSeek AI Agent node fails with 400 \"Missing reasoning_content\" when using tools with thinking mode (deepseek-v4-flash)",
+    "description": "[Bug] DeepSeek AI Agent node fails with 400 \"Missing reasoning_content\" when using tools with thinking mode (deepseek-v4-flash). This issue affects 6+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify n8n troubleshoot symptoms",
+        "description": "Check for the issue in your n8n deployment:\n```bash\nkubectl get pods -n n8n -l app.kubernetes.io/name=n8n\nkubectl logs -l app.kubernetes.io/name=n8n -n n8n --tail=100 | grep -i error\n```\nLook for error: ``Bad request - please check your parameters. The reasoning_content in the thinking mode must be passed back to the API.``"
+      },
+      {
+        "title": "Review n8n configuration",
+        "description": "Inspect the relevant n8n configuration:\n```bash\nkubectl get all -n n8n -l app.kubernetes.io/name=n8n\nkubectl get configmap -n n8n -l app.kubernetes.io/part-of=n8n\n```\n### Bug Description\n\nThe n8n DeepSeek Chat Model node does not preserve and resend the `reasoning_content` field in assistant messages during multi-turn tool calls when thinking mode is active."
+      },
+      {
+        "title": "Apply the fix for [Bug] DeepSeek AI Agent node fails with 400 \"Missing…",
+        "description": "I ran into this too with DeepSeek V4-Flash. The fix is to make sure your assistant messages include the full reasoning_content field when resending — easy to miss since it's not required by other providers. If you want a workaround, I've been using Cheap AI API (topaitools.vip/token-chuhai.html) which handles the proxy side and manages this automatically. $1/$6 per 1M tokens, no subscription.\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Confirm [Bug] DeepSeek AI Agent node fails with 400… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=n8n -n n8n --tail=50 --since=5m\nkubectl get events -n n8n --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that ``Bad request - please check your parameters. The reasoning_content in the thinking mode must be passed back to the API.`` no longer appears in logs."
+      }
+    ],
+    "resolution": {
+      "summary": "I ran into this too with DeepSeek V4-Flash. The fix is to make sure your assistant messages include the full reasoning_content field when resending — easy to miss since it's not required by other providers. If you want a workaround, I've been using Cheap AI API (topaitools.vip/token-chuhai.html) which handles the proxy side and manages this automatically. $1/$6 per 1M tokens, no subscription.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "n8n",
+      "community",
+      "workflow",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "n8n"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/n8n-io/n8n/issues/29119",
+      "repo": "https://github.com/n8n-io/n8n"
+    },
+    "reactions": 6,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with n8n installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-18T06:36:30.884Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: n8n — [Bug] DeepSeek AI Agent node fails with 400 "Missing reasoning_content" when using tools with thinking mode (deepseek-v4-flash)

**Type:** troubleshoot | **Source:** https://github.com/n8n-io/n8n/issues/29119 (6 reactions)
**File:** `fixes/cncf-generated/n8n/n8n-29119-bug-deepseek-ai-agent-node-fails-with-400-missing-reasoning-content-wh.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*