### PR TITLE
🌱 kubevirt: Allow configuration of alternative kubelet directories

### DIFF
--- a/fixes/cncf-generated/kubevirt/kubevirt-5913-allow-configuration-of-alternative-kubelet-directories.json
+++ b/fixes/cncf-generated/kubevirt/kubevirt-5913-allow-configuration-of-alternative-kubelet-directories.json
@@ -1,0 +1,77 @@
+{
+  "version": "kc-mission-v1",
+  "name": "kubevirt-5913-allow-configuration-of-alternative-kubelet-directories",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "kubevirt: Allow configuration of alternative kubelet directories",
+    "description": "Allow configuration of alternative kubelet directories. Requested by 5+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current kubevirt deployment",
+        "description": "Verify your kubevirt version and configuration:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nhelm list -n kubevirt 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working kubevirt installation."
+      },
+      {
+        "title": "Review kubevirt configuration",
+        "description": "Inspect the relevant kubevirt configuration:\n```bash\nkubectl get all -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get configmap -n kubevirt -l app.kubernetes.io/part-of=kubevirt\n```\n**Is this a BUG REPORT or FEATURE REQUEST?**: Feature Request\r\n\n**What happened**:\nI attempted to install KubeVirt and I couldn't because the distribution of Kubernetes I am using ([k0s](https://github.com/k0sproject/k0s)) uses a non-standard"
+      },
+      {
+        "title": "Apply the fix for Allow configuration of alternative kubelet directories",
+        "description": "Threads the configured kubelet root through to the heartbeat controller:\n\nvirt-handler.go -> NewVirtualMachineController -> heartbeat.NewHeartBeat\n\nNow `cpu_manager_state` is located relative to whatever `--kubelet-root` is actually set to.\n```yaml\nClient Version: version.Info{GitVersion:\"v0.41.0\", GitCommit:\"b7f322409e310ebaf7edb9f657d9864ad5730ab0\", GitTreeState:\"clean\", BuildDate:\"2021-05-12T14:43:31Z\", GoVersion:\"go1.13.14\", Compiler:\"gc\", Platform:\"linux/amd64\"}\nServer Version: version.Info{GitVersion:\"v0.42.1-dirty\", GitCommit:\"3e4ea2d9b8d4405dc307e885bc49f10c8ce5372c\", GitTreeState:\"dirty\", BuildDate:\"2021-06-10T02:06:01Z\", GoVersion:\"go1.16.1\", Compiler:\"gc\", Platform:\"linux/amd64\"}\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n kubevirt -l app.kubernetes.io/name=kubevirt\nkubectl get events -n kubevirt --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Allow configuration of alternative kubelet directories\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Threads the configured kubelet root through to the heartbeat controller:\n\nvirt-handler.go -> NewVirtualMachineController -> heartbeat.NewHeartBeat\n\nNow `cpu_manager_state` is located relative to whatever `--kubelet-root` is actually set to.",
+      "codeSnippets": [
+        "Client Version: version.Info{GitVersion:\"v0.41.0\", GitCommit:\"b7f322409e310ebaf7edb9f657d9864ad5730ab0\", GitTreeState:\"clean\", BuildDate:\"2021-05-12T14:43:31Z\", GoVersion:\"go1.13.14\", Compiler:\"gc\", Platform:\"linux/amd64\"}\nServer Version: version.Info{GitVersion:\"v0.42.1-dirty\", GitCommit:\"3e4ea2d9b8d4405dc307e885bc49f10c8ce5372c\", GitTreeState:\"dirty\", BuildDate:\"2021-06-10T02:06:01Z\", GoVersion:\"go1.16.1\", Compiler:\"gc\", Platform:\"linux/amd64\"}",
+        "Client Version: version.Info{Major:\"1\", Minor:\"20\", GitVersion:\"v1.20.0\", GitCommit:\"af46c47ce925f4c4ad5cc8d1fca46c7b77d13b38\", GitTreeState:\"clean\", BuildDate:\"2020-12-08T17:59:43Z\", GoVersion:\"go1.15.5\", Compiler:\"gc\", Platform:\"linux/amd64\"}\nServer Version: version.Info{Major:\"1\", Minor:\"21+\", GitVersion:\"v1.21.1-k0s1\", GitCommit:\"5e58841cce77d4bc13713ad2b91fa0d961e69192\", GitTreeState:\"clean\", BuildDate:\"2021-05-20T14:08:24Z\", GoVersion:\"go1.16.4\", Compiler:\"gc\", Platform:\"linux/amd64\"}",
+        "NAME=\"Ubuntu\"\nVERSION=\"20.04.2 LTS (Focal Fossa)\"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME=\"Ubuntu 20.04.2 LTS\"\nVERSION_ID=\"20.04\"\nHOME_URL=\"https://www.ubuntu.com/\"\nSUPPORT_URL=\"https://help.ubuntu.com/\"\nBUG_REPORT_URL=\"https://bugs.launchpad.net/ubuntu/\"\nPRIVACY_POLICY_URL=\"https://www.ubuntu.com/legal/terms-and-policies/privacy-policy\"\nVERSION_CODENAME=focal\nUBUNTU_CODENAME=focal"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "kubevirt",
+      "incubating",
+      "app-definition",
+      "feature"
+    ],
+    "cncfProjects": [
+      "kubevirt"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/kubevirt/kubevirt/issues/5913",
+      "repo": "https://github.com/kubevirt/kubevirt",
+      "pr": "https://github.com/kubevirt/kubevirt/pull/16346"
+    },
+    "reactions": 5,
+    "comments": 14,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with kubevirt installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-09-04T06:28:19.907Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: kubevirt — Allow configuration of alternative kubelet directories

**Type:** feature | **Source:** https://github.com/kubevirt/kubevirt/issues/5913 (5 reactions)
**Fix PR:** https://github.com/kubevirt/kubevirt/pull/16346
**File:** `fixes/cncf-generated/kubevirt/kubevirt-5913-allow-configuration-of-alternative-kubelet-directories.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*