### PR TITLE
🌱 alertmanager: Remove function in KV is hard to use from templates

### DIFF
--- a/fixes/cncf-generated/alertmanager/alertmanager-3393-remove-function-in-kv-is-hard-to-use-from-templates.json
+++ b/fixes/cncf-generated/alertmanager/alertmanager-3393-remove-function-in-kv-is-hard-to-use-from-templates.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "alertmanager-3393-remove-function-in-kv-is-hard-to-use-from-templates",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "alertmanager: Remove function in KV is hard to use from templates",
+    "description": "Remove function in KV is hard to use from templates. Requested by 11+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current alertmanager deployment",
+        "description": "Verify your alertmanager version and configuration:\n```bash\nkubectl get pods -n alertmanager -l app.kubernetes.io/name=alertmanager\nhelm list -n alertmanager 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working alertmanager installation."
+      },
+      {
+        "title": "Review alertmanager configuration",
+        "description": "Inspect the relevant alertmanager configuration:\n```bash\nkubectl get all -n alertmanager -l app.kubernetes.io/name=alertmanager\nkubectl get configmap -n alertmanager -l app.kubernetes.io/part-of=alertmanager\n```\nThis week I was attempting to write an Alertmanager template that printed the Summary, Description and Runbook URL annotations, followed by any additional annotations indented under the title `Annotations:`."
+      },
+      {
+        "title": "Apply the fix for Remove function in KV is hard to use from templates",
+        "description": "#### Pull Request Checklist\n\n- Please list all open issue(s) discussed with maintainers related to this change\n    - Fixes #3393\n- Is this a new Receiver integration?\n\n- Is this a bugfix?\n\n- Is this a new feature?\n\n- Does this change affect performance?\n\n- Is this a breaking change?\n\n#### Which\n```yaml\n{{ .Annotations.Remove \"summary\" }}\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n alertmanager -l app.kubernetes.io/name=alertmanager\nkubectl get events -n alertmanager --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Remove function in KV is hard to use from templates\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "#### Pull Request Checklist\n\n- Please list all open issue(s) discussed with maintainers related to this change\n    - Fixes #3393\n- Is this a new Receiver integration?\n\n- Is this a bugfix?\n\n- Is this a new feature?\n\n- Does this change affect performance?\n\n- Is this a breaking change?\n\n#### Which user-facing changes does this PR introduce?\n\n#### Notes\n\nThis adds a short example showing how to use",
+      "codeSnippets": [
+        "{{ .Annotations.Remove \"summary\" }}",
+        "and I was able to create the template I wanted:",
+        "when instead I could do:"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "alertmanager",
+      "graduated",
+      "observability",
+      "feature"
+    ],
+    "cncfProjects": [
+      "alertmanager"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/prometheus/alertmanager/issues/3393",
+      "repo": "https://github.com/prometheus/alertmanager",
+      "pr": "https://github.com/prometheus/alertmanager/pull/5297"
+    },
+    "reactions": 11,
+    "comments": 5,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with alertmanager installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-21T06:16:04.284Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: alertmanager — Remove function in KV is hard to use from templates

**Type:** feature | **Source:** https://github.com/prometheus/alertmanager/issues/3393 (11 reactions)
**Fix PR:** https://github.com/prometheus/alertmanager/pull/5297
**File:** `fixes/cncf-generated/alertmanager/alertmanager-3393-remove-function-in-kv-is-hard-to-use-from-templates.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*