### PR TITLE
🌱 helm: MaxDecompressedFileSize in v3.17.3 breaks existing charts

### DIFF
--- a/fixes/cncf-generated/helm/helm-30738-maxdecompressedfilesize-in-v3-17-3-breaks-existing-charts.json
+++ b/fixes/cncf-generated/helm/helm-30738-maxdecompressedfilesize-in-v3-17-3-breaks-existing-charts.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "helm-30738-maxdecompressedfilesize-in-v3-17-3-breaks-existing-charts",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "helm: MaxDecompressedFileSize in v3.17.3 breaks existing charts",
+    "description": "MaxDecompressedFileSize in v3.17.3 breaks existing charts. This issue affects 60+ users.",
+    "type": "upgrade",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify helm upgrade symptoms",
+        "description": "Check for the issue in your helm installation:\n```bash\nhelm version --short\nhelm repo list\n```\nLook for errors or warnings that may indicate the issue."
+      },
+      {
+        "title": "Review helm configuration",
+        "description": "Review the relevant helm configuration:\nVersion 3.17.3 is enforcing a maximum chart size which breaks existing helm charts."
+      },
+      {
+        "title": "Apply the fix for MaxDecompressedFileSize in v3.17.3 breaks existing charts",
+        "description": "Apply the configuration change to resolve the issue:\n```yaml\nhelm template gloo-platform gloo-platform/gloo-platform --version=2.6.9 --set common.cluster=cluster1\n```"
+      },
+      {
+        "title": "Confirm MaxDecompressedFileSize in v3.17.3 breaks… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\nTest helm to confirm the issue is resolved.\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "See the source issue for the community-verified solution: https://github.com/helm/helm/issues/30738",
+      "codeSnippets": [
+        "helm template gloo-platform gloo-platform/gloo-platform --version=2.6.9 --set common.cluster=cluster1",
+        "Error: decompressed chart file \"gloo-platform/values.schema.json\" is larger than the maximum file size 5242880",
+        "helm fetch gloo-platform/gloo-platform --version 2.7.0\ntar -xzvf gloo-platform-2.7.0.tgz\nmv gloo-platform/values.schema.json /tmp/_values.schema.json\ncat /tmp/_values.schema.json| jq -c > gloo-platform/values.schema.json\n\nhelm upgrade --install gloo-platform-mgmt ./gloo-platform"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "helm",
+      "graduated",
+      "app-definition",
+      "upgrade"
+    ],
+    "cncfProjects": [
+      "helm"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "upgrade"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/helm/helm/issues/30738",
+      "repo": "https://github.com/helm/helm"
+    },
+    "reactions": 60,
+    "comments": 28,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "tools": [
+      "helm"
+    ],
+    "description": "A working helm installation or development environment."
+  },
+  "security": {
+    "scannedAt": "2026-09-01T06:16:56.021Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: helm — MaxDecompressedFileSize in v3.17.3 breaks existing charts

**Type:** upgrade | **Source:** https://github.com/helm/helm/issues/30738 (60 reactions)
**File:** `fixes/cncf-generated/helm/helm-30738-maxdecompressedfilesize-in-v3-17-3-breaks-existing-charts.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*