### PR TITLE
🌱 containerd: pkg/oci/spec_opts.go needs updating with latest opencontainers/runtme-spec

### DIFF
--- a/fixes/cncf-generated/containerd/containerd-12493-pkg-oci-spec-opts-go-needs-updating-with-latest-opencontainers-.json
+++ b/fixes/cncf-generated/containerd/containerd-12493-pkg-oci-spec-opts-go-needs-updating-with-latest-opencontainers-.json
@@ -1,0 +1,74 @@
+{
+  "version": "kc-mission-v1",
+  "name": "containerd-12493-pkg-oci-spec-opts-go-needs-updating-with-latest-opencontainers-",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "containerd: pkg/oci/spec_opts.go needs updating with latest opencontainers/runtme-spec",
+    "description": "pkg/oci/spec_opts.go needs updating with latest opencontainers/runtme-spec. This issue affects 8+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify containerd troubleshoot symptoms",
+        "description": "Check for the issue in your containerd deployment:\n```bash\nkubectl get pods -n containerd -l app.kubernetes.io/name=containerd\nkubectl logs -l app.kubernetes.io/name=containerd -n containerd --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review containerd configuration",
+        "description": "Inspect the relevant containerd configuration:\n```bash\nkubectl get all -n containerd -l app.kubernetes.io/name=containerd\nkubectl get configmap -n containerd -l app.kubernetes.io/part-of=containerd\n```\nIn https://github.com/opencontainers/runtime-spec/commit/869b2d5b0c9fbb9db559ab53cf1fa61a170835e9, the schema for LinuxPid was changed, so that Limit is now a `*int64` rather than just an `int64`."
+      },
+      {
+        "title": "Apply the fix for pkg/oci/spec_opts.go needs updating with latest…",
+        "description": "I see this has been fixed for the `containerd/containerd/v2` releases, but not when importing `github.com/containerd/containerd` as a library (which one of my dependencies does).  Would a backport of the fix to the `release-1.7` branch (and then a 1.7.31 release) be accepted?\n```yaml\n../../../go/1.24.10/pkg/mod/github.com/containerd/containerd/v2@v2.2.0/pkg/oci/spec_opts.go:1604:34: cannot use limit (variable of type int64) as *int64 value in assignment\n```"
+      },
+      {
+        "title": "Confirm pkg/oci/spec_opts.go needs updating with latest… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=containerd -n containerd --tail=50 --since=5m\nkubectl get events -n containerd --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "I see this has been fixed for the `containerd/containerd/v2` releases, but not when importing `github.com/containerd/containerd` as a library (which one of my dependencies does).  Would a backport of the fix to the `release-1.7` branch (and then a 1.7.31 release) be accepted?",
+      "codeSnippets": [
+        "../../../go/1.24.10/pkg/mod/github.com/containerd/containerd/v2@v2.2.0/pkg/oci/spec_opts.go:1604:34: cannot use limit (variable of type int64) as *int64 value in assignment"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "containerd",
+      "graduated",
+      "runtime",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "containerd"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/containerd/containerd/issues/12493",
+      "repo": "https://github.com/containerd/containerd"
+    },
+    "reactions": 8,
+    "comments": 10,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with containerd installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-08-27T09:07:55.510Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: containerd — pkg/oci/spec_opts.go needs updating with latest opencontainers/runtme-spec

**Type:** troubleshoot | **Source:** https://github.com/containerd/containerd/issues/12493 (8 reactions)
**File:** `fixes/cncf-generated/containerd/containerd-12493-pkg-oci-spec-opts-go-needs-updating-with-latest-opencontainers-.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*