### PR TITLE
🌱 longhorn: [BUG] Longhorn can no longer create XFS volumes smaller than 300 MiB

### DIFF
--- a/fixes/cncf-generated/longhorn/longhorn-8488-bug-longhorn-can-no-longer-create-xfs-volumes-smaller-than-300-mib.json
+++ b/fixes/cncf-generated/longhorn/longhorn-8488-bug-longhorn-can-no-longer-create-xfs-volumes-smaller-than-300-mib.json
@@ -1,0 +1,78 @@
+{
+  "version": "kc-mission-v1",
+  "name": "longhorn-8488-bug-longhorn-can-no-longer-create-xfs-volumes-smaller-than-300-mib",
+  "missionClass": "fixer",
+  "author": "KubeStellar Bot",
+  "authorGithub": "kubestellar",
+  "mission": {
+    "title": "longhorn: [BUG] Longhorn can no longer create XFS volumes smaller than 300 MiB",
+    "description": "[BUG] Longhorn can no longer create XFS volumes smaller than 300 MiB. Community-reported issue.",
+    "type": "troubleshoot",
+    "status": "completed",
+    "steps": [
+      {
+        "title": "Identify longhorn troubleshoot symptoms",
+        "description": "Check for the issue in your longhorn deployment:\n```bash\nkubectl get pods -n longhorn -l app.kubernetes.io/name=longhorn\nkubectl logs -l app.kubernetes.io/name=longhorn -n longhorn --tail=100 | grep -i error\n```\nLook for errors or warnings in the logs that may indicate the issue."
+      },
+      {
+        "title": "Review longhorn configuration",
+        "description": "Inspect the relevant longhorn configuration:\n```bash\nkubectl get all -n longhorn -l app.kubernetes.io/name=longhorn\nkubectl get configmap -n longhorn -l app.kubernetes.io/part-of=longhorn\n```\n## Describe the bug\n\ntest_csi.text_xfs_pv has failed in the [last eight builds](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/test_results_analyzer/)."
+      },
+      {
+        "title": "Apply the fix for [BUG] Longhorn can no longer create XFS volumes smaller…",
+        "description": "#### What this PR does / why we need it:\n\nSee the linked issue for the upstream context.\n```yaml\n2024-05-01T22:11:11.441646508Z I0501 22:11:11.441532   14424 mount_linux.go:515] Disk \"/dev/longhorn/longhorn-testvol-pgbaei\" appears to be unformatted, attempting to format as type: \"xfs\" with options: [-f /dev/longhorn/longhorn-testvol-pgbaei]\n2024-05-01T22:11:11.447402309Z E0501 22:11:11.447331   14424 mount_linux.go:522] format of disk \"/dev/longhorn/longhorn-testvol-pgbaei\" failed: type:(\"xfs\") target:(\"/var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/c3fd6a649dc2c88fa6601a1a3c588aee2df8ddf83570e66ea6b6298e6bbb330c/globalmount\") options:(\"defaults\") errcode:(exit status 1) ou\n```"
+      },
+      {
+        "title": "Confirm [BUG] Longhorn can no longer create XFS volumes… is resolved",
+        "description": "Verify the fix by checking that the original error no longer occurs:\n```bash\nkubectl logs -l app.kubernetes.io/name=longhorn -n longhorn --tail=50 --since=5m\nkubectl get events -n longhorn --sort-by='.lastTimestamp' | tail -10\n```\nConfirm that the issue symptoms are gone."
+      }
+    ],
+    "resolution": {
+      "summary": "#### What this PR does / why we need it:\n\nSee the linked issue for the upstream context.",
+      "codeSnippets": [
+        "2024-05-01T22:11:11.441646508Z I0501 22:11:11.441532   14424 mount_linux.go:515] Disk \"/dev/longhorn/longhorn-testvol-pgbaei\" appears to be unformatted, attempting to format as type: \"xfs\" with options: [-f /dev/longhorn/longhorn-testvol-pgbaei]\n2024-05-01T22:11:11.447402309Z E0501 22:11:11.447331   14424 mount_linux.go:522] format of disk \"/dev/longhorn/longhorn-testvol-pgbaei\" failed: type:(\"xfs\") target:(\"/var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/c3fd6a649dc2c88fa6601a1a3c588aee2df8ddf83570e66ea6b6298e6bbb330c/globalmount\") options:(\"defaults\") errcode:(exit status 1) output:(Filesystem must be larger than 300MB.\n2024-05-01T22:11:11.447415856Z Usage: mkfs.xfs\n2024-05-01T22:11:11.447419962Z /* blocksize */\t\t[-b size=num]\n2024-05-01T22:11:11.447423394Z /* config file *",
+        "> k get pvc\nNAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS     VOLUMEATTRIBUTESCLASS   AGE\ntest-too-small           Bound    pvc-b97968ff-1c64-46a9-bfbc-f7de507db156   200Mi      RWO            test-too-small   <unset>                 16m\ntest-too-small-restore   Bound    pvc-5195ed5e-18bd-434c-853f-4a6f144f2d49   200Mi      RWO            test-too-small   <unset>                 13m\ntest-too-small-clone     Bound    pvc-24b99af3-c4ae-4691-befb-1f214c22b52c   200Mi      RWO            test-too-small   <unset>                 13m \n>\n> k get pv\nNAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                            STORAGECLASS     VOLUMEATTRIBUTESCLASS   REASON   AGE\n"
+      ]
+    }
+  },
+  "metadata": {
+    "tags": [
+      "longhorn",
+      "incubating",
+      "storage",
+      "troubleshoot"
+    ],
+    "cncfProjects": [
+      "longhorn"
+    ],
+    "targetResourceKinds": [
+      "Job"
+    ],
+    "difficulty": "intermediate",
+    "issueTypes": [
+      "troubleshoot"
+    ],
+    "maturity": "incubating",
+    "sourceUrls": {
+      "issue": "https://github.com/longhorn/longhorn/issues/8488",
+      "repo": "https://github.com/longhorn/longhorn",
+      "pr": "https://github.com/longhorn/longhorn/pull/8482"
+    },
+    "reactions": 4,
+    "comments": 12,
+    "synthesizedBy": "copilot"
+  },
+  "prerequisites": {
+    "kubernetes": ">=1.24",
+    "tools": [
+      "kubectl"
+    ],
+    "description": "A running Kubernetes cluster with longhorn installed or the issue environment reproducible."
+  },
+  "security": {
+    "scannedAt": "2026-09-12T06:21:15.819Z",
+    "scannerVersion": "cncf-gen-3.0.0",
+    "sanitized": true,
+    "findings": []
+  }
+}


### PR DESCRIPTION
## 🌱 New Mission: longhorn — [BUG] Longhorn can no longer create XFS volumes smaller than 300 MiB

**Type:** troubleshoot | **Source:** https://github.com/longhorn/longhorn/issues/8488 (4 reactions)
**Fix PR:** https://github.com/longhorn/longhorn/pull/8482
**File:** `fixes/cncf-generated/longhorn/longhorn-8488-bug-longhorn-can-no-longer-create-xfs-volumes-smaller-than-300-mib.json`

### Copilot: Please enhance this mission

The JSON file has been pre-filled with content from the source issue. Please improve:
1. Make step descriptions more specific with exact commands for this issue
2. Add the exact error message to the description if missing
3. Explain the root cause in the resolution summary
4. Add relevant YAML/code snippets to codeSnippets if missing
5. Run `node scripts/scanner.mjs` to validate

*Auto-generated by CNCF Mission Generator*