### PR TITLE
🌱 alertmanager: No documentation on how to setup a custom email template

### DIFF
--- a/fixes/cncf-generated/alertmanager/alertmanager-1602-no-documentation-on-how-to-setup-a-custom-email-template.json
+++ b/fixes/cncf-generated/alertmanager/alertmanager-1602-no-documentation-on-how-to-setup-a-custom-email-template.json
@@ -1,0 +1,73 @@
+{
+  "version": "kc-mission-v1",
+  "name": "alertmanager-1602-no-documentation-on-how-to-setup-a-custom-email-template",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "alertmanager: No documentation on how to setup a custom email template",
+    "description": "No documentation on how to setup a custom email template. Requested by 8+ users.",
+    "type": "deploy",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current alertmanager deployment",
+        "description": "Verify your alertmanager version and configuration:\n```bash\nkubectl get pods -n alertmanager -l app.kubernetes.io/name=alertmanager\nhelm list -n alertmanager 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working alertmanager installation."
+      },
+      {
+        "title": "Review alertmanager configuration",
+        "description": "Inspect the relevant alertmanager configuration:\n```bash\nkubectl get all -n alertmanager -l app.kubernetes.io/name=alertmanager\nkubectl get configmap -n alertmanager -l app.kubernetes.io/part-of=alertmanager\n```\n**What did you do?**\nTrying to add a custom email template. This is not an usage related question, since the docs for adding a custom email template are missing."
+      },
+      {
+        "title": "Apply the fix for No documentation on how to setup a custom email template",
+        "description": "#### Summary\n\nAdd a complete example showing how to define an external HTML email template, load it with the top-level `templates` glob, and reference it from an email receiver. The example stays intentionally small while covering the configuration gap described in #1602.\n\n#### Pull Request Checklist\n\n- Please list all open issue(s) discussed with maintainers related to this change\n    - Fixes #1602\n- Is this a new Receiver integration?\n\n- Is this a bugfix?\n\n- Is this a new feature?\n\n- Does\n\nSee the source issue for community-verified solutions."
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n alertmanager -l app.kubernetes.io/name=alertmanager\nkubectl get events -n alertmanager --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"No documentation on how to setup a custom email template\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "#### Summary\n\nAdd a complete example showing how to define an external HTML email template, load it with the top-level `templates` glob, and reference it from an email receiver. The example stays intentionally small while covering the configuration gap described in #1602.",
+      "codeSnippets": []
+    }
+  },
+  "metadata": {
+    "tags": [
+      "alertmanager",
+      "graduated",
+      "observability",
+      "deploy"
+    ],
+    "cncfProjects": [
+      "alertmanager"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "deploy"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/prometheus/alertmanager/issues/1602",
+      "repo": "https://github.com/prometheus/alertmanager",
+      "pr": "https://github.com/prometheus/alertmanager/pull/5391"
+    },
+    "reactions": 8,
+    "comments": 8,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with alertmanager installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-21T06:16:13.715Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: alertmanager — No documentation on how to setup a custom email template

**Type:** deploy | **Source:** https://github.com/prometheus/alertmanager/issues/1602 (8 reactions)
**Fix PR:** https://github.com/prometheus/alertmanager/pull/5391
**File:** `fixes/cncf-generated/alertmanager/alertmanager-1602-no-documentation-on-how-to-setup-a-custom-email-template.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*