### PR TITLE
🌱 open-policy-agent-opa-: Exclude /health endpoint from being traced in distributed tracing

### DIFF
--- a/fixes/cncf-generated/open-policy-agent-opa-/open-policy-agent-opa-7494-exclude-health-endpoint-from-being-traced-in-distribu.json
+++ b/fixes/cncf-generated/open-policy-agent-opa-/open-policy-agent-opa-7494-exclude-health-endpoint-from-being-traced-in-distribu.json
@@ -1,0 +1,75 @@
+{
+  "version": "kc-mission-v1",
+  "name": "open-policy-agent-opa-7494-exclude-health-endpoint-from-being-traced-in-distribu",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "open-policy-agent-opa-: Exclude /health endpoint from being traced in distributed tracing",
+    "description": "Exclude /health endpoint from being traced in distributed tracing. Requested by 9+ users.",
+    "type": "feature",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Check current open-policy-agent-opa- deployment",
+        "description": "Verify your open-policy-agent-opa- version and configuration:\n```bash\nkubectl get pods -n open-policy-agent-opa- -l app.kubernetes.io/name=open-policy-agent-opa-\nhelm list -n open-policy-agent-opa- 2>/dev/null || echo \"Not installed via Helm\"\n```\nThis feature requires a working open-policy-agent-opa- installation."
+      },
+      {
+        "title": "Review open-policy-agent-opa- configuration",
+        "description": "Inspect the relevant open-policy-agent-opa- configuration:\n```bash\nkubectl get all -n open-policy-agent-opa- -l app.kubernetes.io/name=open-policy-agent-opa-\nkubectl get configmap -n open-policy-agent-opa- -l app.kubernetes.io/part-of=open-policy-agent-opa-\n```\n### Discussed in https://github.com/orgs/open-policy-agent/discussions/686\n\n<div type='discussions-op-text'>\n\n<sup>Originally posted by **loekensgard** April  4, 2025</sup>\nHi,\n\nI am currently configuring distributed tracing for OPA using the"
+      },
+      {
+        "title": "Apply the fix for Exclude /health endpoint from being traced in distributed…",
+        "description": "Health probes polled by an orchestrator can dominate the spans OPA emits, so let operators glob-match the incoming request paths that shouldn't start one. Filters apply to OPA's own server, not to the requests it makes to others.\n```yaml\ndistributed_tracing:\n  type: grpc\n  address: <address>\n  service_name: <custom_name>\n  resource:\n    deployment_environment: Dev/Qa/Prod\n```"
+      },
+      {
+        "title": "Verify the feature works",
+        "description": "Test that the new capability is working as expected:\n```bash\nkubectl get pods -n open-policy-agent-opa- -l app.kubernetes.io/name=open-policy-agent-opa-\nkubectl get events -n open-policy-agent-opa- --sort-by='.lastTimestamp' | tail -10\n```\nConfirm the feature described in \"Exclude /health endpoint from being traced in distributed…\" is functioning correctly."
+      }
+    ],
+    "resolution": {
+      "summary": "Health probes polled by an orchestrator can dominate the spans OPA emits, so let operators glob-match the incoming request paths that shouldn't start one. Filters apply to OPA's own server, not to the requests it makes to others.",
+      "codeSnippets": [
+        "distributed_tracing:\n  type: grpc\n  address: <address>\n  service_name: <custom_name>\n  resource:\n    deployment_environment: Dev/Qa/Prod"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "open-policy-agent-opa-",
+      "graduated",
+      "security",
+      "feature"
+    ],
+    "cncfProjects": [
+      "open-policy-agent-opa-"
+    ],
+    "targetResourceKinds": [],
+    "difficulty": "beginner",
+    "issueTypes": [
+      "feature"
+    ],
+    "maturity": "graduated",
+    "sourceUrls": {
+      "issue": "https://github.com/open-policy-agent/opa/issues/7494",
+      "repo": "https://github.com/open-policy-agent/opa",
+      "pr": "https://github.com/open-policy-agent/opa/pull/9153"
+    },
+    "reactions": 9,
+    "comments": 1,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with open-policy-agent-opa- installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-09-10T06:20:22.081Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: open-policy-agent-opa- — Exclude /health endpoint from being traced in distributed tracing

**Type:** feature | **Source:** https://github.com/open-policy-agent/opa/issues/7494 (9 reactions)
**Fix PR:** https://github.com/open-policy-agent/opa/pull/9153
**File:** `fixes/cncf-generated/open-policy-agent-opa-/open-policy-agent-opa-7494-exclude-health-endpoint-from-being-traced-in-distribu.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*