### PR TITLE
🌱 clickhouse: Allow interactive queries finish in the background

### DIFF
--- a/fixes/cncf-generated/clickhouse/clickhouse-49683-allow-interactive-queries-finish-in-the-background.json
+++ b/fixes/cncf-generated/clickhouse/clickhouse-49683-allow-interactive-queries-finish-in-the-background.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "clickhouse-49683-allow-interactive-queries-finish-in-the-background",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "clickhouse: Allow interactive queries finish in the background",
+    "description": "Allow interactive queries finish in the background. Requested by 45+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current clickhouse setup",
+        "description": "Verify your clickhouse version and configuration:\n```bash\nclickhouse-client --version\n```\nThis feature requires a working clickhouse installation."
+      },
+      {
+        "title": "Review clickhouse configuration",
+        "description": "Review the relevant clickhouse configuration:\n**Use case**\n\nA user can run an interactive session with long-running INSERT SELECT."
+      },
+      {
+        "title": "Apply the fix for Allow interactive queries finish in the background",
+        "description": "Use APPEND:\n```sql\n) create table t (x Int64) engine ReplicatedMergeTree('/t', 'r1') order by x;\n...\n) create materialized view v refresh after 999 year to t as select number*10 as x from numbers(5);\n\nCREATE MATERIALIZED VIEW v\nREFRESH AFTER 999 YEAR TO t\nAS SELECT number * 10 AS x\nFROM\n```yaml\nServer generates and persists `(part_name, part_offset)` pairs to disk instead of the full result.\n\n**Step 2**: Client fetches data in chunks using those row IDs\n```"
+      },
+      {
+        "title": "Upgrade clickhouse to include the fix",
+        "description": "If the fix is included in a newer release, upgrade clickhouse:\n```bash\n# Check current version\nclickhouse-client --version\n# Follow the project's upgrade guide at https://github.com/ClickHouse/ClickHouse\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected.\nConfirm the feature described in \"Allow interactive queries finish in the background\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Use APPEND:\n```sql\n) create table t (x Int64) engine ReplicatedMergeTree('/t', 'r1') order by x;\n...\n) create materialized view v refresh after 999 year to t as select number*10 as x from numbers(5);\n\nCREATE MATERIALIZED VIEW v\nREFRESH AFTER 999 YEAR TO t\nAS SELECT number * 10 AS x\nFROM numbers(5)\n\nQuery id: 730eb12d-ce87-4f40-bf61-2a81410f802d\n\nElapsed: 0.002 sec.",
+      "codeSnippets": [
+        "Server generates and persists `(part_name, part_offset)` pairs to disk instead of the full result.\n\n**Step 2**: Client fetches data in chunks using those row IDs"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "clickhouse",
+      "community",
+      "analytics-db",
+      "feature"
+    ],
+    "cncfProjects": [
+      "clickhouse"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "community",
+    "sourceUrls": {
+      "issue": "https://github.com/ClickHouse/ClickHouse/issues/49683",
+      "repo": "https://github.com/ClickHouse/ClickHouse"
+    },
+    "reactions": 45,
+    "comments": 15,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "clickhouse-client"
+    ],
+    "description": "A working clickhouse installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-08-20T06:32:43.300Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: clickhouse — Allow interactive queries finish in the background

**Type:** feature | **Source:** https://github.com/ClickHouse/ClickHouse/issues/49683 (45 reactions)
**File:** `fixes/cncf-generated/clickhouse/clickhouse-49683-allow-interactive-queries-finish-in-the-background.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*