### PR TITLE
🌱 backstage: NodeJS 24.17 CVE-2026-48931 fix affecting node-fetch - Premature close error

### DIFF
--- a/fixes/cncf-generated/backstage/backstage-34651-nodejs-24-17-cve-2026-48931-fix-affecting-node-fetch-premature-c.json
+++ b/fixes/cncf-generated/backstage/backstage-34651-nodejs-24-17-cve-2026-48931-fix-affecting-node-fetch-premature-c.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "backstage-34651-nodejs-24-17-cve-2026-48931-fix-affecting-node-fetch-premature-c",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "backstage: NodeJS 24.17 CVE-2026-48931 fix affecting node-fetch - Premature close error",
+    "description": "NodeJS 24.17 CVE-2026-48931 fix affecting node-fetch - Premature close error. This issue affects 27+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify backstage troubleshoot symptoms",
+        "description": "Check for the issue in your backstage installation:\n```bash\nnpx backstage-cli info\n```\nLook for errors or warnings that may indicate the issue."
+      },
+      {
+        "title": "Review backstage configuration",
+        "description": "Review the relevant backstage configuration:\nWe had a minor incident on our backstage instance, starting yesterday."
+      },
+      {
+        "title": "Apply the fix for NodeJS 24.17 CVE-2026-48931 fix affecting node-fetch -…",
+        "description": "I'm receiving this response on the frontend, even after correcting the Node.js version in the Microsoft Azure provider:\n\n`Login failed; caused by ResponseError: Request failed with 503 Service Unavailable`\n\nIn the application pod I identified this log:\n\n```json\n{\n  \"level\":\"error\",\n \n```yaml\n@balint-backmaker thank youuuu for your sugestion, i changed for node 24.16.0 and is working\n\n> I'm receiving this response on the frontend, even after correcting the Node.js version in the Microsoft Azure provider:\n> \n> `Login failed; caused by ResponseError: Request failed with 503 Service Unavailable`\n> \n> In the application pod I identified this log:\n> \n> {\n>   \"level\":\"error\",\n>   \"message\":\"Request failed with status 503 Service has not started up yet\",\n>   \"name\":\"ServiceUnavailableError\",\n>   \"plugin\":\"catalog\",\n>   \"service\":\"***\",\n>   \"stack\":\"ServiceUnavailableError: Service has not\n```"
+      },
+      {
+        "title": "Upgrade backstage to include the fix",
+        "description": "If the fix is included in a newer release, upgrade backstage:\n```bash\n# Check current version\nnpx backstage-cli info\n# Follow the project's upgrade guide at https://github.com/backstage/backstage\n```"
+      },
+      {
+        "title": "Confirm NodeJS 24.17 CVE-2026-48931 fix affecting… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest backstage to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "I'm receiving this response on the frontend, even after correcting the Node.js version in the Microsoft Azure provider:\n\n`Login failed; caused by ResponseError: Request failed with 503 Service Unavailable`\n\nIn the application pod I identified this log:\n\n```json\n{\n  \"level\":\"error\",\n  \"message\":\"Request failed with status 503 Service has not started up yet\",\n  \"name\":\"ServiceUnavailableError\",\n ",
+      "codeSnippets": [
+        "@balint-backmaker thank youuuu for your sugestion, i changed for node 24.16.0 and is working\n\n> I'm receiving this response on the frontend, even after correcting the Node.js version in the Microsoft Azure provider:\n> \n> `Login failed; caused by ResponseError: Request failed with 503 Service Unavailable`\n> \n> In the application pod I identified this log:\n> \n> {\n>   \"level\":\"error\",\n>   \"message\":\"Request failed with status 503 Service has not started up yet\",\n>   \"name\":\"ServiceUnavailableError\",\n>   \"plugin\":\"catalog\",\n>   \"service\":\"***\",\n>   \"stack\":\"ServiceUnavailableError: Service has not started up yet\\n at Timeout._onTimeout (/app/node_modules/@***/backend-defaults/dist/entrypoints/httpRouter/http/createLifecycleMiddleware.cjs.js:49:16)\\n at listOnTimeout (node:internal/timers:605:1"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "backstage",
+      "incubating",
+      "app-definition",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "backstage"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/backstage/backstage/issues/34651",
+      "repo": "https://github.com/backstage/backstage"
+    },
+    "reactions": 27,
+    "comments": 16,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "node",
+      "npm"
+    ],
+    "description": "A working backstage installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-08-26T06:12:05.148Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: backstage — NodeJS 24.17 CVE-2026-48931 fix affecting node-fetch - Premature close error

**Type:** troubleshoot | **Source:** https://github.com/backstage/backstage/issues/34651 (27 reactions)
**File:** `fixes/cncf-generated/backstage/backstage-34651-nodejs-24-17-cve-2026-48931-fix-affecting-node-fetch-premature-c.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*