### PR TITLE
🌱 cilium: L2Announcement with externalTrafficPolicy: Local

### DIFF
--- a/fixes/cncf-generated/cilium/cilium-27800-l2announcement-with-externaltrafficpolicy-local.json
+++ b/fixes/cncf-generated/cilium/cilium-27800-l2announcement-with-externaltrafficpolicy-local.json
@@ -1,0 +1,80 @@
+{
+  "version": "kc-mission-v1",
+  "name": "cilium-27800-l2announcement-with-externaltrafficpolicy-local",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "cilium: L2Announcement with externalTrafficPolicy: Local",
+    "description": "L2Announcement with externalTrafficPolicy: Local. This issue affects 27+ users.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify cilium troubleshoot symptoms",
+        "description": "Check for the issue in your cilium deployment:\n```bash\nkubectl get pods -n cilium -l app.kubernetes.io/name=cilium\nkubectl logs -l app.kubernetes.io/name=cilium -n cilium --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review cilium configuration",
+        "description": "Inspect the relevant cilium configuration:\n```bash\nkubectl get all -n cilium -l app.kubernetes.io/name=cilium\nkubectl get configmap -n cilium -l app.kubernetes.io/part-of=cilium\n```\n### Is there an existing issue for this?\n\n- [X] I have searched the existing issues\n\n### What happened?\n\nI have\n* a `CiliumL2AnnouncementPolicy` configured to expose 2 `LoadBalancer` type services\n* 2 `Service` one with `externalTrafficPolicy:"
+      },
+      {
+        "title": "Apply the fix for L2Announcement with externalTrafficPolicy: Local",
+        "description": "Hmm. So the L2Announcement feature doesn't \"implement\" `externalTrafficPolicy` as in, we ignore the setting at the present. That means that we might announce the IP from a node that doesn't have a pod for the service, thus violating the wish expressed with `externalTrafficPolicy`. \n\nThe feature\n```yaml\ncilium-cli: v0.15.6 compiled with go1.21.0 on darwin/arm64\ncilium image (default): v1.14.0\ncilium image (stable): v1.14.1\ncilium image (running): 1.14.1\n```"
+      },
+      {
+        "title": "Confirm L2Announcement with externalTrafficPolicy: Local is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=cilium -n cilium --tail=50 --since=5m\nkubectl get events -n cilium --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "Hmm. So the L2Announcement feature doesn't \"implement\" `externalTrafficPolicy` as in, we ignore the setting at the present. That means that we might announce the IP from a node that doesn't have a pod for the service, thus violating the wish expressed with `externalTrafficPolicy`. \n\nThe feature relies on the generic service LB functionality to forward traffic received for a given IP.",
+      "codeSnippets": [
+        "cilium-cli: v0.15.6 compiled with go1.21.0 on darwin/arm64\ncilium image (default): v1.14.0\ncilium image (stable): v1.14.1\ncilium image (running): 1.14.1",
+        "Client Version: v1.28.1\nKustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3\nServer Version: v1.27.5+k0s",
+        "❯ curl -vvvvvvv -k http://192.168.2.110:8443\n*   Trying 192.168.2.110:8443...\n* connect to 192.168.2.110 port 8443 failed: Operation timed out\n* Failed to connect to 192.168.2.110 port 8443 after 75006 ms: Couldn't connect to server\n* Closing connection 0\ncurl: (28) Failed to connect to 192.168.2.110 port 8443 after 75006 ms: Couldn't connect to server"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "cilium",
+      "graduated",
+      "networking",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "cilium"
+    ],
+    "targetResourceKinds": [
+      "Pod",
+      "Node",
+      "Service"
+    ],
+    "difficulty": "advanced",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/cilium/cilium/issues/27800",
+      "repo": "https://github.com/cilium/cilium"
+    },
+    "reactions": 27,
+    "comments": 31,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with cilium installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-09-05T06:14:06.683Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: cilium — L2Announcement with externalTrafficPolicy: Local

**Type:** troubleshoot | **Source:** https://github.com/cilium/cilium/issues/27800 (27 reactions)
**File:** `fixes/cncf-generated/cilium/cilium-27800-l2announcement-with-externaltrafficpolicy-local.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*