### PR TITLE
🌱 keycloak: CVE-2026-18963 Unauthenticated account takeover via reset-credentials flow

### DIFF
--- a/fixes/cncf-generated/keycloak/keycloak-51833-cve-2026-18963-unauthenticated-account-takeover-via-reset-credent.json
+++ b/fixes/cncf-generated/keycloak/keycloak-51833-cve-2026-18963-unauthenticated-account-takeover-via-reset-credent.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "keycloak-51833-cve-2026-18963-unauthenticated-account-takeover-via-reset-credent",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "keycloak: CVE-2026-18963 Unauthenticated account takeover via reset-credentials flow bypass",
+    "description": "CVE-2026-18963 Unauthenticated account takeover via reset-credentials flow bypass. This issue affects 26+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify keycloak troubleshoot symptoms",
+        "description": "Check for the issue in your keycloak installation:\n```bash\nkc.sh --version 2>/dev/null || bin/kc.sh --version\n```\nLook for errors or warnings that may indicate the issue."
+      },
+      {
+        "title": "Review keycloak configuration",
+        "description": "Review the relevant keycloak configuration:\n### Description\n\nA flaw was found in the reset-credentials flow of the keycloak-services component, which is the core engine for identity and access management in Red Hat Build of Keycloak."
+      },
+      {
+        "title": "Apply the fix for CVE-2026-18963 Unauthenticated account takeover via…",
+        "description": "Closes CVE-2026-18963\r\n\nPort to the main branch.\n```yaml\npython3 cve-2026-18963-hunt.py --base https://keycloak.example --since 30d\n```"
+      },
+      {
+        "title": "Confirm CVE-2026-18963 Unauthenticated account takeover… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest keycloak to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "See the fix PR for the community-verified solution: https://github.com/keycloak/keycloak/pull/51844",
+      "codeSnippets": [
+        "python3 cve-2026-18963-hunt.py --base https://keycloak.example --since 30d"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "keycloak",
+      "incubating",
+      "security",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "keycloak"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/keycloak/keycloak/issues/51833",
+      "repo": "https://github.com/keycloak/keycloak",
+      "pr": "https://github.com/keycloak/keycloak/pull/51844"
+    },
+    "reactions": 26,
+    "comments": 18,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "java"
+    ],
+    "description": "A working keycloak installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-08-25T06:14:25.361Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: keycloak — CVE-2026-18963 Unauthenticated account takeover via reset-credentials flow bypass

**Type:** troubleshoot | **Source:** https://github.com/keycloak/keycloak/issues/51833 (26 reactions)
**Fix PR:** https://github.com/keycloak/keycloak/pull/51844
**File:** `fixes/cncf-generated/keycloak/keycloak-51833-cve-2026-18963-unauthenticated-account-takeover-via-reset-credent.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*